### PR TITLE
fixing missing @return phpDoc

### DIFF
--- a/src/Faker/Provider/Payment.php
+++ b/src/Faker/Provider/Payment.php
@@ -286,6 +286,7 @@ class Payment extends Base
      *
      * @example 'RZTIAT22263'
      * @link    http://en.wikipedia.org/wiki/ISO_9362
+     * @return  string Swift/Bic number
      */
     public static function swiftBicNumber()
     {


### PR DESCRIPTION
“...There is not anything which returns to nothing, but all things return dissolved into their elements. ” 
― Lucretius
