### PR TITLE
add date parameter to date function

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -129,7 +129,7 @@ Each of the generator properties (like `name`, `address`, and `lorem`) are calle
     dateTime                // DateTime('2008-04-25 08:37:17')
     dateTimeAD              // DateTime('1800-04-29 20:38:49')
     iso8601                 // '1978-12-09T10:10:29+0000'
-    date($format = 'Y-m-d') // '1979-06-09'
+    date($format = 'Y-m-d', $date = '+10 days') // '2013-09-15'
     time($format = 'H:i:s') // '20:49:42'
     dateTimeBetween($startDate = '-30 years', $endDate = 'now') // DateTime('2003-03-15 02:00:49')
     dateTimeThisCentury     // DateTime('1915-05-30 19:28:21')

--- a/src/Faker/Provider/DateTime.php
+++ b/src/Faker/Provider/DateTime.php
@@ -50,11 +50,18 @@ class DateTime extends \Faker\Provider\Base
      * Get a date string between January 1, 1970 and now
      *
      * @param string $format
+     * @param string $date Defaults between January 1, 1970 and now
      * @example '2008-11-27'
      */
-    public static function date($format = 'Y-m-d')
+    public static function date($format = 'Y-m-d', $date = null)
     {
-        return static::dateTime()->format($format);
+        if (null === $date) {
+            $date = static::dateTime();
+        } else if (!$date instanceof \DateTime) {
+            $date = new \DateTime($date);
+        }
+
+        return $date->format($format);
     }
 
     /**

--- a/test/Faker/Provider/DateTimeTest.php
+++ b/test/Faker/Provider/DateTimeTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Faker\Test\Provider;
+
+use Faker\Provider\DateTime;
+
+class DateTimeTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDate()
+    {
+        $this->assertRegExp('/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/i', DateTime::date());
+    }
+
+    public function testDateFormat()
+    {
+        $this->assertRegExp('/^[0-9]{8}$/i', DateTime::date('Ymd'));
+    }
+
+    public function testDateFormatAndDate()
+    {
+        $this->assertEquals(date('Ymd', strtotime('+10days')), DateTime::date('Ymd', '+10 days'));
+    }
+}


### PR DESCRIPTION
Make it possible to add a date string to the `date` function. Add Tests.

``` yml
date('Ymd', '+10 days')
```
