### PR TITLE
Improve unique generator performance

### DIFF
--- a/src/Faker/UniqueGenerator.php
+++ b/src/Faker/UniqueGenerator.php
@@ -41,8 +41,8 @@ class UniqueGenerator
             if ($i > $this->maxRetries) {
                 throw new \OverflowException(sprintf('Maximum retries of %d reached without finding a unique value', $this->maxRetries));
             }
-        } while (in_array($res, $this->uniques[$name]));
-        $this->uniques[$name][]= $res;
+        } while (array_key_exists($res, $this->uniques[$name]));
+        $this->uniques[$name][$res]= null;
 
         return $res;
     }


### PR DESCRIPTION
Hi,

Currently the unique generator keeps the already used elements as array values and performs the lookup with `in_array` to assert that the generated value has not already been used. This operation is a O(n) operation which becomes slower in time for large datasets generation.

I refactored this operation to uses array indexes instead, which will leads to hash table lookups that are O(1) operations.

I did a little benchmark generating 10k unixTimes, the generation time is decreased from 1.77 seconds to 0.37 seconds.
