### PR TITLE
Fixed file provider to ignore unreadable and special files

### DIFF
--- a/src/Faker/Provider/File.php
+++ b/src/Faker/Provider/File.php
@@ -585,8 +585,12 @@ class File extends \Faker\Provider\Base
 
         // Drop . and .. and reset array keys
         $files = array_filter(array_values(array_diff(scandir($sourceDirectory), array('.', '..'))), function ($file) use ($sourceDirectory) {
-                return !is_dir($sourceDirectory . DIRECTORY_SEPARATOR . $file);
+            return is_file($sourceDirectory . DIRECTORY_SEPARATOR . $file) && is_readable($sourceDirectory . DIRECTORY_SEPARATOR . $file);
         });
+
+        if (empty($files)) {
+            throw new \InvalidArgumentException(sprintf('Source directory %s is empty.', $sourceDirectory));
+        }
 
         $sourceFullPath = $sourceDirectory . DIRECTORY_SEPARATOR . static::randomElement($files);
 


### PR DESCRIPTION
After fixing #547 I found out that there are some other cases which will cause ```copy``` to fail: unreadable files and special files (e.g. pipes).

The proposed changes should fix this issue and additionally I added an exception if the chosen directory is empty.