### PR TITLE
Altered date_between() to avoid 32-bit limits and support a wider and…

### DIFF
--- a/src/Faker/Provider/DateTime.php
+++ b/src/Faker/Provider/DateTime.php
@@ -12,17 +12,18 @@ class DateTime extends \Faker\Provider\Base
             return (int) $max;
         }
 
-        if (! $max instanceof \DateTime) {
+        if (!$max instanceof \DateTime) {
             $max = new \DateTime($max);
         }
 
-        return $max->format("U");
+        return $max->format('U');
     }
 
     /**
-     * Get a timestamp between January 1, 1970 and now
+     * Get a timestamp between January 1, 1970 and now.
      *
      * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
+     *
      * @return int
      *
      * @example 1061306726
@@ -33,35 +34,42 @@ class DateTime extends \Faker\Provider\Base
     }
 
     /**
-     * Get a datetime object for a date between January 1, 1970 and now
+     * Get a datetime object for a date between January 1, 1970 and now.
      *
      * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
+     *
      * @example DateTime('2005-08-16 20:39:21')
+     *
      * @return \DateTime
      */
     public static function dateTime($max = 'now')
     {
-        return new \DateTime('@' . static::unixTime($max));
+        return new \DateTime('@'.static::unixTime($max));
     }
 
     /**
-     * Get a datetime object for a date between January 1, 001 and now
+     * Get a datetime object for a date between January 1, 001 and now.
      *
      * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
+     *
      * @example DateTime('1265-03-22 21:15:52')
+     *
      * @return \DateTime
      */
     public static function dateTimeAD($max = 'now')
     {
         $beginningOfTime = new \DateTime('January 1, 001');
+
         return static::dateTimeBetween($beginningOfTime, $max);
     }
 
     /**
-     * get a date string formatted with ISO8601
+     * get a date string formatted with ISO8601.
      *
      * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
+     *
      * @return string
+     *
      * @example '2003-10-21T16:05:52+0000'
      */
     public static function iso8601($max = 'now')
@@ -70,11 +78,13 @@ class DateTime extends \Faker\Provider\Base
     }
 
     /**
-     * Get a date string between January 1, 1970 and now
+     * Get a date string between January 1, 1970 and now.
      *
      * @param string               $format
      * @param \DateTime|int|string $max    maximum timestamp used as random end limit, default to "now"
+     *
      * @return string
+     *
      * @example '2008-11-27'
      */
     public static function date($format = 'Y-m-d', $max = 'now')
@@ -83,11 +93,13 @@ class DateTime extends \Faker\Provider\Base
     }
 
     /**
-     * Get a time string (24h format by default)
+     * Get a time string (24h format by default).
      *
      * @param string               $format
      * @param \DateTime|int|string $max    maximum timestamp used as random end limit, default to "now"
+     *
      * @return string
+     *
      * @example '15:02:34'
      */
     public static function time($format = 'H:i:s', $max = 'now')
@@ -101,22 +113,24 @@ class DateTime extends \Faker\Provider\Base
      *
      * @param string $startDate Defaults to 30 years ago
      * @param string $endDate   Defaults to "now"
+     *
      * @example DateTime('1999-02-02 11:42:52')
