### PR TITLE
Limit Propel numbers to signed range of values.

### DIFF
--- a/src/Faker/ORM/Propel/ColumnTypeGuesser.php
+++ b/src/Faker/ORM/Propel/ColumnTypeGuesser.php
@@ -35,18 +35,18 @@ class ColumnTypeGuesser
 
                 return function() use ($generator, $size) { return $generator->randomNumber($size + 2) / 100; };
             case PropelColumnTypes::TINYINT:
-                return function() { return mt_rand(0,255); };
+                return function() { return mt_rand(0,127); };
             case PropelColumnTypes::SMALLINT:
-                return function() { return mt_rand(0,65535); };
+                return function() { return mt_rand(0,32767); };
             case PropelColumnTypes::INTEGER:
-                return function() { return mt_rand(0,intval('4294967295')); };
+                return function() { return mt_rand(0,intval('2147483647')); };
             case PropelColumnTypes::BIGINT:
-                return function() { return mt_rand(0,intval('18446744073709551615')); };
+                return function() { return mt_rand(0,intval('9223372036854775807')); };
             case PropelColumnTypes::FLOAT:
-                return function() { return mt_rand(0,intval('4294967295'))/mt_rand(1,intval('4294967295')); };
+                return function() { return mt_rand(0,intval('2147483647'))/mt_rand(1,intval('2147483647')); };
             case PropelColumnTypes::DOUBLE:
             case PropelColumnTypes::REAL:
-                return function() { return mt_rand(0,intval('18446744073709551615'))/mt_rand(1,intval('18446744073709551615')); };
+                return function() { return mt_rand(0,intval('9223372036854775807'))/mt_rand(1,intval('9223372036854775807')); };
             case PropelColumnTypes::CHAR:
             case PropelColumnTypes::VARCHAR:
             case PropelColumnTypes::BINARY:


### PR DESCRIPTION
As Propel doesn't provide an option to set unsigned integer values in the schema, the generator should limit its range of generated values to the signed range, in order to avoid "Numeric value out of range" issues.
