### PR TITLE
Updated es_AR Address.php provider

### DIFF
--- a/src/Faker/Provider/es_AR/Address.php
+++ b/src/Faker/Provider/es_AR/Address.php
@@ -43,7 +43,7 @@ class Address extends \Faker\Provider\Address
         'Zambia', 'Zimbabue'
     );
     protected static $cityFormats = array(
-        '{{cityPrefix}} {{firstName}}{{citySuffix}}',
+        '{{cityPrefix}} {{firstName}} {{citySuffix}}',
         '{{cityPrefix}} {{firstName}}',
         '{{firstName}} {{citySuffix}}',
         '{{lastName}} {{citySuffix}}',

--- a/src/Faker/Provider/es_AR/Address.php
+++ b/src/Faker/Provider/es_AR/Address.php
@@ -45,16 +45,16 @@ class Address extends \Faker\Provider\Address
     protected static $cityFormats = array(
         '{{cityPrefix}} {{firstName}}{{citySuffix}}',
         '{{cityPrefix}} {{firstName}}',
-        '{{firstName}}{{citySuffix}}',
-        '{{lastName}}{{citySuffix}}',
+        '{{firstName}} {{citySuffix}}',
+        '{{lastName}} {{citySuffix}}',
     );
     protected static $streetNameFormats = array(
         '{{firstName}} {{streetSuffix}}',
         '{{lastName}} {{streetSuffix}}'
     );
     protected static $streetAddressFormats = array(
-        '{{buildingNumber}} {{streetName}}',
-        '{{buildingNumber}} {{streetName}} {{secondaryAddress}}',
+        '{{streetName}} {{buildingNumber}}',
+        '{{streetName}} {{buildingNumber}} {{secondaryAddress}}',
     );
     protected static $addressFormats = array(
         "{{streetAddress}}\n{{city}}, {{stateAbbr}} {{postcode}}",


### PR DESCRIPTION
CitySuffix should be separated by a space from the name.
The building number should be after the street name.