### PR TITLE
Sanitizing username to prevent invalid email

### DIFF
--- a/src/Faker/Provider/Internet.php
+++ b/src/Faker/Provider/Internet.php
@@ -94,7 +94,7 @@ class Internet extends \Faker\Provider\Base
 
         $userName = static::toLower(static::bothify($this->generator->parse($format)));
         
-        return filter_var($userName, FILTER_SANITIZE_EMAIL);
+        return filter_var($userName, \FILTER_SANITIZE_EMAIL);
     }
 
     /**

--- a/src/Faker/Provider/Internet.php
+++ b/src/Faker/Provider/Internet.php
@@ -92,7 +92,9 @@ class Internet extends \Faker\Provider\Base
     {
         $format = static::randomElement(static::$userNameFormats);
 
-        return static::toLower(static::bothify($this->generator->parse($format)));
+        $userName = static::toLower(static::bothify($this->generator->parse($format)));
+        
+        return filter_var($userName, FILTER_SANITIZE_EMAIL);
     }
 
     /**


### PR DESCRIPTION
In certain locales (e.g. nl_NL), special characters are used in names such as ç; when using these characters for generating email addresses, this will result in an invalid email address (e.g. valbinusgenaamdweissvonweissenlöw@example.net or sarah.ünal@example.com), which causes tests in my case to fail.