+     *
      * @return \DateTime
      */
     public static function dateTimeBetween($startDate = '-30 years', $endDate = 'now')
     {
-        if(! $startDate instanceof \DateTime) {
+        if (!$startDate instanceof \DateTime) {
             $startDate = new \DateTime($startDate);
         }
-        if(! $endDate instanceof \DateTime) {
+        if (!$endDate instanceof \DateTime) {
             $endDate = new \DateTime($endDate);
         }
         $returnDate = $startDate;
 
         //getTimestamp alternative for large numbers
-        $startTimestamp = $startDate->format("U");
-        $endTimestamp = $endDate->format("U");
+        $startTimestamp = $startDate->format('U');
+        $endTimestamp = $endDate->format('U');
 
         if ($startTimestamp > $endTimestamp) {
             throw new \InvalidArgumentException('Start date must be anterior to end date.');
@@ -147,7 +161,7 @@ class DateTime extends \Faker\Provider\Base
         $randomSeconds = mt_rand($timeSecondsMin, $timeSecondsMax);
 
         //fix to midnight, add the seconds
-        $returnDate->setTime(0,0,0);
+        $returnDate->setTime(0, 0, 0);
         $returnDate->modify('+'.$randomSeconds.' seconds');
 
         $returnDate->setTimezone(new \DateTimeZone(date_default_timezone_get()));
@@ -157,7 +171,9 @@ class DateTime extends \Faker\Provider\Base
 
     /**
      * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
+     *
      * @example DateTime('1964-04-04 11:02:02')
+     *
      * @return \DateTime
      */
     public static function dateTimeThisCentury($max = 'now')
@@ -167,7 +183,9 @@ class DateTime extends \Faker\Provider\Base
 
     /**
      * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
+     *
      * @example DateTime('2010-03-10 05:18:58')
+     *
      * @return \DateTime
      */
     public static function dateTimeThisDecade($max = 'now')
@@ -177,7 +195,9 @@ class DateTime extends \Faker\Provider\Base
 
     /**
      * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
+     *
      * @example DateTime('2011-09-19 09:24:37')
+     *
      * @return \DateTime
      */
     public static function dateTimeThisYear($max = 'now')
@@ -187,7 +207,9 @@ class DateTime extends \Faker\Provider\Base
 
     /**
      * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
+     *
      * @example DateTime('2011-10-05 12:51:46')
+     *
      * @return \DateTime
      */
     public static function dateTimeThisMonth($max = 'now')
@@ -197,7 +219,9 @@ class DateTime extends \Faker\Provider\Base
 
     /**
      * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
+     *
      * @return string
+     *
      * @example 'am'
      */
     public static function amPm($max = 'now')
@@ -207,7 +231,9 @@ class DateTime extends \Faker\Provider\Base
 
     /**
      * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
+     *
      * @return string
+     *
      * @example '22'
      */
     public static function dayOfMonth($max = 'now')
@@ -217,7 +243,9 @@ class DateTime extends \Faker\Provider\Base
 
     /**
      * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
+     *
      * @return string
+     *
      * @example 'Tuesday'
      */
     public static function dayOfWeek($max = 'now')
@@ -227,7 +255,9 @@ class DateTime extends \Faker\Provider\Base
 
     /**
      * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
+     *
      * @return string
+     *
      * @example '7'
      */
     public static function month($max = 'now')
@@ -237,7 +267,9 @@ class DateTime extends \Faker\Provider\Base
 
     /**
      * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
+     *
      * @return string
+     *
      * @example 'September'
      */
     public static function monthName($max = 'now')
@@ -247,7 +279,9 @@ class DateTime extends \Faker\Provider\Base
 
     /**
      * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
+     *
      * @return int
+     *
      * @example 1673
      */
     public static function year($max = 'now')
@@ -257,6 +291,7 @@ class DateTime extends \Faker\Provider\Base
 
     /**
      * @return string
+     *
      * @example 'XVII'
      */
     public static function century()
@@ -266,6 +301,7 @@ class DateTime extends \Faker\Provider\Base
 
     /**
      * @return string
+     *
      * @example 'Europe/Paris'
      */
     public static function timezone()

--- a/src/Faker/Provider/DateTime.php
+++ b/src/Faker/Provider/DateTime.php
@@ -12,11 +12,11 @@ class DateTime extends \Faker\Provider\Base
             return (int) $max;
         }
 
-        if ($max instanceof \DateTime) {
-            return $max->getTimestamp();
+        if (! $max instanceof \DateTime) {
+            $max = new \DateTime($max);
         }
 
-        return strtotime(empty($max) ? 'now' : $max);
+        return $max->format("U");
     }
 
     /**
@@ -53,7 +53,8 @@ class DateTime extends \Faker\Provider\Base
      */
     public static function dateTimeAD($max = 'now')
     {
-        return new \DateTime('@' . mt_rand(-62135597361, static::getMaxTimestamp($max)));
+        $beginningOfTime = new \DateTime('January 1, 001');
+        return static::dateTimeBetween($beginningOfTime, $max);
     }
 
     /**
@@ -105,19 +106,53 @@ class DateTime extends \Faker\Provider\Base
      */
     public static function dateTimeBetween($startDate = '-30 years', $endDate = 'now')
     {
-        $startTimestamp = $startDate instanceof \DateTime ? $startDate->getTimestamp() : strtotime($startDate);
-        $endTimestamp = static::getMaxTimestamp($endDate);
+        if(! $startDate instanceof \DateTime) {
+            $startDate = new \DateTime($startDate);
+        }
+        if(! $endDate instanceof \DateTime) {
+            $endDate = new \DateTime($endDate);
+        }
+        $returnDate = $startDate;
+
+        //getTimestamp alternative for large numbers
+        $startTimestamp = $startDate->format("U");
+        $endTimestamp = $endDate->format("U");
 
         if ($startTimestamp > $endTimestamp) {
             throw new \InvalidArgumentException('Start date must be anterior to end date.');
         }
 
-        $timestamp = mt_rand($startTimestamp, $endTimestamp);
+        //get difference between timestamps
+        $diff = $endTimestamp - $startTimestamp;
 
-        $ts = new \DateTime('@' . $timestamp);
-        $ts->setTimezone(new \DateTimeZone(date_default_timezone_get()));
+        $secondsPerDay = 86400;
 
-        return $ts;
+        //convert to days - floor isn't really random but should be sufficient
+        $daysDifference = floor($diff / $secondsPerDay);
+
+        $addDays = mt_rand(0, $daysDifference);
+
+        //modify the returnDate
+        $returnDate->modify('+'.$addDays.' days');
+
+        //if the new date is equal to the start or end, limit the time appropriately
+        $timeMin = (($returnDate->format('Y-m-d') == $startDate->format('Y-m-d')) ? $startDate->format('H:i:s') : '00:00:00');
+        $timeMax = (($returnDate->format('Y-m-d') == $endDate->format('Y-m-d')) ? $endDate->format('H:i:s') : '23:59:59');
+
+        //convert times to seconds
+        $timeSecondsMin = strtotime($timeMin) - strtotime('TODAY');
+        $timeSecondsMax = strtotime($timeMax) - strtotime('TODAY');
+
+        //random number of seconds - will be used as "since midnight" on our new day
+        $randomSeconds = mt_rand($timeSecondsMin, $timeSecondsMax);
+
+        //fix to midnight, add the seconds
+        $returnDate->setTime(0,0,0);
+        $returnDate->modify('+'.$randomSeconds.' seconds');
+
+        $returnDate->setTimezone(new \DateTimeZone(date_default_timezone_get()));
+
+        return $returnDate;
     }
 
     /**


### PR DESCRIPTION
… older range of random dates.

This is gross, but it now avoids the limits of `mt_rand` by first randomizing the date clamped to the min and max and then randomizing the time (clamped to the given min and max times if the date happened to fall on one of them). I also updated `dateTimeAD()` to utilize this, since it appeared that previously it was not, in fact, getting a random date since the beginning of time but rather operating within `mt_rand()`'s limits.

I tested it a bit as part of the FakerPress plugin and it appears to be working quite nicely. If someone has a better solution or can explain how there wasn't an issue previously, please let me know. See #599 