### PR TITLE
fixed problem with Utf-8 string

### DIFF
--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -104,5 +104,18 @@ class Base
 	{
 		return static::lexify(static::numerify($string));
 	}
-	
+
+	/**
+	 * Converts string to lowercase.
+	 * Uses mb_string extension if available
+	 * @param string $string String that should be converted to lowercase
+	 * @return string
+	 */
+	public static function toLower($string) {
+		if (function_exists('mb_strtolower')) {
+			return mb_strtolower($string);
+		}
+		return strtolower($string);
+	}
+
 }

--- a/src/Faker/Provider/Internet.php
+++ b/src/Faker/Provider/Internet.php
@@ -70,7 +70,7 @@ class Internet extends \Faker\Provider\Base
 	public function userName()
 	{
 		$format = static::randomElement(static::$userNameFormats);
-		return strtolower(static::bothify($this->generator->parse($format)));
+		return static::toLower(static::bothify($this->generator->parse($format)));
 	}
 	
 	/**
@@ -91,7 +91,7 @@ class Internet extends \Faker\Provider\Base
 		$company = $companyElements[0];
 		$company = preg_replace('/\W/', '', $company);
 
-		return strtolower($company);
+		return static::toLower($company);
 	}
 	
 	/**


### PR DESCRIPTION
When string is utf-8 coded, strtolower breaks strings. mb_string should be used when available
