### PR TITLE
Throws an exception if no class found to get a connection

### DIFF
--- a/src/Faker/ORM/Propel/Populator.php
+++ b/src/Faker/ORM/Propel/Populator.php
@@ -18,7 +18,7 @@ class Populator
 	{
 		$this->generator = $generator;
 	}
-	
+
 	/**
 	 * Add an order for the generation of $number records for $entity.
 	 *
@@ -38,10 +38,10 @@ class Populator
 		$this->entities[$class] = $entity;
 		$this->quantities[$class] = $number;
 	}
-	
+
 	/**
 	 * Populate the database using all the Entity classes previously added.
-	 * 
+	 *
 	 * @param PropelPDO $con A Propel connection object
 	 *
 	 * @return array A list of the inserted PKs
@@ -56,7 +56,7 @@ class Populator
 		$insertedEntities = array();
 		$con->beginTransaction();
 		foreach ($this->quantities as $class => $number) {
-			for ($i=0; $i < $number; $i++) { 
+			for ($i=0; $i < $number; $i++) {
 				$insertedEntities[$class][]= $this->entities[$class]->execute($con, $insertedEntities);
 			}
 		}
@@ -64,14 +64,19 @@ class Populator
 		if ($isInstancePoolingEnabled) {
 			\Propel::enableInstancePooling();
 		}
-		
+
 		return $insertedEntities;
 	}
-	
+
 	protected function getConnection()
 	{
 		// use the first connection available
 		$class = key($this->entities);
+
+		if (!$class) {
+			throw new \RuntimeException('No class found from entities. Did you add entities to the Populator ?');
+		}
+
 		$peer = $class::PEER;
 		return \Propel::getConnection($peer::DATABASE_NAME, \Propel::CONNECTION_WRITE);
 	}


### PR DESCRIPTION
This PR adds an exception in the `Populator::getConnection()` method, useful if you didn't add any entities into the `Populator`…

Cheers,
William
