### PR TITLE
en_GB people provider

### DIFF
--- a/src/Faker/Provider/en_GB/Person.php
+++ b/src/Faker/Provider/en_GB/Person.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Faker\Provider\en_GB;
+
+class Person extends \Faker\Provider\Person
+{
+    protected static $maleNameFormats = array(
+        '{{firstNameMale}} {{lastName}}',
+    );
+
+    protected static $femaleNameFormats = array(
+        '{{firstNameFemale}} {{lastName}}',
+    );
+
+    protected static $firstNameMale = array(
+        'Aaron', 'Adam', 'Adrian', 'Aiden', 'Alan', 'Alex', 'Alexander', 'Alfie', 'Andrew', 'Andy', 'Anthony', 'Archie', 'Arthur',
+        'Barry', 'Ben', 'Benjamin', 'Bradley', 'Brandon', 'Bruce',
+        'Callum', 'Cameron', 'Charles', 'Charlie', 'Chris', 'Christian', 'Christopher', 'Colin', 'Connor', 'Craig',
+        'Dale', 'Damien', 'Dan', 'Daniel', 'Darren', 'Dave', 'David', 'Dean', 'Dennis', 'Dominic', 'Duncan', 'Dylan',
+        'Edward', 'Elliot', 'Elliott', 'Ethan',
+        'Finley', 'Frank', 'Fred', 'Freddie',
+        'Gary', 'Gavin', 'George', 'Gordon', 'Graham', 'Grant', 'Greg',
+        'Harley', 'Harrison', 'Harry', 'Harvey', 'Henry',
+        'Ian', 'Isaac',
+        'Jack', 'Jackson', 'Jacob', 'Jake', 'James', 'Jamie', 'Jason', 'Jayden', 'Jeremy', 'Jim', 'Joe', 'Joel', 'John', 'Jonathan', 'Jordan', 'Joseph', 'Joshua',
+        'Karl', 'Keith', 'Ken', 'Kevin', 'Kieran', 'Kyle',
+        'Lee', 'Leo', 'Lewis', 'Liam', 'Logan', 'Louis', 'Lucas', 'Luke',
+        'Mark', 'Martin', 'Mason', 'Matthew', 'Max', 'Michael', 'Mike', 'Mohammed', 'Muhammad',
+        'Nathan', 'Neil', 'Nick', 'Noah',
+        'Oliver', 'Oscar', 'Owen',
+        'Patrick', 'Paul', 'Pete', 'Peter', 'Philip',
+        'Quentin',
+        'Ray', 'Reece', 'Riley', 'Rob', 'Ross', 'Ryan',
+        'Samuel', 'Scott', 'Sean', 'Sebastian', 'Stefan', 'Stephen', 'Steve',
+        'Theo', 'Thomas', 'Tim', 'Toby', 'Tom', 'Tony', 'Tyler',
+        'Wayne', 'Will', 'William',
+        'Zachary', 'Zach'
+    );
+
+    protected static $firstNameFemale = array(
+        'Abbie', 'Abigail', 'Adele', 'Alexa', 'Alexandra', 'Alice', 'Alison', 'Amanda', 'Amber', 'Amelia', 'Amy', 'Anna', 'Ashley', 'Ava',
+        'Beth', 'Bethany', 'Becky',
+        'Caitlin', 'Candice', 'Carlie', 'Carmen', 'Carole', 'Caroline', 'Carrie', 'Charlotte', 'Chelsea', 'Chloe', 'Claire', 'Courtney',
+        'Daisy', 'Danielle', 'Donna',
+        'Eden', 'Eileen', 'Eleanor', 'Elizabeth', 'Ella', 'Ellie', 'Elsie', 'Emily', 'Emma', 'Erin', 'Eva', 'Evelyn', 'Evie',
+        'Faye', 'Fiona', 'Florence', 'Francesca', 'Freya',
+        'Georgia', 'Grace',
+        'Hannah', 'Heather', 'Helen', 'Helena', 'Hollie', 'Holly',
+        'Imogen', 'Isabel', 'Isabella', 'Isabelle', 'Isla', 'Isobel',
+        'Jade', 'Jane', 'Jasmine', 'Jennifer', 'Jessica', 'Joanne', 'Jodie', 'Julia', 'Julie', 'Justine',
+        'Karen', 'Karlie', 'Katie', 'Keeley', 'Kelly', 'Kimberly', 'Kirsten', 'Kirsty',
+        'Laura', 'Lauren', 'Layla', 'Leah', 'Leanne', 'Lexi', 'Lilly', 'Lily', 'Linda', 'Lindsay', 'Lisa', 'Lizzie', 'Lola', 'Lucy',
+        'Maisie', 'Mandy', 'Maria', 'Mary', 'Matilda', 'Megan', 'Melissa', 'Mia', 'Millie', 'Molly',
+        'Naomi', 'Natalie', 'Natasha', 'Nicole', 'Nikki',
+        'Olivia',
+        'Patricia', 'Paula', 'Pauline', 'Phoebe', 'Poppy',
+        'Rachel', 'Rebecca', 'Rosie', 'Rowena', 'Roxanne', 'Ruby', 'Ruth',
+        'Sabrina', 'Sally', 'Samantha', 'Sarah', 'Sasha', 'Scarlett', 'Selina', 'Shannon', 'Sienna', 'Sofia', 'Sonia', 'Sophia', 'Sophie', 'Stacey', 'Stephanie','Suzanne', 'Summer',
+        'Tanya', 'Tara', 'Teagan', 'Theresa', 'Tiffany', 'Tina', 'Tracy',
+        'Vanessa', 'Vicky', 'Victoria',
+        'Wendy',
+        'Yasmine', 'Yvette', 'Yvonne',
+        'Zoe',
+    );
+
+    protected static $lastName = array(
+        'Smith', 'Jones', 'Taylor', 'Williams', 'Brown', 'Davies', 'Evans', 'Wilson', 'Thomas', 'Roberts',
+        'Johnson', 'Lewis', 'Walker', 'Robinson', 'Wood', 'Thompson', 'White', 'Watson', 'Jackson', 'Wright',
+        'Green', 'Harris', 'Cooper', 'King', 'Lee', 'Martin', 'Clarke', 'James', 'Morgan', 'Hughes',
+        'Edwards', 'Hill', 'Moore', 'Clark', 'Harrison', 'Scott', 'Young', 'Morris', 'Hall', 'Ward',
+        'Turner', 'Carter', 'Phillips', 'Mitchell', 'Patel', 'Adams', 'Campbell', 'Anderson', 'Allen', 'Cook',
+        'Bailey', 'Parker', 'Miller', 'Davis', 'Murphy', 'Price', 'Bell', 'Baker', 'Griffiths', 'Kelly',
+        'Simpson', 'Marshall', 'Collins', 'Bennett', 'Cox', 'Richardson', 'Fox', 'Gray', 'Rose', 'Chapman',
+        'Hunt', 'Robertson', 'Shaw', 'Reynolds', 'Lloyd', 'Ellis', 'Richards', 'Russell', 'Wilkinson', 'Khan',
+        'Graham', 'Stewart', 'Reid', 'Murray', 'Powell', 'Palmer', 'Holmes', 'Rogers', 'Stevens', 'Walsh',
+        'Hunter', 'Thompson', 'Matthews', 'Ross', 'Owen', 'Mason', 'Knight', 'Kennedy', 'Butler', 'Saunders'
+    );
+}

