### PR TITLE
Fixed Typo and Platform Independent EOL

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ Even if this example shows a property access, each call to `$faker->name` yields
 ```php
 <?php
 for ($i=0; $i < 10; $i++) {
-  echo $faker->name, "\n";
+  echo $faker->name . PHP_EOL;
 }
   // Adaline Reichel
   // Dr. Santa Prosacco DVM


### PR DESCRIPTION
Using PHP_EOL ensures this will give the exact return the person expects, regardless of platform.
