### PR TITLE
Removed superfluous space

### DIFF
--- a/src/Faker/Provider/nl_NL/Address.php
+++ b/src/Faker/Provider/nl_NL/Address.php
@@ -15,7 +15,7 @@ class Address extends \Faker\Provider\Address
     protected static $cityFormats = array('{{cityName}}');
 
     protected static $addressFormats = array(
-        '{{streetAddress}}\n {{postcode}} {{city}}',
+        '{{streetAddress}}\n{{postcode}} {{city}}',
     );
 
     protected static $streetSuffix = array(


### PR DESCRIPTION
The nl_NL version had a space between a newline character and zipcode.