--- a/src/Faker/Provider/en_GB/Person.php
+++ b/src/Faker/Provider/en_GB/Person.php
@@ -12,6 +12,9 @@ class Person extends \Faker\Provider\Person
         '{{firstNameFemale}} {{lastName}}',
     );
 
+    /**
+     * @link http://www.ons.gov.uk/ons/rel/vsob1/baby-names--england-and-wales/2013/index.html
+     */
     protected static $firstNameMale = array(
         'Aaron', 'Adam', 'Adrian', 'Aiden', 'Alan', 'Alex', 'Alexander', 'Alfie', 'Andrew', 'Andy', 'Anthony', 'Archie', 'Arthur',
         'Barry', 'Ben', 'Benjamin', 'Bradley', 'Brandon', 'Bruce',
@@ -63,16 +66,28 @@ class Person extends \Faker\Provider\Person
         'Zoe',
     );
 
+    /**
+     * @link http://surname.sofeminine.co.uk/w/surnames/most-common-surnames-in-great-britain.html
+     */
     protected static $lastName = array(
-        'Smith', 'Jones', 'Taylor', 'Williams', 'Brown', 'Davies', 'Evans', 'Wilson', 'Thomas', 'Roberts',
-        'Johnson', 'Lewis', 'Walker', 'Robinson', 'Wood', 'Thompson', 'White', 'Watson', 'Jackson', 'Wright',
-        'Green', 'Harris', 'Cooper', 'King', 'Lee', 'Martin', 'Clarke', 'James', 'Morgan', 'Hughes',
-        'Edwards', 'Hill', 'Moore', 'Clark', 'Harrison', 'Scott', 'Young', 'Morris', 'Hall', 'Ward',
-        'Turner', 'Carter', 'Phillips', 'Mitchell', 'Patel', 'Adams', 'Campbell', 'Anderson', 'Allen', 'Cook',
-        'Bailey', 'Parker', 'Miller', 'Davis', 'Murphy', 'Price', 'Bell', 'Baker', 'Griffiths', 'Kelly',
-        'Simpson', 'Marshall', 'Collins', 'Bennett', 'Cox', 'Richardson', 'Fox', 'Gray', 'Rose', 'Chapman',
-        'Hunt', 'Robertson', 'Shaw', 'Reynolds', 'Lloyd', 'Ellis', 'Richards', 'Russell', 'Wilkinson', 'Khan',
-        'Graham', 'Stewart', 'Reid', 'Murray', 'Powell', 'Palmer', 'Holmes', 'Rogers', 'Stevens', 'Walsh',
-        'Hunter', 'Thompson', 'Matthews', 'Ross', 'Owen', 'Mason', 'Knight', 'Kennedy', 'Butler', 'Saunders'
+        'Adams', 'Allen', 'Anderson',
+        'Bailey', 'Baker', 'Bell', 'Bennett', 'Brown', 'Butler',
+        'Campbell', 'Carter', 'Chapman', 'Clark', 'Clarke', 'Collins', 'Cook', 'Cooper', 'Cox',
+        'Davies', 'Davis',
+        'Edwards', 'Ellis', 'Evans', 
+        'Fox', 
+        'Graham', 'Gray', 'Green', 'Griffiths', 
+        'Hall', 'Harris', 'Harrison', 'Hill', 'Holmes', 'Hughes', 'Hunt', 'Hunter', 
+        'Jackson', 'James', 'Johnson', 'Jones', 
+        'Kelly', 'Kennedy', 'Khan', 'King', 'Knight', 
+        'Lee', 'Lewis', 'Lloyd', 
+        'Marshall', 'Martin', 'Mason', 'Matthews', 'Miller', 'Mitchell', 'Moore', 'Morgan', 'Morris', 'Murphy', 'Murray', 
+        'Owen', 
+        'Palmer', 'Parker', 'Patel', 'Phillips', 'Powell', 'Price', 
+        'Reid', 'Reynolds', 'Richards', 'Richardson', 'Roberts', 'Robertson', 'Robinson', 'Rogers', 'Rose', 'Ross', 'Russell', 
+        'Saunders' 'Scott', 'Shaw', 'Simpson', 'Smith', 'Stevens', 'Stewart', 
+        'Taylor', 'Thomas', 'Thompson', 'Turner', 
+        'Walker', 'Walsh', 'Ward', 'Watson', 'White', 'Wilkinson', 'Williams', 'Wilson', 'Wood', 'Wright', 
+        'Young',
     );
 }


### PR DESCRIPTION
I've recently found myself using Faker for some test data to provide a demonstration system and found that the names which were being generated in most cases, weren't names which are commonly used in the UK.

I've created a simple Person class for the UK.

Data for forenames came from ONS [female names here](http://www.ons.gov.uk/ons/rel/vsob1/baby-names--england-and-wales/2013/info-girls-names-2013.html) and [male names here](http://www.ons.gov.uk/ons/rel/vsob1/baby-names--england-and-wales/2013/info-boys-names-2013.html) - I used the data from 2003 and 2013.

I also used some of the names already in the en_US locale which were relevant to a UK audience.

For surnames, I found a list [here](http://surname.sofeminine.co.uk/w/surnames/most-common-surnames-in-great-britain.html) which seemed to reflect usage well.

I haven't added any tests as I've only changed the contents of the arrays, but if there's anything else I should be doing let me know. I've not made an open source contribution before, and I wasn't entirely sure if I should be submitting this as none of the other EN locales have specific Person providers (other than the default en_GB).