### PR TITLE
Fix integer values overflowing on signed INTEGER columns.

### DIFF
--- a/src/Faker/ORM/Doctrine/ColumnTypeGuesser.php
+++ b/src/Faker/ORM/Doctrine/ColumnTypeGuesser.php
@@ -27,7 +27,7 @@ class ColumnTypeGuesser
             case 'smallint':
                 return function() { return mt_rand(0,65535); };
             case 'integer':
-                return function() { return mt_rand(0,intval('4294967295')); };
+                return function() { return mt_rand(0,intval('2147483647')); };
             case 'bigint':
                 return function() { return mt_rand(0,intval('18446744073709551615')); };
             case 'float':


### PR DESCRIPTION
Doctrine does not hint or support unsigned schema columns, which means that by default columns will be signed in many DBMS.

For example in the most popular DBMS, MySQL, the max value for `INTEGER` column is 2147483647.

I have changed the upper bound for integer generation to be in the safe zone.

This fixes exceptions thrown from Doctrine such as:

> SQLSTATE[22003]: Numeric value out of range: 1264 Out of range value for column 'number' at row 1
