### PR TITLE
add toAscii method to Italian Internet provider

### DIFF
--- a/src/Faker/Provider/it_IT/Internet.php
+++ b/src/Faker/Provider/it_IT/Internet.php
@@ -12,7 +12,9 @@ class Internet extends \Faker\Provider\Internet
      */
     public function userName()
     {
-        return static::toAscii(parent::userName());
+        $format = static::randomElement(static::$userNameFormats);
+
+        return static::toLower(static::toAscii(static::bothify($this->generator->parse($format))));
     }
 
     /**


### PR DESCRIPTION
This was inspired by issue #189. Copied and adapted from French Internet provider. Even if current Person provider for Italian does not contains any accented letters, I added them anyway, for forward compatibility. The only current issue with Italian Person provider are names with accent inside, that currently are translated into invalid email, like "ld'amico@yahoo.com"
