### PR TITLE
Avoid OverflowException for uniques

### DIFF
--- a/src/Faker/UniqueGenerator.php
+++ b/src/Faker/UniqueGenerator.php
@@ -38,6 +38,9 @@ class UniqueGenerator
         do {
             $res = call_user_func_array(array($this->generator, $name), $arguments);
             $i++;
+            if ($i > $this->maxRetries - 100) {
+                $res .= rand(0, 100000);
+            }
             if ($i > $this->maxRetries) {
                 throw new \OverflowException(sprintf('Maximum retries of %d reached without finding a unique value', $this->maxRetries));
             }


### PR DESCRIPTION
Should be done in a cleaner way after checking $name type
