### PR TITLE
Replace 'UK' with ISO3166 compliant code 'GB'

### DIFF
--- a/src/Faker/Provider/Miscellaneous.php
+++ b/src/Faker/Provider/Miscellaneous.php
@@ -6,7 +6,7 @@ class Miscellaneous extends \Faker\Provider\Base
 {
     protected static $languageCode = array('cn', 'de', 'en', 'es', 'fr', 'it', 'pt', 'ru');
 
-    protected static $countryCode = array('CA', 'CN', 'DE', 'ES', 'FR', 'IE', 'IN', 'IT', 'MX', 'PT', 'RU', 'UK', 'US');
+    protected static $countryCode = array('CA', 'CN', 'DE', 'ES', 'FR', 'IE', 'IN', 'IT', 'MX', 'PT', 'RU', 'GB', 'US');
 
     protected static $localeData = array(
         'aa_DJ',  'aa_ER',  'aa_ET',


### PR DESCRIPTION
Lets you use Faker in situations where ISO3166 compliance is expected, such as testing Symfony2 `country` form fields, without random test fails.
