### PR TITLE
Make DateTime Locale aware

### DIFF
--- a/src/Faker/Factory.php
+++ b/src/Faker/Factory.php
@@ -13,7 +13,7 @@ class Factory
         $generator = new Generator();
         foreach (static::$defaultProviders as $provider) {
             $providerClassName = self::getProviderClassname($provider, $locale);
-            $generator->addProvider(new $providerClassName($generator));
+            $generator->addProvider(new $providerClassName($generator, $locale));
         }
 
         return $generator;

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -2,6 +2,7 @@
 
 namespace Faker\Provider;
 
+use Faker\Factory;
 use Faker\Generator;
 
 class Base
@@ -14,7 +15,7 @@ class Base
     /**
      * @param \Faker\Generator $generator
      */
-    public function __construct(Generator $generator)
+    public function __construct(Generator $generator, $locale = Factory::DEFAULT_LOCALE)
     {
         $this->generator = $generator;
     }

--- a/src/Faker/Provider/DateTime.php
+++ b/src/Faker/Provider/DateTime.php
@@ -2,9 +2,21 @@
 
 namespace Faker\Provider;
 
+use Faker\Factory;
+
 class DateTime extends \Faker\Provider\Base
 {
     protected static $century = array('I','II','III','IV','V','VI','VII','VIII','IX','X','XI','XII','XIII','XIV','XV','XVI','XVII','XVIII','XIX','XX','XX1');
+    protected static $dayOfWeekFormatter = null;
+    protected static $monthNameFormatter = null;
+
+    public function __construct($generator, $locale = Factory::DEFAULT_LOCALE)
+    {
+        self::$dayOfWeekFormatter = \IntlDateFormatter::create($locale, \IntlDateFormatter::NONE, \IntlDateFormatter::NONE, date_default_timezone_get(), \IntlDateFormatter::GREGORIAN, 'EEEE');
+        self::$monthNameFormatter = \IntlDateFormatter::create($locale, \IntlDateFormatter::NONE, \IntlDateFormatter::NONE, date_default_timezone_get(), \IntlDateFormatter::GREGORIAN, 'MMMM');
+
+        parent::__construct($generator, $locale);
+    }
 
     /**
      * Get a timestamp between January 1, 1970 and now
@@ -143,7 +155,7 @@ class DateTime extends \Faker\Provider\Base
      */
     public static function dayOfWeek()
     {
-        return static::dateTime()->format('l');
+        return self::$dayOfWeekFormatter->format(static::unixTime());
     }
 
     /**
@@ -159,7 +171,7 @@ class DateTime extends \Faker\Provider\Base
      */
     public static function monthName()
     {
-        return static::dateTime()->format('F');
+        return self::$monthNameFormatter->format(static::unixTime());
     }
 
     /**

--- a/test/Faker/Provider/DateTimeLocalizationTest.php
+++ b/test/Faker/Provider/DateTimeLocalizationTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Faker\Test\Provider;
+
+use Faker\Factory;
+
+class DateLocalizationTest extends \PHPUnit_Framework_TestCase
+{
+	public function localizedDayOfWeekProvider()
+	{
+		return array(
+			array(
+				null, // fallback to default locale
+				array('Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday')
+			),
+			array(
+				'de_DE',
+				array('Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag', 'Samstag', 'Sonntag')
+			),
+			array(
+				'en_US',
+				array('Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday')
+			),
+			array(
+				'fr_FR',
+				array('lundi', 'mardi', 'mercredi', 'jeudi', 'vendredi', 'samedi', 'dimanche')
+			),
+			array(
+				'it_IT',
+				array('lunedì', 'martedì', 'mercoledì', 'giovedì', 'venerdì', 'sabato', 'domenica')
+			),
+			array(
+				'tr_TR',
+				array('Pazartesi', 'Salı', 'Çarşamba', 'Perşembe', 'Cuma', 'Cumartesi', 'Pazar')
+			)
+			
+		);
+	}
+
+	/**
+	 * @dataProvider localizedDayOfWeekProvider
+	 */
+	public function testLocalizedDayOfWeek($locale, $reference)
+	{
+		$faker = $locale ? Factory::create($locale) : Factory::create();
+
+		foreach($reference as $item)
+		{
+			$this->assertContains($faker->dayOfWeek, $reference);
+		}
+	}
+
+	public function localizedMonthNameProvider()
+	{
+		return array(
+			array(
+				null, // fallback to default locale
+				array('January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December')
+			),
+			array(
+				'de_AT',
+				array('Jänner', 'Februar', 'März', 'April', 'Mai', 'Juni', 'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember')
+			),
+			array(
+				'de_DE',
+				array('Januar', 'Februar', 'März', 'April', 'Mai', 'Juni', 'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember')
+			),
+			array(
+				'en_US',
+				array('January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December')
+			),
+			array(
+				'fr_FR',
+				array('janvier', 'février', 'mars', 'avril', 'mai', 'juin', 'juillet', 'août', 'septembre', 'octobre', 'novembre', 'décembre')
+			),
+			array(
+				'it_IT',
+				array('gennaio', 'febbraio', 'marzo', 'aprile', 'maggio', 'giugno', 'luglio', 'agosto', 'settembre', 'ottobre', 'novembre', 'dicembre')
+			),
+			array(
+				'tr_TR',
+				array('Ocak', 'Şubat', 'Mart', 'Nisan', 'Mayıs', 'Haziran', 'Temmuz', 'Ağustos', 'Eylül', 'Ekim', 'Kasım', 'Aralık')
+			)
+		);
+	}
+
+	/**
+	 * @dataProvider localizedMonthNameProvider
+	 */
+	public function testLocalizedMonthName($locale, $reference)
+	{
+		$faker = $locale ? Factory::create($locale) : Factory::create();
+
+		foreach($reference as $item)
+		{
+			$this->assertContains($faker->monthName, $reference);
+		}
+	}
+}


### PR DESCRIPTION
DateTime was using `DateTime::format()` which results always in output generated for an english locale. By passing `$locale` to the Generators (right now only used by `Faker\Provider\DateTime`) `IntlDateFormatter` will be able to generate localized day- and month-names. 

Let me know what you think :)
