### PR TITLE
add random GET argument for imageUrl faker

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -215,6 +215,8 @@ Each of the generator properties (like `name`, `address`, and `lorem`) are calle
     imageUrl($width, $height, 'cats')     // 'http://lorempixel.com/800/600/cats/'
     image($dir = '/tmp', $width = 640, $height = 480) // '/tmp/13b73edae8443990be1aa8f1a483bc27.jpg'
     image($dir, $width, $height, 'cats')  // 'tmp/13b73edae8443990be1aa8f1a483bc27.jpg' it's a cat!
+    image($dir, $width, $height, 'cats', true)  // 'tmp/13b73edae8443990be1aa8f1a483bc27.jpg?52345' it's a cat with a five digit random GET argument,
+                                                // thus, each generated image within a single web page will be different (no client cache use).
 
 ### `Faker\Provider\Uuid`
 

--- a/src/Faker/Provider/Image.php
+++ b/src/Faker/Provider/Image.php
@@ -15,9 +15,11 @@ class Image extends Base
     /**
      * Generate the URL that will return a random image
      *
+     * Set randomize to false to add a random GET parameter at the end of the url.
+     *
      * @example 'http://lorempixel.com/640/480/'
      */
-    public static function imageUrl($width = 640, $height = 480, $category = null)
+    public static function imageUrl($width = 640, $height = 480, $category = null, $randomize=false)
     {
         $url = "http://lorempixel.com/{$width}/{$height}/";
         if ($category) {
@@ -25,6 +27,10 @@ class Image extends Base
                 throw new \InvalidArgumentException(sprintf('Unkown image category "%s"', $category));
             }
             $url .= "{$category}/";
+        }
+
+        if ($randomize) {
+            $url .= '?' . static::randomNumber(5, true);
         }
 
         return $url;

--- a/src/Faker/Provider/Image.php
+++ b/src/Faker/Provider/Image.php
@@ -19,7 +19,7 @@ class Image extends Base
      *
      * @example 'http://lorempixel.com/640/480/'
      */
-    public static function imageUrl($width = 640, $height = 480, $category = null, $randomize=false)
+    public static function imageUrl($width = 640, $height = 480, $category = null, $randomize = false)
     {
         $url = "http://lorempixel.com/{$width}/{$height}/";
         if ($category) {

--- a/test/Faker/Provider/ImageTest.php
+++ b/test/Faker/Provider/ImageTest.php
@@ -21,6 +21,15 @@ class ImageTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(Image::imageUrl(800, 400, 'nature'), 'http://lorempixel.com/800/400/nature/');
     }
 
+    public function testRandomizedUrl()
+    {
+        $url = Image::imageUrl(800, 400, null, true);
+        $splitUrl = preg_split('/\?/', $url);
+
+        $this->assertEquals(count($splitUrl), 2);
+        $this->assertEquals($splitUrl[0], 'http://lorempixel.com/800/400/');
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      */


### PR DESCRIPTION
When using multiple imageUrl with same configuration, only one image is loaded from lorempixel since the generated url are the same.

This pull requests adds an argument to tell Faker to add a random GET parameter to the generated url in order to have different images from lorempixel.