### PR TITLE
Bug in Faker\Provider\Miscellaneous::boolean

### DIFF
--- a/src/Faker/Provider/Miscellaneous.php
+++ b/src/Faker/Provider/Miscellaneous.php
@@ -13,7 +13,7 @@ class Miscellaneous extends \Faker\Provider\Base
 	 */
 	public static function boolean($chanceOfGettingTrue = 50)
 	{
-		return mt_rand(0, 100) <= $chanceOfGettingTrue ? true: false;
+		return mt_rand(1, 100) <= $chanceOfGettingTrue ? true: false;
 	}
 
 	/**


### PR DESCRIPTION
Hey,

I've found that boolean method sometimes returns TRUE when $pChanceOfTrue is '0'. That's because the method is drawing a number from range 0 - 100.

This simple fix removes this bug.
