### PR TITLE
Fix docblock for Provider\Base::unique()

### DIFF
--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -237,7 +237,7 @@ class Base
      *                            After which an OverflowExcption is thrown.
      * @throws OverflowException When no unique value can be found by iterating $maxRetries times
      * 
-     * @return UniqueGenerator A proxy class returning only existing values
+     * @return UniqueGenerator A proxy class returning only non-existing values
      */
     public function unique($reset = false, $maxRetries = 10000)
     {


### PR DESCRIPTION
This PR corrects a lie in the docbock for `Provider\Base::unique()`
