### PR TITLE
add random GET argument for imageUrl faker

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -221,8 +221,6 @@ Each of the generator properties (like `name`, `address`, and `lorem`) are calle
     imageUrl($width, $height, 'cats')     // 'http://lorempixel.com/800/600/cats/'
     image($dir = '/tmp', $width = 640, $height = 480) // '/tmp/13b73edae8443990be1aa8f1a483bc27.jpg'
     image($dir, $width, $height, 'cats')  // 'tmp/13b73edae8443990be1aa8f1a483bc27.jpg' it's a cat!
-    image($dir, $width, $height, 'cats', true)  // 'tmp/13b73edae8443990be1aa8f1a483bc27.jpg?52345' it's a cat with a five digit random GET argument,
-                                                // thus, each generated image within a single web page will be different (no client cache use).
 
 ### `Faker\Provider\Uuid`
 

--- a/readme.md
+++ b/readme.md
@@ -221,6 +221,8 @@ Each of the generator properties (like `name`, `address`, and `lorem`) are calle
     imageUrl($width, $height, 'cats')     // 'http://lorempixel.com/800/600/cats/'
     image($dir = '/tmp', $width = 640, $height = 480) // '/tmp/13b73edae8443990be1aa8f1a483bc27.jpg'
     image($dir, $width, $height, 'cats')  // 'tmp/13b73edae8443990be1aa8f1a483bc27.jpg' it's a cat!
+    image($dir, $width, $height, 'cats', true)  // 'tmp/13b73edae8443990be1aa8f1a483bc27.jpg?52345' it's a cat with a five digit random GET argument,
+                                                // thus, each generated image within a single web page will be different (no client cache use).
 
 ### `Faker\Provider\Uuid`
 

--- a/src/Faker/Provider/Image.php
+++ b/src/Faker/Provider/Image.php
@@ -15,9 +15,11 @@ class Image extends Base
     /**
      * Generate the URL that will return a random image
      *
+     * Set randomize to false to add a random GET parameter at the end of the url.
+     *
      * @example 'http://lorempixel.com/640/480/'
      */
-    public static function imageUrl($width = 640, $height = 480, $category = null)
+    public static function imageUrl($width = 640, $height = 480, $category = null, $randomize=false)
     {
         $url = "http://lorempixel.com/{$width}/{$height}/";
         if ($category) {
@@ -25,6 +27,10 @@ class Image extends Base
                 throw new \InvalidArgumentException(sprintf('Unkown image category "%s"', $category));
             }
             $url .= "{$category}/";
+        }
+
+        if ($randomize) {
+            $url .= '?' . static::randomNumber(5, true);
         }
 
         return $url;

--- a/src/Faker/Provider/Image.php
+++ b/src/Faker/Provider/Image.php
@@ -19,7 +19,7 @@ class Image extends Base
      *
      * @example 'http://lorempixel.com/640/480/'
      */
-    public static function imageUrl($width = 640, $height = 480, $category = null, $randomize=false)
+    public static function imageUrl($width = 640, $height = 480, $category = null, $randomize = false)
     {
         $url = "http://lorempixel.com/{$width}/{$height}/";
         if ($category) {

--- a/src/Faker/Provider/Image.php
+++ b/src/Faker/Provider/Image.php
@@ -15,11 +15,11 @@ class Image extends Base
     /**
      * Generate the URL that will return a random image
      *
-     * Set randomize to false to add a random GET parameter at the end of the url.
+     * Set randomize to false to remove the random GET parameter at the end of the url.
      *
-     * @example 'http://lorempixel.com/640/480/'
+     * @example 'http://lorempixel.com/640/480/?12345'
      */
-    public static function imageUrl($width = 640, $height = 480, $category = null, $randomize = false)
+    public static function imageUrl($width = 640, $height = 480, $category = null, $randomize = true)
     {
         $url = "http://lorempixel.com/{$width}/{$height}/";
         if ($category) {

--- a/test/Faker/Provider/ImageTest.php
+++ b/test/Faker/Provider/ImageTest.php
@@ -21,6 +21,15 @@ class ImageTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(Image::imageUrl(800, 400, 'nature'), 'http://lorempixel.com/800/400/nature/');
     }
 
+    public function testRandomizedUrl()
+    {
+        $url = Image::imageUrl(800, 400, null, true);
+        $splitUrl = preg_split('/\?/', $url);
+
+        $this->assertEquals(count($splitUrl), 2);
+        $this->assertEquals($splitUrl[0], 'http://lorempixel.com/800/400/');
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      */

--- a/test/Faker/Provider/ImageTest.php
+++ b/test/Faker/Provider/ImageTest.php
@@ -6,28 +6,28 @@ use Faker\Provider\Image;
 
 class ImageTest extends \PHPUnit_Framework_TestCase
 {
-    public function testUrlWithDefaults()
+    public function testImageUrlUses640x680AsTheDefaultSize()
     {
-        $this->assertEquals(Image::imageUrl(), 'http://lorempixel.com/640/480/');
+        $this->assertRegExp('#^http://lorempixel.com/640/480/#', Image::imageUrl());
     }
 
-    public function testUrlWithDimensions()
+    public function testImageUrlAcceptsCustomWidthAndHeight()
     {
-        $this->assertEquals(Image::imageUrl(800, 400), 'http://lorempixel.com/800/400/');
+        $this->assertRegExp('#^http://lorempixel.com/800/400/#', Image::imageUrl(800, 400));
     }
 
-    public function testUrlWithDimensionsAndCategory()
+    public function testImageUrlAcceptsCustomCategory()
     {
-        $this->assertEquals(Image::imageUrl(800, 400, 'nature'), 'http://lorempixel.com/800/400/nature/');
+        $this->assertRegExp('#^http://lorempixel.com/800/400/nature/#', Image::imageUrl(800, 400, 'nature'));
     }
 
-    public function testRandomizedUrl()
+    public function testImageUrlAddsARandomGetParameterByDefault()
     {
-        $url = Image::imageUrl(800, 400, null, true);
+        $url = Image::imageUrl(800, 400);
         $splitUrl = preg_split('/\?/', $url);
 
         $this->assertEquals(count($splitUrl), 2);
-        $this->assertEquals($splitUrl[0], 'http://lorempixel.com/800/400/');
+        $this->assertRegexp('#\d{5}#', $splitUrl[1]);
     }
 
     /**


### PR DESCRIPTION
Fixes the imageUrl provider bug when displaying several images on a web page.

Supersedes #372 
