### PR TITLE
Fixed notice error if no entities

### DIFF
--- a/src/Faker/ORM/Propel/Populator.php
+++ b/src/Faker/ORM/Propel/Populator.php
@@ -11,8 +11,8 @@ require_once __DIR__ . '/EntityPopulator.php';
 class Populator
 {
 	protected $generator;
-	protected $entities;
-	protected $quantities;
+	protected $entities = array();
+	protected $quantities = array();
 
 	public function __construct(\Faker\Generator $generator)
 	{


### PR DESCRIPTION
This PR avoids notice error if you don't provide entities to the populator.

Oh and it fixed trailing whitespaces… I don't really know how to avoid these fixes, should be better without them anyway.

Cheers,
William.
