### PR TITLE
Fixed bug with relations using namespaces

### DIFF
--- a/src/Faker/ORM/Propel/EntityPopulator.php
+++ b/src/Faker/ORM/Propel/EntityPopulator.php
@@ -50,7 +50,7 @@ class EntityPopulator
 		$columnTypeGuesser = new \Faker\ORM\Propel\ColumnTypeGuesser($generator);
 		foreach ($tableMap->getColumns() as $columnMap) {
 			if ($columnMap->isForeignKey()) {
-				$relatedClass = $columnMap->getRelation()->getForeignTable()->getPhpName();
+				$relatedClass = $columnMap->getRelation()->getForeignTable()->getClassname();
 				$formatters[$columnMap->getPhpName()] = function($inserted) use($relatedClass) { return isset($inserted[$relatedClass]) ? $inserted[$relatedClass][mt_rand(0, count($inserted[$relatedClass]) - 1)] : null; };
 				continue;
 			}


### PR DESCRIPTION
If you use Propel with namespaces turned on, the ability to populate relations with inserted entities doesn't work as you're finding entities by their PHP name, not by their classname which is quite similar without namespaces but not with them.

Are you agree with that fix ? Works fine, unit tests all green (but not sure this part is tested :p)

William
