### PR TITLE
Added support for partial execution and multiple runs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -188,16 +188,32 @@ You can check available Faker locales in the source code, [under the `Provider` 
 
 Faker provides adapters for Object-Relational and Object-Document Mappers (currently, [Propel](http://www.propelorm.org), [Doctrine2](http://www.doctrine-project.org/projects/orm/2.0/docs/en), and [Mandango](https://github.com/mandango/mandango) are supported). These adapters ease the population of databases through the Entity classes provided by an ORM library (or the population of document stores using Document classes provided by an ODM library).
 
-To populate entities, create a new populator class (using a generator instance as parameter), then list the class and number of all the entities that must be generated. To launch the actual data population, call the `execute()` method.
+To populate entities, create a new populator class (using a generator instance as parameter), then list the class and number of all the entities that must be generated. To launch the actual data population, call the `execute()` method. If you'd like to do a partial execute for a specific entity, you may pass it as an optional argument (`execute($manager, $entity)`). This is particularly useful when you depend on previous results to build your next entity data.
 
 Here is an example showing how to populate 5 `Author` and 10 `Book` objects:
 
 ```php
 <?php
 $generator = \Faker\Factory::create();
-$populator = new Faker\ORM\Propel\Populator($generator);
+$populator = new \Faker\ORM\Propel\Populator($generator);
 $populator->addEntity('Author', 5);
 $populator->addEntity('Book', 10);
+$insertedPKs = $populator->execute();
+```
+
+Using partial executes:
+
+```php
+<?php
+$generator = \Faker\Factory::create();
+$populator = new \Faker\ORM\Propel\Populator($generator);
+$populator->addEntity('Author', 5);
+$insertedPKs = $populator->execute(null, 'Author');
+
+$authors = $insertedPKs['Author'];
+$populator->addEntity('Book', 10, array(
+  'author' => function() use ($generator, $authors) { return $generator->randomElement($authors); },
+  ));
 $insertedPKs = $populator->execute();
 ```
 

--- a/src/Faker/ORM/Doctrine/Populator.php
+++ b/src/Faker/ORM/Doctrine/Populator.php
@@ -44,11 +44,11 @@ class Populator
 	/**
 	 * Populate the database using all the Entity classes previously added.
 	 *
-	 * @param EntityManager $entityManager A Propel connection object
+	 * @param EntityManager $entityManager A Doctrine connection object
 	 *
 	 * @return array A list of the inserted PKs
 	 */
-	public function execute($entityManager = null)
+	public function execute($entityManager = null, $entity = null)
 	{
 		if (null === $entityManager) {
 			$entityManager = $this->manager;
@@ -59,9 +59,16 @@ class Populator
 
 		$insertedEntities = array();
 		foreach ($this->quantities as $class => $number) {
+			if (null !== $entity && $entity !== $class) {
+				continue;
+			}
+
 			for ($i=0; $i < $number; $i++) {
 				$insertedEntities[$class][]= $this->entities[$class]->execute($entityManager, $insertedEntities);
 			}
+
+			unset($this->entities[$class]);
+			unset($this->quantities[$class]);
 		}
 		$entityManager->flush();
 

--- a/src/Faker/ORM/Mandango/Populator.php
+++ b/src/Faker/ORM/Mandango/Populator.php
@@ -46,13 +46,20 @@ class Populator
 	 *
 	 * @return array A list of the inserted entities.
 	 */
-	public function execute()
+	public function execute($entity = null)
 	{
 		$insertedEntities = array();
 		foreach ($this->quantities as $class => $number) {
+			if (null !== $entity && $entity !== $class) {
+				continue;
+			}
+
 			for ($i=0; $i < $number; $i++) {
 				$insertedEntities[$class][]= $this->entities[$class]->execute($this->mandango, $insertedEntities);
 			}
+
+			unset($this->entities[$class]);
+			unset($this->quantities[$class]);
 		}
 		$this->mandango->flush();
 

--- a/src/Faker/ORM/Propel/Populator.php
+++ b/src/Faker/ORM/Propel/Populator.php
@@ -48,7 +48,7 @@ class Populator
 	 *
 	 * @return array A list of the inserted PKs
 	 */
-	public function execute($con = null)
+	public function execute($con = null, $entity = null)
 	{
 		if (null === $con) {
 			$con = $this->getConnection();
@@ -58,9 +58,16 @@ class Populator
 		$insertedEntities = array();
 		$con->beginTransaction();
 		foreach ($this->quantities as $class => $number) {
+			if (null !== $entity && $entity !== $class) {
+				continue;
+			}
+
 			for ($i=0; $i < $number; $i++) {
 				$insertedEntities[$class][]= $this->entities[$class]->execute($con, $insertedEntities);
 			}
+
+			unset($this->entities[$class]);
+			unset($this->quantities[$class]);
 		}
 		$con->commit();
 		if ($isInstancePoolingEnabled) {


### PR DESCRIPTION
1. This change prevents multiple calls to `execute()` triggering re-insertion of entities already persisted. For each run, it now clears the managed entities.
2. Multiple `execute()` calls are particularly useful when one needs partial results to populate the next entity data. This paved the way to support partial executions by passing the entity class name:

`````` php

```php
<?php
$generator = \Faker\Factory::create();
$populator = new \Faker\ORM\Propel\Populator($generator);
$populator->addEntity('Author', 5);
$insertedPKs = $populator->execute(null, 'Author');

$authors = $insertedPKs['Author'];
$populator->addEntity('Book', 10, array(
  'author' => function() use ($generator, $authors) { return $generator->randomElement($authors); },
  ));
$insertedPKs = $populator->execute();
``````
