### PR TITLE
Addition of en_GB mobileNumber methods

### DIFF
--- a/src/Faker/Provider/en_GB/PhoneNumber.php
+++ b/src/Faker/Provider/en_GB/PhoneNumber.php
@@ -37,4 +37,13 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
       return static::numerify(static::randomElement(static::$mobileFormats));
     }
 
+    /**
+     * Return a en_GB cell (mobile) phone number
+     * @return string
+     */
+    public static function cellNumber()
+    {
+      return static::mobileNumber();
+    }
+
 }

--- a/src/Faker/Provider/en_GB/PhoneNumber.php
+++ b/src/Faker/Provider/en_GB/PhoneNumber.php
@@ -34,6 +34,6 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
      */
     public static function mobileNumber()
     {
-      return static::numerify(static::randomElement(static::$mobileFormats));
+        return static::numerify(static::randomElement(static::$mobileFormats));
     }
 }

--- a/src/Faker/Provider/en_GB/PhoneNumber.php
+++ b/src/Faker/Provider/en_GB/PhoneNumber.php
@@ -16,4 +16,25 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
         '(0####) ######',
         '(0####) #####',
     );
+
+    /**
+     * An array of en_GB mobile (cell) phone number formats
+     * @var array
+     */
+    protected static $mobileFormats = array(
+      // Local
+      '07#########',
+      '07### ######',
+      '07### ### ###'
+    );
+
+    /**
+     * Return a en_GB mobile phone number
+     * @return string
+     */
+    public static function mobileNumber()
+    {
+      return static::numerify(static::randomElement(static::$mobileFormats));
+    }
+
 }

--- a/src/Faker/Provider/en_GB/PhoneNumber.php
+++ b/src/Faker/Provider/en_GB/PhoneNumber.php
@@ -36,14 +36,4 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     {
       return static::numerify(static::randomElement(static::$mobileFormats));
     }
-
-    /**
-     * Return a en_GB cell (mobile) phone number
-     * @return string
-     */
-    public static function cellNumber()
-    {
-      return static::mobileNumber();
-    }
-
 }

--- a/src/Faker/Provider/en_NZ/PhoneNumber.php
+++ b/src/Faker/Provider/en_NZ/PhoneNumber.php
@@ -78,15 +78,6 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     }
 
     /**
-     * Return a en_NZ cell (mobile) phone number
-     * @return string
-     */
-    public static function cellNumber()
-    {
-        return static::mobileNumber();
-    }
-
-    /**
      * Return a en_NZ toll free phone number
      * @return string
      */


### PR DESCRIPTION
Additions to the PhoneNumber Provider for en_GB so that a UK format phone number can be returned.