### PR TITLE
[RFR] Issue with one-to-one nullable relationship

### DIFF
--- a/src/Faker/ORM/Doctrine/EntityPopulator.php
+++ b/src/Faker/ORM/Doctrine/EntityPopulator.php
@@ -99,21 +99,29 @@ class EntityPopulator
 
             $relatedClass = $this->class->getAssociationTargetClass($assocName);
 
-            $unique = false;
+            $unique = $optional = false;
             $mappings = $this->class->getAssociationMappings();
             foreach ($mappings as $mapping) {
                 if ($mapping['targetEntity'] == $relatedClass) {
                     if ($mapping['type'] == ClassMetadata::ONE_TO_ONE) {
                         $unique = true;
+                        $optional = $mapping['joinColumns'][0]['nullable'];
                         break;
                     }
                 }
             }
 
             $index = 0;
-            $formatters[$assocName] = function($inserted) use ($relatedClass, &$index, $unique) {
+            $formatters[$assocName] = function($inserted) use ($relatedClass, &$index, $unique, $optional) {
                 if ($unique && isset($inserted[$relatedClass])) {
-                    return $inserted[$relatedClass][$index++];
+                    $related = null;
+                    if (isset($inserted[$relatedClass][$index]) || !$optional) {
+                        $related = $inserted[$relatedClass][$index];
+                    }
+
+                    $index++;
+
+                    return $related;
                 } elseif (isset($inserted[$relatedClass])) {
                     return $inserted[$relatedClass][mt_rand(0, count($inserted[$relatedClass]) - 1)];
                 }


### PR DESCRIPTION
Let's consider the following one-to-one relationship between a user and a project entities:

``` php
class Project
{
    /**
     * @var User
     *
     * @ORM\OneToOne(targetEntity="Acme\DemoBundle\Entity\User")
     * @ORM\JoinColumn(name="user_id", referencedColumnName="id", nullable=true)
     */
    private $user;
}
```

This relationship is optional. Yet, if I generate a single `User` entity and ten `Project` entities, the populator will raise the following error:

> [Symfony\Component\Debug\Exception\ContextErrorException]  
>  Notice: Undefined offset: 1 in /home/jpetitcolas/dev/Faker/src/Faker/ORM/Doctrine/EntityPopulator.php line 116

Indeed, as my relationship is unique, Faker tries to get the following existing inserted entity, even if it does not exist.

This PR checks if the relationship is optional. If so, and if no more entity is available, Faker does not set it.
