### PR TITLE
Fix for 'The first argument to copy() function cannot be a directory'

### DIFF
--- a/src/Faker/Provider/File.php
+++ b/src/Faker/Provider/File.php
@@ -584,8 +584,8 @@ class File extends \Faker\Provider\Base
         }
 
         // Drop . and .. and reset array keys
-		$files = array_filter(array_values(array_diff(scandir($sourceDirectory), array('.', '..'))), function($file) {
-			return !is_dir($file);
+		$files = array_filter(array_values(array_diff(scandir($sourceDirectory), array('.', '..'))), function($file) use ($sourceDirectory) {
+			return !is_dir($sourceDirectory . DIRECTORY_SEPARATOR . $file);
 		});
 
         $sourceFullPath = $sourceDirectory . DIRECTORY_SEPARATOR . static::randomElement($files);

--- a/src/Faker/Provider/File.php
+++ b/src/Faker/Provider/File.php
@@ -584,7 +584,9 @@ class File extends \Faker\Provider\Base
         }
 
         // Drop . and .. and reset array keys
-        $files = array_values(array_diff(scandir($sourceDirectory), array('.', '..')));
+		$files = array_filter(array_values(array_diff(scandir($sourceDirectory), array('.', '..'))), function($file) {
+			return !is_dir($file);
+		});
 
         $sourceFullPath = $sourceDirectory . DIRECTORY_SEPARATOR . static::randomElement($files);
 

--- a/src/Faker/Provider/File.php
+++ b/src/Faker/Provider/File.php
@@ -584,9 +584,9 @@ class File extends \Faker\Provider\Base
         }
 
         // Drop . and .. and reset array keys
-		$files = array_filter(array_values(array_diff(scandir($sourceDirectory), array('.', '..'))), function($file) use ($sourceDirectory) {
-			return !is_dir($sourceDirectory . DIRECTORY_SEPARATOR . $file);
-		});
+        $files = array_filter(array_values(array_diff(scandir($sourceDirectory), array('.', '..'))), function ($file) use ($sourceDirectory) {
+                return !is_dir($sourceDirectory . DIRECTORY_SEPARATOR . $file);
+        });
 
         $sourceFullPath = $sourceDirectory . DIRECTORY_SEPARATOR . static::randomElement($files);
 


### PR DESCRIPTION
This is a fix for the issue #539. Directories are excluded using the provided filter.