### PR TITLE
Word-size dependency for `Faker\Provider\Base::numberBetween()`.

### DIFF
--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -74,7 +74,7 @@ class Base
      */
     public static function numberBetween($from = null, $to = null)
     {
-        return mt_rand($from ?: 0, $to ?: PHP_INT_MAX);
+        return mt_rand($from ?: 0, $to ?: 2147483647); // 32bit compat default
     }
 
     /**


### PR DESCRIPTION
Using [mt_rand in combination with PHP_MAX_INT](https://github.com/fzaninotto/Faker/blob/master/src/Faker/Provider/Base.php#L75-78) causes distinct sequences depending on the word size of the PHP installation (32 or 64bit).

When for example unit tests depend on those sequences to be predictable it may cause them to fail for developers using a different word size.

It would be safe to only rely on a range of `0` to `2147483647` (2^31-1) by default.
A greater range should be available on demand, but not enforced when the target system is not known.
