### PR TITLE
newline size has to be taken into an account...

### DIFF
--- a/src/Faker/Provider/Lorem.php
+++ b/src/Faker/Provider/Lorem.php
@@ -102,11 +102,12 @@ class Lorem extends \Faker\Provider\Base
 	{
 		// determine how many paragraphs are needed to reach the $maxNbChars once;
 		$text = array();
+		$nlSize = strlen("\n");
 		$size = 0;
 		while ($size < $maxNbChars) {
 			$paragraph = self::paragraph();
 			$text []= $paragraph;
-			$size += strlen($paragraph);
+			$size += strlen($paragraph) + $nlSize;
 		}
 		array_pop($text);
 


### PR DESCRIPTION
..because we are joining paragraphs at the end. I we don't do that in worst case the string we return could be larger for paragraph count \* length of \n
