### PR TITLE
Feature : Add dateTimeInInterval Method

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -146,6 +146,7 @@ Each of the generator properties (like `name`, `address`, and `lorem`) are calle
     date($format = 'Y-m-d', $max = 'now') // '1979-06-09'
     time($format = 'H:i:s', $max = 'now') // '20:49:42'
     dateTimeBetween($startDate = '-30 years', $endDate = 'now') // DateTime('2003-03-15 02:00:49')
+    dateTimeInInterval($startDate = '-30 years', $interval = '+ 5 days') // DateTime('2003-03-15 02:00:49')
     dateTimeThisCentury($max = 'now')     // DateTime('1915-05-30 19:28:21')
     dateTimeThisDecade($max = 'now')      // DateTime('2007-05-29 22:30:48')
     dateTimeThisYear($max = 'now')        // DateTime('2011-02-27 20:52:14')

--- a/src/Faker/Provider/DateTime.php
+++ b/src/Faker/Provider/DateTime.php
@@ -117,6 +117,29 @@ class DateTime extends \Faker\Provider\Base
     }
 
     /**
+     * Get a DateTime object based on a random date between one given date and
+     * an interval
+     * Accepts date string that can be recognized by strtotime().
+     *
+     * @param string $date      Defaults to 30 years ago
+     * @param string $interval  Defaults to 5 days after
+     * @example dateTimeInInterval('1999-02-02 11:42:52', '+ 5 days')
+     * @return \DateTime
+     */
+    public static function dateTimeInInterval($date = '-30 years', $interval = '+5 days')
+    {
+        $intervalObject = \DateInterval::createFromDateString($interval);
+        $datetime       = $date instanceof \DateTime ? $date : new \DateTime($date);
+        $otherDatetime  = clone $datetime;
+        $otherDatetime->add($intervalObject);
+        
+        $begin = $datetime > $otherDatetime ? $otherDatetime : $datetime;
+        $end = $datetime===$begin ? $otherDatetime : $datetime;
+
+        return static::dateTimeBetween($begin, $end);
+    }
+
+    /**
      * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
      * @example DateTime('1964-04-04 11:02:02')
      * @return \DateTime

--- a/test/Faker/Provider/DateTimeTest.php
+++ b/test/Faker/Provider/DateTimeTest.php
@@ -74,6 +74,35 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     *
+     * @dataProvider providerDateTimeInInterval
+     */
+    public function testDateTimeInInterval($start, $interval = "+5 days", $isInFutur)
+    {
+        $date = DateTimeProvider::dateTimeInInterval($start, $interval);
+        $this->assertInstanceOf('\DateTime', $date);
+        
+        $_interval = \DateInterval::createFromDateString($interval);
+        $_start = new \DateTime($start);
+        if($isInFutur){
+            $this->assertGreaterThanOrEqual($_start, $date);
+            $this->assertLessThanOrEqual($_start->add($_interval), $date);
+        }else{
+            $this->assertLessThanOrEqual($_start, $date);
+            $this->assertGreaterThanOrEqual($_start->add($_interval), $date);
+        }
+    }
+
+    public function providerDateTimeInInterval()
+    {
+        return array(
+            array('-1 year', '+5 days', true),
+            array('-1 day', '-1 hour', false),
+            array('-1 day', '+1 hour', true),
+        );
+    }
+
     public function testFixedSeedWithMaximumTimestamp()
     {
         $max = '2018-03-01 12:00:00';


### PR DESCRIPTION
Permit to take a date and add or substract a php recognized interval.

I'm sure this can be usefull, because i write that in one of my alice loader, but not if this can be look as good writed (long in comparison with other pretty date functions) or in your waited tasks list.

So let me know if you want i finish with csfixer, tests, rebase and all or if this is not usefull.

@see http://php.net/manual/fr/dateinterval.createfromdatestring.php
@see http://php.net/manual/fr/datetime.formats.relative.php

@note : edited directly on github for moment