### PR TITLE
Biased integer

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -233,6 +233,10 @@ Each of the generator properties (like `name`, `address`, and `lorem`) are calle
     countryCode             // UK
     languageCode            // en
 
+### `Faker\Provider\Biased`
+
+    biasedInteger($min, $max, $function) // 42
+
 ## Unique and Optional modifiers
 
 Faker provides two special providers, `unique()` and `optional()`, to be called before any provider. `optional()` can be useful for seeding non-required fields, like a mobile telephone number; `unique()` is required to populate fields that cannot accept twice the same value, like primary identifiers.

--- a/readme.md
+++ b/readme.md
@@ -235,7 +235,7 @@ Each of the generator properties (like `name`, `address`, and `lorem`) are calle
 
 ### `Faker\Provider\Biased`
 
-    biasedInteger($min, $max, $function) // 42
+    biasedNumberBetween($min, $max, $function) // 42
 
 ## Unique and Optional modifiers
 

--- a/src/Faker/Factory.php
+++ b/src/Faker/Factory.php
@@ -6,7 +6,7 @@ class Factory
 {
     const DEFAULT_LOCALE = 'en_US';
 
-    protected static $defaultProviders = array('Address', 'Barcode', 'Color', 'Company', 'DateTime', 'File', 'Image', 'Internet', 'Lorem', 'Miscellaneous', 'Payment', 'Person', 'PhoneNumber', 'Text', 'UserAgent', 'Uuid');
+    protected static $defaultProviders = array('Address', 'Barcode', 'Biased', 'Color', 'Company', 'DateTime', 'File', 'Image', 'Internet', 'Lorem', 'Miscellaneous', 'Payment', 'Person', 'PhoneNumber', 'Text', 'UserAgent', 'Uuid');
 
     public static function create($locale = self::DEFAULT_LOCALE)
     {

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -104,7 +104,7 @@ namespace Faker;
  * @method mixed optional()
  * @method UniqueGenerator unique()
  *
- * @method integer biasedInteger()
+ * @method integer biasedNumberBetween()
  *
  * @property string $userAgent
  * @property string $chrome

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -104,6 +104,8 @@ namespace Faker;
  * @method mixed optional()
  * @method UniqueGenerator unique()
  *
+ * @method integer biasedInteger()
+ *
  * @property string $userAgent
  * @property string $chrome
  * @property string $firefox

--- a/src/Faker/Provider/Biased.php
+++ b/src/Faker/Provider/Biased.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Faker\Provider;
+
+class Biased extends \Faker\Provider\Base
+{
+    /**
+     * Returns a biased integer between $min and $max (both inclusive).
+     * The distribution depends on $function.
+     *
+     * The algorithm creates two doubles, x, y ∈ [0, 1) and checks whether the
+     * return value of $function for x is greater than or equal to y. If this is
+     * the case the number is accepted and x is mapped to the appropriate integer
+     * between $min and $max. Otherwise two new doubles are created until the pair
+     * is accepted.
+     *
+     * @param integer $min Minimum value of the generated integers.
+     * @param integer $max Maximum value of the generated integers.
+     * @param callable $function A function mapping x ∈ [0, 1) onto a double ∈ [0, 1]
+     * @return integer An integer between $min and $max.
+     */
+    public function biasedInteger($min, $max, $function)
+    {
+        do {
+            $x = mt_rand() / (mt_getrandmax() + 1);
+            $y = mt_rand() / (mt_getrandmax() + 1);
+        } while ($function($x) < $y);
+        
+        return floor($x * ($max - $min + 1) + $min);
+    }
+
+    /**
+     * 'unbiased' creates an unbiased distribution by giving
+     * each value the same value of one.
+     *
+     * @return integer
+     */
+    protected static function unbiased($x)
+    {
+        return 1;
+    }
+
+    /**
+     * 'linearLow' favors lower numbers. The probability decreases
+     * in a linear fashion.
+     *
+     * @return integer
+     */
+    protected static function linearLow($x)
+    {
+        return 1 - $x;
+    }
+
+    /**
+     * 'linearHigh' favors higher numbers. The probability increases
+     * in a linear fashion.
+     *
+     * @return integer
+     */
+    protected static function linearHigh($x)
+    {
+        return $x;
+    }
+}

--- a/src/Faker/Provider/Biased.php
+++ b/src/Faker/Provider/Biased.php
@@ -8,7 +8,7 @@ class Biased extends \Faker\Provider\Base
      * Returns a biased integer between $min and $max (both inclusive).
      * The distribution depends on $function.
      *
-     * The algorithm creates two doubles, x, y ∈ [0, 1) and checks whether the
+     * The algorithm creates two doubles, x ∈ [0, 1], y ∈ [0, 1) and checks whether the
      * return value of $function for x is greater than or equal to y. If this is
      * the case the number is accepted and x is mapped to the appropriate integer
      * between $min and $max. Otherwise two new doubles are created until the pair
@@ -16,15 +16,15 @@ class Biased extends \Faker\Provider\Base
      *
      * @param integer $min Minimum value of the generated integers.
      * @param integer $max Maximum value of the generated integers.
-     * @param callable $function A function mapping x ∈ [0, 1) onto a double ∈ [0, 1]
+     * @param callable $function A function mapping x ∈ [0, 1] onto a double ∈ [0, 1]
      * @return integer An integer between $min and $max.
      */
-    public function biasedInteger($min, $max, $function)
+    public function biasedNumberBetween($min = 0, $max = 100, $function = 'sqrt')
     {
         do {
-            $x = mt_rand() / (mt_getrandmax() + 1);
+            $x = mt_rand() / mt_getrandmax();
             $y = mt_rand() / (mt_getrandmax() + 1);
-        } while ($function($x) < $y);
+        } while (call_user_func($function, $x) < $y);
         
         return floor($x * ($max - $min + 1) + $min);
     }

--- a/test/Faker/Provider/BiasedTest.php
+++ b/test/Faker/Provider/BiasedTest.php
@@ -1,0 +1,62 @@
+<?php
+namespace Faker\Test\Provider;
+
+use Faker\Provider\Biased;
+use Faker\Generator;
+
+class BiasedTest extends \PHPUnit_Framework_TestCase
+{
+    const MAX = 10;
+    const NUMBERS = 10000;
+    protected $generator;
+    protected $results = array();
+    
+    protected function setUp()
+    {
+        $this->generator = new Generator();
+        $this->generator->addProvider(new Biased($this->generator));
+        $this->generator->seed(0);
+
+        $this->results = array_fill(1, self::MAX, 0);
+    }
+    
+    public function performFake($function)
+    {
+        for($i = 0; $i < self::NUMBERS; $i++) {
+            $this->results[$this->generator->biasedInteger(1, self::MAX, $function)]++;
+        }
+    }
+    
+    public function testUnbiased()
+    {
+        $this->performFake(array('\Faker\Provider\Biased', 'unbiased'));
+
+        // assert that all numbers are near the expected unbiased value
+        foreach ($this->results as $number => $amount) {
+            $this->assertGreaterThan((self::NUMBERS / self::MAX) * .95, $amount, "Value was more than 5 percent under the expected value");
+            $this->assertLessThan((self::NUMBERS / self::MAX) * 1.05, $amount, "Value was more than 5 percent over the expected value");
+        }
+    }
+    
+    public function testLinearHigh()
+    {
+        $this->performFake(array('\Faker\Provider\Biased', 'linearHigh'));
+
+        $last = 0;
+        // assert that the list is ordered
+        foreach ($this->results as $number => $amount) {
+            $this->assertGreaterThan($last * .98, $amount, "Amount was smaller than that of the number before");
+        }
+    }
+    
+    public function testLinearLow()
+    {
+        $this->performFake(array('\Faker\Provider\Biased', 'linearLow'));
+
+        $last = PHP_INT_MAX;
+        // assert that the list is ordered
+        foreach ($this->results as $number => $amount) {
+            $this->assertLessThan($last, $amount, "Amount was greater than that of the number before");
+        }
+    }
+}


### PR DESCRIPTION
biasedInteger allows generating an integer that is biased by a given function.

See fzaninotto/Faker#304

See this example data:
![graph](https://cloud.githubusercontent.com/assets/209270/2977894/3b1f61a4-dbb1-11e3-84a3-181ed2a74591.png)

Number	|unbiased|	linearLow|	linearHigh|	sqrt	|square
-------------|------------|------------------|-------------------|------------|---------
1	|9857	|19016|	1007	|3222|	84
2	|10032	|17000|	2931	|5715|	717
3|	9966	|14977|	4928	|7538|	1846
4|	9914	|13015|	7033	|8872|	3645
5|	10099	|11080|	9145	|9915|	6095
6|	9800	|9012	|11001|	11234|	9138
7|	9987	|6860	|12936|	11906|	12800
8|	10096	|5053	|15047|	13160|	17019
9|	10026	|2945	|16919|	13775|	21512
10|	10223	|1042	|19053|	14663|	27144					
Loop iterations:	|100000|	200217|	199822	|150115|	299345
Loop iterations (percent)	|100.00%|	200.22%	|199.82%|	150.12%	|299.34%

Loop iterations are the number of times the contents of the loop were executed, `100000` is perfect, no values were discarded.

For even more fascination see this `sqrt` distribution of a higher number range :smile:
![graph2](https://cloud.githubusercontent.com/assets/209270/2977935/e176948c-dbb1-11e3-9b0c-992d48d2d639.png)
