### PR TITLE
speeds up Provider\Base\randomKey()

### DIFF
--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -186,10 +186,7 @@ class Base
         if (!$array) {
             return null;
         }
-        $keys = array_keys($array);
-        $key = $keys[mt_rand(0, count($keys) - 1)];
-
-        return $key;
+        return array_rand($array);
     }
 
     /**


### PR DESCRIPTION
Today, while doing some profiling on our unit tests, I noticed that we were spending a lot of time in Faker.
Specifically, `randomKey()` was particularly slow.

I looked into the code a bit, and was surprised you weren't using `array_rand()` here, instead of the `array_keys()` + `mt_rand()` to select one of the isolated keys.

I thought there must be a reason (such as, perhaps, small arrays might perform better with your algorithm). To find out, I ran some tests and plotted the results:

![0-1000 results](https://docs.google.com/spreadsheets/d/1E6GGO3K9TbnQVARFjSG8Zq8OYPeM2sUwML-GnKd6F-w/embed/oimg?id=1E6GGO3K9TbnQVARFjSG8Zq8OYPeM2sUwML-GnKd6F-w&oid=2012738200&zx=51waklnjoi8k)

The problem is exacerbated with even more elements:

![0-10,000 results](https://docs.google.com/spreadsheets/d/1E6GGO3K9TbnQVARFjSG8Zq8OYPeM2sUwML-GnKd6F-w/embed/oimg?id=1E6GGO3K9TbnQVARFjSG8Zq8OYPeM2sUwML-GnKd6F-w&oid=1773598094&zx=hzx1kkw9xs2w)

[Spreadsheet](https://docs.google.com/spreadsheets/d/1E6GGO3K9TbnQVARFjSG8Zq8OYPeM2sUwML-GnKd6F-w/edit#gid=0)

Hacked up code to provide this data:

``` php
<?php

function randByKey(array $a)
{
    // see https://github.com/fzaninotto/Faker/blob/5476642acfe1e2851b55debc3f4b6d972338f2a0/src/Faker/Provider/Base.php#L184
    $keys = array_keys($a);
    $key = $keys[mt_rand(0, count($keys) - 1)];
    return $key;
}

function randomKey(array $a = null, $useRand = false)
{
    if ($useRand) {
        return array_rand($a);
    } else {
        return randByKey($a);
    }
}

function randomArray($numElements)
{
    $a = [];
    for ($i=0; $i<$numElements; $i++) {
        // numbers are good enough here
        $a[] = rand(10000000, 99999999);
    }
    return $a;
}

$max = 10000;
$times = 1000;
for ($numElements = 1; $numElements <= $max; $numElements += $max/100) {
    $a = randomArray($numElements);

    $start = microtime(true);
    for ($repeat = 0; $repeat < $times; $repeat++) {
        $discard = randomKey($a, false);
    }
    $byKey = microtime(true) - $start;

    $start = microtime(true);
    for ($repeat = 0; $repeat < $times; $repeat++) {
        $discard = randomKey($a, true);
    }
    $byRand = microtime(true) - $start;

    echo "{$numElements}\t{$byKey}\t{$byRand}\n";
}
```

Anyway, unless there's a compelling reason to _not_ use `array_rand()`, here, please do.
