### PR TITLE
Doctrine orm polish

### DIFF
--- a/src/Faker/ORM/Doctrine/EntityPopulator.php
+++ b/src/Faker/ORM/Doctrine/EntityPopulator.php
@@ -170,7 +170,10 @@ class EntityPopulator
                         $ex->getMessage()
                     ));
                 }
-                $this->class->reflFields[$field]->setValue($obj, $value);
+                //Try a standard setter if it's available, otherwise fall back on reflection
+                $setter = sprintf("set%s", ucfirst($field));
+                if(method_exists($obj, $setter)) $obj->$setter($value);
+                else $this->class->reflFields[$field]->setValue($obj, $value);
             }
         }
     }

--- a/src/Faker/ORM/Doctrine/EntityPopulator.php
+++ b/src/Faker/ORM/Doctrine/EntityPopulator.php
@@ -163,7 +163,7 @@ class EntityPopulator
                 //Add some extended debugging information to any errors thrown by the formatter
                 try {
                     $value = is_callable($format) ? $format($insertedEntities, $obj) : $format;
-                } catch(\InvalidArgumentException $ex) {
+                } catch (\InvalidArgumentException $ex) {
                     throw new \InvalidArgumentException(sprintf("Failed to generate a value for %s::%s: %s",
                         get_class($obj),
                         $field,
@@ -172,8 +172,11 @@ class EntityPopulator
                 }
                 //Try a standard setter if it's available, otherwise fall back on reflection
                 $setter = sprintf("set%s", ucfirst($field));
-                if(method_exists($obj, $setter)) $obj->$setter($value);
-                else $this->class->reflFields[$field]->setValue($obj, $value);
+                if(method_exists($obj, $setter)) {
+                    $obj->$setter($value);
+                } else {
+                    $this->class->reflFields[$field]->setValue($obj, $value);
+                }
             }
         }
     }

--- a/src/Faker/ORM/Doctrine/EntityPopulator.php
+++ b/src/Faker/ORM/Doctrine/EntityPopulator.php
@@ -160,7 +160,16 @@ class EntityPopulator
     {
         foreach ($this->columnFormatters as $field => $format) {
             if (null !== $format) {
-                $value = is_callable($format) ? $format($insertedEntities, $obj) : $format;
+                //Add some extended debugging information to any errors thrown by the formatter
+                try {
+                    $value = is_callable($format) ? $format($insertedEntities, $obj) : $format;
+                } catch(\InvalidArgumentException $ex) {
+                    throw new \InvalidArgumentException(sprintf("Failed to generate a value for %s::%s: %s",
+                        get_class($obj),
+                        $field,
+                        $ex->getMessage()
+                    ));
+                }
                 $this->class->reflFields[$field]->setValue($obj, $value);
             }
         }


### PR DESCRIPTION
I made 2 changes to facilitate my use of Faker against Doctrine entities.

First, to track down formatter errors, I re-throw the InvalidArgumentException with the specific class name and field name that failed.  This helped me track down several issues I had tracking down decimal fields that were bigger than mt_getrandmax.

Second, Doctrine entities usually have setters for their properties, and those setters can have their own behaviors (regenerating slugs on setting a title, passing relationship assignment between owner and inversion, etc.).  I therefore thought trying to use the setter to assign a value before falling back on reflection might improve the resulting object mockup.  The reflection strategy is useful for hydration, where the data has already been established and is merely being re-loaded into an object, not for creating new data, as the EntityPopulator is trying to do.