### PR TITLE
Remove array_rand from use

### DIFF
--- a/src/Faker/ORM/Mandango/EntityPopulator.php
+++ b/src/Faker/ORM/Mandango/EntityPopulator.php
@@ -3,6 +3,7 @@
 namespace Faker\ORM\Mandango;
 
 use Mandango\Mandango;
+use Faker\Provider\Base;
 
 /**
  * Service class for populating a table through a Mandango ActiveRecord class.
@@ -71,7 +72,7 @@ class EntityPopulator
 
             $formatters[$referenceName] = function ($insertedEntities) use ($referenceClass) {
                 if (isset($insertedEntities[$referenceClass])) {
-                    return $insertedEntities[$referenceClass][array_rand($insertedEntities[$referenceClass])];
+                    return Base::randomElement($insertedEntities[$referenceClass]);
                 }
             };
         }

--- a/src/Faker/Provider/UserAgent.php
+++ b/src/Faker/Provider/UserAgent.php
@@ -87,9 +87,9 @@ class UserAgent extends \Faker\Provider\Base
         );
 
         $platforms = array(
-            '(' . static::windowsPlatformToken() . '; ' . static::randomElement(static::$lang) . '; rv:1.9.' . mt_rand(0, 2) . '.20) ' . $ver[array_rand($ver, 1)],
-            '(' . static::linuxPlatformToken() . '; rv:' . mt_rand(5, 7) . '.0) ' . $ver[array_rand($ver, 1)],
-            '(' . static::macPlatformToken() . ' rv:' . mt_rand(2, 6) . '.0) ' . $ver[array_rand($ver, 1)]
+            '(' . static::windowsPlatformToken() . '; ' . static::randomElement(static::$lang) . '; rv:1.9.' . mt_rand(0, 2) . '.20) ' . static::randomElement($ver),
+            '(' . static::linuxPlatformToken() . '; rv:' . mt_rand(5, 7) . '.0) ' . static::randomElement($ver),
+            '(' . static::macPlatformToken() . ' rv:' . mt_rand(2, 6) . '.0) ' . static::randomElement($ver)
         );
 
         return "Mozilla/5.0 " . static::randomElement($platforms);

--- a/src/Faker/Provider/zh_CN/PhoneNumber.php
+++ b/src/Faker/Provider/zh_CN/PhoneNumber.php
@@ -14,7 +14,7 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
 
     public static function phoneNumber()
     {
-        $operators = static::$operators[array_rand(static::$operators)];
+        $operators = static::randomElement(static::$operators);
 
         return $operators . static::numerify(static::randomElement(static::$formats));
     }


### PR DESCRIPTION
Base::randomElement uses `mt_srand`, `array_rand` does not.
