### PR TITLE
Remove spaces in generated emails.

### DIFF
--- a/src/Faker/Provider/Internet.php
+++ b/src/Faker/Provider/Internet.php
@@ -29,7 +29,7 @@ class Internet extends \Faker\Provider\Base
 	public function email()
 	{
 		$format = static::randomElement(static::$emailFormats);
-		return $this->generator->parse($format);
+		return preg_replace('/\s/', '', $this->generator->parse($format));
 	}
 
 	/**


### PR DESCRIPTION
This issue was visible when using faker in `fr_FR` because of last name containing spaces.
