### PR TITLE
Created faker for Currency Codes.

### DIFF
--- a/src/Faker/Provider/Miscellaneous.php
+++ b/src/Faker/Provider/Miscellaneous.php
@@ -154,6 +154,30 @@ class Miscellaneous extends \Faker\Provider\Base
     );
 
     /**
+     * @link http://en.wikipedia.org/wiki/ISO_4217
+     * On date of 2015-01-10
+     */
+    protected static $currencyCode = array(
+        'AED', 'AFN', 'ALL', 'AMD', 'ANG', 'AOA', 'ARS', 'AUD', 'AWG', 'AZN',
+        'BAM', 'BBD', 'BDT', 'BGN', 'BHD', 'BIF', 'BMD', 'BND', 'BOB', 'BRL',
+        'BSD', 'BTC', 'BTN', 'BWP', 'BYR', 'BZD', 'CAD', 'CDF', 'CHF', 'CLF',
+        'CLP', 'CNY', 'COP', 'CRC', 'CUP', 'CVE', 'CZK', 'DJF', 'DKK', 'DOP',
+        'DZD', 'EEK', 'EGP', 'ERN', 'ETB', 'EUR', 'FJD', 'FKP', 'GBP', 'GEL',
+        'GGP', 'GHS', 'GIP', 'GMD', 'GNF', 'GTQ', 'GYD', 'HKD', 'HNL', 'HRK',
+        'HTG', 'HUF', 'IDR', 'ILS', 'IMP', 'INR', 'IQD', 'IRR', 'ISK', 'JEP',
+        'JMD', 'JOD', 'JPY', 'KES', 'KGS', 'KHR', 'KMF', 'KPW', 'KRW', 'KWD',
+        'KYD', 'KZT', 'LAK', 'LBP', 'LKR', 'LRD', 'LSL', 'LTL', 'LVL', 'LYD',
+        'MAD', 'MDL', 'MGA', 'MKD', 'MMK', 'MNT', 'MOP', 'MRO', 'MTL', 'MUR',
+        'MVR', 'MWK', 'MXN', 'MYR', 'MZN', 'NAD', 'NGN', 'NIO', 'NOK', 'NPR',
+        'NZD', 'OMR', 'PAB', 'PEN', 'PGK', 'PHP', 'PKR', 'PLN', 'PYG', 'QAR',
+        'RON', 'RSD', 'RUB', 'RWF', 'SAR', 'SBD', 'SCR', 'SDG', 'SEK', 'SGD',
+        'SHP', 'SLL', 'SOS', 'SRD', 'STD', 'SVC', 'SYP', 'SZL', 'THB', 'TJS',
+        'TMT', 'TND', 'TOP', 'TRY', 'TTD', 'TWD', 'TZS', 'UAH', 'UGX', 'USD',
+        'UYU', 'UZS', 'VEF', 'VND', 'VUV', 'WST', 'XAF', 'XAG', 'XAU', 'XCD',
+        'XDR', 'XOF', 'XPF', 'YER', 'ZAR', 'ZMK', 'ZMW', 'ZWL'
+    );
+
+    /**
      * Return a boolean, true or false
      *
      * @param integer $chanceOfGettingTrue Between 0 (always get false) and 100 (always get true).
@@ -220,5 +244,14 @@ class Miscellaneous extends \Faker\Provider\Base
     public static function languageCode()
     {
         return static::randomElement(static::$languageCode);
+    }
+
+    /**
+     * @example 'EUR'
+     * @link https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+     */
+    public static function currencyCode()
+    {
+        return static::randomElement(static::$currencyCode);
     }
 }

--- a/test/Faker/Provider/MiscellaneousTest.php
+++ b/test/Faker/Provider/MiscellaneousTest.php
@@ -46,4 +46,9 @@ class MiscellaneousTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertRegExp('/^[a-z]{2}$/', Miscellaneous::languageCode());
     }
+
+    public function testCurrencyCode()
+    {
+        $this->assertRegExp('/^[A-Z]{3}$/', Miscellaneous::currencyCode());
+    }
 }


### PR DESCRIPTION
Created faker for currency codes (similar to country codes and language codes). The list of currencies are taken from the ISO 4217 standard list.