### PR TITLE
Speedup numerify() by more than 40%

### DIFF
--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -197,7 +197,19 @@ class Base
      */
     public static function numerify($string = '###')
     {
-        $string = preg_replace_callback('/\#/u', 'static::randomDigit', $string);
+        // instead of using randomDigit() several times, which is slow,
+        // count the number of hashes and generate once a large number
+        $toReplace = array();
+        for ($i = 0, $count = strlen($string); $i < $count; $i++) {
+            if ($string[$i] === '#') {
+                $toReplace []= $i;
+            }
+        }
+        $nbReplacements = count($toReplace);
+        $numbers = (string) static::randomNumber($nbReplacements, true);
+        for ($i = 0; $i < $nbReplacements; $i++) {
+            $string[$toReplace[$i]] = $numbers[$i];
+        }
         $string = preg_replace_callback('/\%/u', 'static::randomDigitNotNull', $string);
 
         return $string;


### PR DESCRIPTION
`preg_replace_callback()` is slow, and calling `mt_rand()` several times is very slow, too.

Good old string PHP is much more effective on that scenario.
