### PR TITLE
Correct state abbreviation for Nunavut

### DIFF
--- a/src/Faker/Provider/en_CA/Address.php
+++ b/src/Faker/Provider/en_CA/Address.php
@@ -17,7 +17,7 @@ class Address extends \Faker\Provider\en_US\Address
     );
 
     protected static $provinceAbbr = array(
-        'AB', 'BC', 'MB', 'NB', 'NL', 'NT', 'NS', 'NV', 'ON', 'PE', 'QC', 'SK', 'YT'
+        'AB', 'BC', 'MB', 'NB', 'NL', 'NT', 'NS', 'NU', 'ON', 'PE', 'QC', 'SK', 'YT'
     );
 
     protected static $addressFormats = array(


### PR DESCRIPTION
Source: http://en.wikipedia.org/wiki/Canadian_postal_abbreviations_for_provinces_and_territories
