### PR TITLE
Add MaxGenerator to Faker.

### DIFF
--- a/src/Faker/MaxGenerator.php
+++ b/src/Faker/MaxGenerator.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Faker;
+
+/**
+ * Proxy for other generators, to return up to a given amount of values. Works with
+ * Faker\Generator\Base->unique()
+ */
+class MaxGenerator
+{
+    public $nextMax = false;
+    public $resetNextIndividual = false;
+
+    protected $generator;
+    protected $data = array();
+
+    public function __construct(Generator $generator, $maxRetries)
+    {
+        $this->generator = $generator;
+        $this->maxRetries = $maxRetries;
+    }
+
+    /**
+     * Catch and proxy all generator calls but return only up to the max number of values total
+     */
+    public function __get($attribute)
+    {
+        return $this->__call($attribute, array());
+    }
+
+    /**
+     * Catch and proxy all generator calls with arguments but return only up to the max number of values total
+     */
+    public function __call($name, $arguments)
+    {
+        if ($this->resetNextIndividual) {
+            unset($this->data[$name]);
+        }
+        if (!isset($this->data[$name])) {
+            $this->data[$name] = array();
+        }
+        $index = rand(1, $this->nextMax);
+        if (!isset($this->data[$name][$index])) {
+            $i = 0;
+            do {
+                $res = call_user_func_array(array($this->generator, $name), $arguments);
+                $i++;
+                if ($i > $this->maxRetries) {
+                    throw new \OverflowException(sprintf('Maximum retries of %d reached without finding a unique value', $this->maxRetries));
+                }
+            } while (array_search($res, $this->data[$name]));
+
+            $this->data[$name][$index] = $res;
+        }
+
+        return $this->data[$name][$index];
+    }
+}

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -5,6 +5,7 @@ namespace Faker\Provider;
 use Faker\Generator;
 use Faker\DefaultGenerator;
 use Faker\UniqueGenerator;
+use Faker\MaxGenerator;
 
 class Base
 {
@@ -17,6 +18,11 @@ class Base
      * @var \Faker\UniqueGenerator
      */
     protected $unique;
+
+    /**
+     * @var \Faker\MaxGenerator
+     */
+    protected $max;
 
     /**
      * @param \Faker\Generator $generator
@@ -317,5 +323,33 @@ class Base
         }
 
         return $this->unique;
+    }
+
+    /**
+     * Chainable method for making any formatter return a given maximum amount of entries.
+     *
+     * <code>
+     * // Will only return the first 3 entries it generates.
+     * $faker->max(3)->person;
+     * </code>
+     *
+     * @param integer $num             The maximum number of entries to generate.
+     * @param boolean $resetIndividual If set to true, resets the list of existing values for the next formatter called.
+     * @param boolean $reset           If set to true, resets the list of existing values for all formatters.
+     * @param integer $maxRetries      Maximum number of retries to find a unique value.
+     * @throws OverflowException       When no unique value can be found by iterating $maxRetries times.
+     *
+     * @return MaxGenerator            A proxy class returning only a maximum number of values for a given formatter.
+     */
+    public function max($num, $resetIndividual = false, $reset = false, $maxRetries = 10000)
+    {
+        if ($reset || !$this->max) {
+            $this->max = new MaxGenerator($this->generator, $maxRetries);
+        }
+
+        $this->max->nextMax = $num;
+        $this->max->resetNextIndividual = $resetIndividual;
+
+        return $this->max;
     }
 }

--- a/test/Faker/MaxGeneratorTest.php
+++ b/test/Faker/MaxGeneratorTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Faker\Test;
+
+use Faker\Provider\Base;
+
+class MaxGeneratorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGeneratorReturnsExpectedMax()
+    {
+        $faker = \Faker\Factory::create();
+        $faker->addProvider(new Base($faker));
+
+        $results = array();
+        for ($i = 0; $i < 100; $i++) {
+            $fake = $faker->max(5)->name();
+            if (!in_array($fake, $results)) {
+                $results[] = $fake;
+            }
+        }
+
+        $count = count($results);
+
+        $this->assertLessThanOrEqual(5, $count);
+        $this->assertGreaterThan(0, $count);
+    }
+
+    private function loadResults($faker, &$arr, $method, $max = 5)
+    {
+        do {
+            $fake = $faker->max($max)->$method();
+            if (in_array($fake, $arr)) {
+                continue;
+            }
+
+            $arr[] = $fake;
+        } while (count($arr) < $max);
+    }
+
+    public function testGeneratorResetIndividualResetsOnlyOne()
+    {
+        $faker = \Faker\Factory::create();
+        $faker->addProvider(new Base($faker));
+
+        $firstResults = array();
+        $this->loadResults($faker, $firstResults, 'firstName');
+
+        $lastResults = array();
+        $this->loadResults($faker, $lastResults, 'lastName');
+
+        $faker->seed(109248);
+
+        $firstResults2 = array();
+        $firstResults2[] = $faker->max(5, true)->firstName();
+        $this->loadResults($faker, $firstResults2, 'firstName');
+
+        $lastResults2 = array();
+        $this->loadResults($faker, $lastResults2, 'lastName');
+
+        $this->assertNotEmpty(array_diff($firstResults, $firstResults2));
+        $this->assertEmpty(array_diff($lastResults, $lastResults2));
+    }
+    public function testGeneratorResetAllValues()
+    {
+        $faker = \Faker\Factory::create();
+        $faker->addProvider(new Base($faker));
+
+        $firstResults = array();
+        $this->loadResults($faker, $firstResults, 'firstName');
+
+        $lastResults = array();
+        $this->loadResults($faker, $lastResults, 'lastName');
+
+        $faker->seed(109248);
+
+        $firstResults2 = array();
+        $firstResults2[] = $faker->max(5, false, true)->firstName();
+        $this->loadResults($faker, $firstResults2, 'firstName');
+
+        $lastResults2 = array();
+        $this->loadResults($faker, $lastResults2, 'lastName');
+
+        $this->assertNotEmpty(array_diff($firstResults, $firstResults2));
+        $this->assertNotEmpty(array_diff($lastResults, $lastResults2));
+    }
+
+    public function testSurpassingMaxRetriesThrowsOverflowException()
+    {
+        $faker = \Faker\Factory::create();
+        $faker->addProvider(new Base($faker));
+
+        $this->setExpectedException('\OverflowException');
+
+        $faker->max(5, false, false, 0)->firstName();
+    }
+}


### PR DESCRIPTION
MaxGenerator will allow the use of `$faker->max($num)->something` to
only return a maximum of $num different results.

I'm not sure if this functionality exists already, as I've only minimally messed with Faker for doing a bit of fuzz testing, and haven't really had time to fully explore the codebase. The problem I ran into was that while generating random data, I also wanted to ensure that collisions existed within the dataset I was generating. The solution was to add `MaxGenerator` and expose a `max()` method on `\Faker\Provider\Base` which would allow me to limit the data I would receive.