### PR TITLE
Allow set custom output path for image provider

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -203,10 +203,12 @@ Each of the generator properties (like `name`, `address`, and `lorem`) are calle
      * @param $dir An absolute path to a local directory
      * @param $width/$height Size (in pixel) of the generated image (defaults to 640x480)
      * @param $category One of 'abstract','animals','business','cats','city','food','nightlife','fashion','people','nature','sports','technics', and 'transport'
+     * @param $outputPath Custom path for output image file
      */
     image($dir)                  // '/path/to/dir/13b73edae8443990be1aa8f1a483bc27.jpg'
     image($dir, $width, $height) // '/path/to/dir/13b73edae8443990be1aa8f1a483bc27.jpg'
     image($dir, $width, $height, $category) // '/path/to/dir/13b73edae8443990be1aa8f1a483bc27.jpg'
+    image($dir, $width, $height, $category, $outputPath) // '/custom/path/to/dir/13b73edae8443990be1aa8f1a483bc27.jpg'
     imageUrl                    // 'http://lorempixel.com/640/480/'
     imageUrl($width, $height)   // 'http://lorempixel.com/800/600/'
     imageUrl($width, $height, $category) // 'http://lorempixel.com/800/600/person/'

--- a/src/Faker/Provider/Image.php
+++ b/src/Faker/Provider/Image.php
@@ -37,7 +37,7 @@ class Image extends Base
      *
      * @example '/path/to/dir/13b73edae8443990be1aa8f1a483bc27.jpg'
      */
-    public static function image($dir, $width = 640, $height = 480, $category = null)
+    public static function image($dir, $width = 640, $height = 480, $category = null, $outputPath = null)
     {
         // Validate directory path
         if (!is_dir($dir) || !is_writable($dir)) {
@@ -47,7 +47,8 @@ class Image extends Base
         // Generate a random filename. Use the server address so that a file
         // generated at the same time on a different server won't have a collision.
         $name = md5(uniqid(empty($_SERVER['SERVER_ADDR']) ? '' : $_SERVER['SERVER_ADDR'], true));
-        $filepath = $dir . DIRECTORY_SEPARATOR . $name .'.jpg';
+        $nameWithExt = $name . '.jpg';
+        $filepath = $dir . DIRECTORY_SEPARATOR . $nameWithExt;
 
         $url = static::imageUrl($width, $height, $category);
 
@@ -72,6 +73,6 @@ class Image extends Base
             return false;
         }
 
-        return $filepath;
+        return null === $outputPath ? $filepath : $outputPath . $nameWithExt;
     }
 }

--- a/test/Faker/Provider/ImageTest.php
+++ b/test/Faker/Provider/ImageTest.php
@@ -45,4 +45,17 @@ class ImageTest extends \PHPUnit_Framework_TestCase
             unlink($file);
         }
     }
+
+    public function testCustomOutputPath()
+    {
+        $tempDir = sys_get_temp_dir();
+        $file = Image::image($tempDir, 640, 480, null, '/custom/path/');
+        $realFilePath = $tempDir . DIRECTORY_SEPARATOR . pathinfo($file, PATHINFO_BASENAME);
+        $this->assertFileExists($realFilePath);
+        $this->assertEquals('/custom/path', pathinfo($file, PATHINFO_DIRNAME));
+
+        if (file_exists($realFilePath)) {
+            unlink($realFilePath);
+        }
+    }
 }


### PR DESCRIPTION
Use case: we want to save file path which should be different from the file path to the file you saved to disk
