### PR TITLE
Replace regex with PHP filter in InternetTest

### DIFF
--- a/test/Faker/Provider/InternetTest.php
+++ b/test/Faker/Provider/InternetTest.php
@@ -58,7 +58,7 @@ class InternetTest extends \PHPUnit_Framework_TestCase
 
     public function testIpv6()
     {
-        $this->assertNotFalse(filter_var(Internet::ipv6(), FILTER_VALIDATE_IP, FILTER_FLAG_IPV6));
+        $this->assertNotFalse(filter_var($this->faker->ipv6(), FILTER_VALIDATE_IP, FILTER_FLAG_IPV6));
     }
 
     public function testMacAddress()


### PR DESCRIPTION
I also add a test for the ipv6() in the Provider/Internet.
