### PR TITLE
fix typo in en_ZA Internet provider

### DIFF
--- a/src/Faker/Provider/en_ZA/Internet.php
+++ b/src/Faker/Provider/en_ZA/Internet.php
@@ -5,5 +5,5 @@ namespace Faker\Provider\en_ZA;
 class Internet extends \Faker\Provider\Internet
 {
     protected static $freeEmailDomain = array('gmail.com', 'yahoo.com', 'hotmail.com', 'webmail.co.za', 'vodamail.co.za');
-    protected static $tld = array('co.za', 'co.za', 'co.za', '.co.za', 'com', 'com', 'net');
+    protected static $tld = array('co.za', 'co.za', 'co.za', 'co.za', 'com', 'com', 'net');
 }


### PR DESCRIPTION
There was a typo in src/Faker/Provider/en_ZA/Internet.php. One of the $tld array items was .co.za instead of just co.za. This resulted in domain..co.za generations when using $faker->domainName
