### PR TITLE
Adding PHPUnit to composer.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,9 @@
     "require": {
         "php": ">=5.3.3"
     },
+    "require-dev": {
+        "phpunit/phpunit": "3.7.*"
+    },
     "autoload": {
         "psr-0": { "Faker": "src/" }
     },


### PR DESCRIPTION
Currently PHPUnit is not bundled, but rather a dependency on the system of the developer. Adding PHPUnit to the required-dev introduces are more consistent and more accessible checkout
