### PR TITLE
Removed abstract property on Provider\Text class

### DIFF
--- a/src/Faker/Provider/Text.php
+++ b/src/Faker/Provider/Text.php
@@ -2,7 +2,7 @@
 
 namespace Faker\Provider;
 
-abstract class Text extends \Faker\Provider\Base
+class Text extends \Faker\Provider\Base
 {
     protected static $baseText = '';
     protected $explodedText = null;
@@ -80,7 +80,7 @@ abstract class Text extends \Faker\Provider\Base
             for ($i = 0; $i < $indexSize; $i++) {
                 $index[] = array_shift($parts);
             }
-            
+
             for ($i = 0, $count = count($parts); $i < $count; $i++) {
                 $stringIndex = implode(' ', $index);
                 if (!isset($words[$stringIndex])) {


### PR DESCRIPTION
I can't see a reason for the Text provider to be abstract...

As it's not always implemented in all locales, an error is triggered by the factory when trying to instanciate it (it is part of the default providers, so the Factory try to instanciate the base version).
