### PR TITLE
Fixed missing timezone with dateTimeBetween

### DIFF
--- a/src/Faker/Provider/DateTime.php
+++ b/src/Faker/Provider/DateTime.php
@@ -83,7 +83,10 @@ class DateTime extends \Faker\Provider\Base
         $endTimestamp = $endDate instanceof \DateTime ? $endDate->getTimestamp() : strtotime($endDate);
         $timestamp = mt_rand($startTimestamp, $endTimestamp);
 
-        return new \DateTime('@' . $timestamp);
+        $ts = new \DateTime('@' . $timestamp);
+        $ts->setTimezone(new \DateTimeZone(date_default_timezone_get()));
+
+        return $ts;
     }
 
     /**


### PR DESCRIPTION
Hi I was running in an issue where the `DateTime::dateTimeBetween()` was returning a \DateTime object with no Timezone set, so it was off. Or am I missing something?
