### PR TITLE
Improve name guesser logic using field length when available

### DIFF
--- a/src/Faker/Guesser/Name.php
+++ b/src/Faker/Guesser/Name.php
@@ -15,7 +15,7 @@ class Name
 
     /**
      * @param string $name
-     * @param int $size
+     * @param int|null $size Length of field, if known
      * @return callable
      */
     public function guessFormat($name, $size = null)
@@ -110,6 +110,7 @@ class Name
                             return $generator->country;
                         };
                 }
+                break;
             case 'locale':
                 return function () use ($generator) {
                     return $generator->locale;

--- a/src/Faker/Guesser/Name.php
+++ b/src/Faker/Guesser/Name.php
@@ -13,7 +13,12 @@ class Name
         $this->generator = $generator;
     }
 
-    public function guessFormat($name)
+    /**
+     * @param string $name
+     * @param int $size
+     * @return callable
+     */
+    public function guessFormat($name, $size = null)
     {
         $name = Base::toLower($name);
         $generator = $this->generator;
@@ -27,13 +32,11 @@ class Name
                 return $generator->dateTime;
             };
         }
-        switch ($name) {
-            case 'first_name':
+        switch (str_replace('_', '', $name)) {
             case 'firstname':
                 return function () use ($generator) {
                     return $generator->firstName;
                 };
-            case 'last_name':
             case 'lastname':
                 return function () use ($generator) {
                     return $generator->lastName;
@@ -44,12 +47,14 @@ class Name
                     return $generator->userName;
                 };
             case 'email':
+            case 'emailaddress':
                 return function () use ($generator) {
                     return $generator->email;
                 };
-            case 'phone_number':
             case 'phonenumber':
             case 'phone':
+            case 'telephone':
+            case 'telnumber':
                 return function () use ($generator) {
                     return $generator->phoneNumber;
                 };
@@ -58,6 +63,7 @@ class Name
                     return $generator->address;
                 };
             case 'city':
+            case 'town':
                 return function () use ($generator) {
                     return $generator->city;
                 };
@@ -74,16 +80,70 @@ class Name
                 return function () use ($generator) {
                     return $generator->state;
                 };
-            case 'country':
+            case 'county':
+                if ($this->generator->locale == 'en_US') {
+                    return function () use ($generator) {
+                        return sprintf('%s County', $generator->city);
+                    };
+                }
+
                 return function () use ($generator) {
-                    return $generator->country;
+                    return $generator->state;
+                };
+            case 'country':
+                switch ($size) {
+                    case 2:
+                        return function () use ($generator) {
+                            return $generator->countryCode;
+                        };
+                    case 3:
+                        return function () use ($generator) {
+                            return $generator->countryISOAlpha3;
+                        };
+                    case 5:
+                    case 6:
+                        return function () use ($generator) {
+                            return $generator->locale;
+                        };
+                    default:
+                        return function () use ($generator) {
+                            return $generator->country;
+                        };
+                }
+            case 'locale':
+                return function () use ($generator) {
+                    return $generator->locale;
+                };
+            case 'currency':
+            case 'currencycode':
+                return function () use ($generator) {
+                    return $generator->currencyCode;
+                };
+            case 'url':
+            case 'website':
+                return function () use ($generator) {
+                    return $generator->url;
+                };
+            case 'company':
+            case 'companyname':
+            case 'employer':
+                return function () use ($generator) {
+                    return $generator->company;
                 };
             case 'title':
+                if ($size !== null && $size <= 10) {
+                    return function () use ($generator) {
+                        return $generator->title;
+                    };
+                }
+
                 return function () use ($generator) {
                     return $generator->sentence;
                 };
             case 'body':
             case 'summary':
+            case 'article':
+            case 'description':
                 return function () use ($generator) {
                     return $generator->text;
                 };

--- a/src/Faker/ORM/Doctrine/EntityPopulator.php
+++ b/src/Faker/ORM/Doctrine/EntityPopulator.php
@@ -82,7 +82,8 @@ class EntityPopulator
                 continue;
             }
 
-            if ($formatter = $nameGuesser->guessFormat($fieldName)) {
+            $size = isset($this->class->fieldMappings[$fieldName]['length']) ? $this->class->fieldMappings[$fieldName]['length'] : null;
+            if ($formatter = $nameGuesser->guessFormat($fieldName, $size)) {
                 $formatters[$fieldName] = $formatter;
                 continue;
             }

--- a/src/Faker/ORM/Propel/EntityPopulator.php
+++ b/src/Faker/ORM/Propel/EntityPopulator.php
@@ -67,7 +67,7 @@ class EntityPopulator
             if ($columnMap->isPrimaryKey()) {
                 continue;
             }
-            if ($formatter = $nameGuesser->guessFormat($columnMap->getPhpName())) {
+            if ($formatter = $nameGuesser->guessFormat($columnMap->getPhpName(), $columnMap->getSize())) {
                 $formatters[$columnMap->getPhpName()] = $formatter;
                 continue;
             }


### PR DESCRIPTION
I kept finding dummy users with Lorem Ipsum as their salutation. This change uses the field length to be a bit more intelligent when that data is known. I've also tried to guess a few more column name and types.