### PR TITLE
PSR-4 Autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,13 @@
         "squizlabs/php_codesniffer": "~1.5"
     },
     "autoload": {
-        "psr-0": {
-            "Faker": "src/",
-            "Faker\\PHPUnit": "test/"
+        "psr-4": {
+            "Faker\\": "src/Faker/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Faker\\PHPUnit\\": "test/Faker/"
         }
     },
     "extra": {


### PR DESCRIPTION
PSR-0 is deprecated. This pull moves us to PSR-4 autoloading, but to maintain bc, retains the original directory structure.
