### PR TITLE
Expand IBAN interface

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -201,6 +201,8 @@ Each of the generator properties (like `name`, `address`, and `lorem`) are calle
     creditCardExpirationDate // 04/13
     creditCardExpirationDateString // '04/13'
     creditCardDetails       // array('MasterCard', '4485480221084675', 'Aleksander Nowak', '04/13')
+    // Generates a random IBAN. Set $countryCode to null for a random country
+    iban($countryCode)      // 'IT31A8497112740YZ575DJ28BP4'
     swiftBicNumber          // RZTIAT22263
 
 ### `Faker\Provider\Color`
@@ -802,6 +804,16 @@ echo $faker->region; // "Saint-Pierre-et-Miquelon"
 
 ```
 
+### `Faker\Provider\hu_HU\Payment`
+
+```php
+<?php
+
+// Generates a random bank account number
+echo $faker->bankAccountNumber; // "HU09904437680048220079300783"
+
+```
+
 ### `Faker\Provider\ja_JP\Person`
 
 ```php
@@ -817,6 +829,16 @@ echo $faker->firstKanaName; // "ハルカ"
 echo $faker->lastKanaName; // "ナカジマ"
 ```
 
+### `Faker\Provider\ka_GE\Payment`
+
+```php
+<?php
+
+// Generates a random bank account number
+echo $faker->bankAccountNumber; // "GE33ZV9773853617253389"
+
+```
+
 ### `Faker\Provider\kk_KZ\Company`
 
 ```php
@@ -824,6 +846,19 @@ echo $faker->lastKanaName; // "ナカジマ"
 
 // Generates an business identification number
 echo $faker->businessIdentificationNumber; // "150140000019"
+
+```
+
+### `Faker\Provider\kk_KZ\Payment`
+
+```php
+<?php
+
+// Generates a random bank name
+echo $faker->bank; // "Қазкоммерцбанк"
+
+// Generates a random bank account number
+echo $faker->bankAccountNumber; // "KZ1076321LO4H6X41I37"
 
 ```
 
@@ -858,6 +893,16 @@ echo $faker->borough; // "강남구"
 
 // Generates a random personal identity card number
 echo $faker->personalIdentityNumber; // "140190-12301"
+
+```
+
+### `Faker\Provider\no_NO\Payment`
+
+```php
+<?php
+
+// Generates a random bank account number
+echo $faker->bankAccountNumber; // "NO3246764709816"
 
 ```
 
@@ -947,6 +992,26 @@ echo $faker->rg;         // '84.405.736-3'
 echo $faker->cnpj;       // '23.663.478/0001-24'
 ```
 
+### `Faker\Provider\ro_MD\Payment`
+
+```php
+<?php
+
+// Generates a random bank account number
+echo $faker->bankAccountNumber; // "MD83BQW1CKMUW34HBESDP3A8"
+
+```
+
+### `Faker\Provider\ro_RO\Payment`
+
+```php
+<?php
+
+// Generates a random bank account number
+echo $faker->bankAccountNumber; // "RO55WRJE3OE8X3YQI7J26U1E"
+
+```
+
 ### `Faker\Provider\ro_RO\Person`
 
 ```php
@@ -1004,6 +1069,16 @@ echo $faker->tollFreeNumber; // "0800 123 456"
 
 // Area Code
 echo $faker->areaCode; // "03"
+```
+
+### `Faker\Provider\sv_SE\Payment`
+
+```php
+<?php
+
+// Generates a random bank account number
+echo $faker->bankAccountNumber; // "SE5018548608468284909192"
+
 ```
 
 ### `Faker\Provider\sv_SE\Person`

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -41,6 +41,8 @@ namespace Faker;
  * @property string $creditCardExpirationDateString
  * @property string $creditCardDetails
  * @property string $bankAccountNumber
+ * @property string $iban
+ * @method string iban($countryCode = null, $prefix = '', $length = null)
  * @property string $swiftBicNumber
  * @property string $vat
  *

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -41,7 +41,6 @@ namespace Faker;
  * @property string $creditCardExpirationDateString
  * @property string $creditCardDetails
  * @property string $bankAccountNumber
- * @property string $iban
  * @method string iban($countryCode = null, $prefix = '', $length = null)
  * @property string $swiftBicNumber
  * @property string $vat

--- a/src/Faker/Provider/Payment.php
+++ b/src/Faker/Provider/Payment.php
@@ -211,9 +211,10 @@ class Payment extends Base
      * @param  integer $length      total length without country code and 2 check digits
      * @return string
      */
-    protected static function iban($countryCode, $prefix = '', $length = null)
+    public static function iban($countryCode = null, $prefix = '', $length = null)
     {
-        $countryCode = strtoupper($countryCode);
+        $countryCode = is_null($countryCode) ? array_rand(self::$ibanFormats) : strtoupper($countryCode);
+
         $format = !isset(static::$ibanFormats[$countryCode]) ? null : static::$ibanFormats[$countryCode];
         if ($length === null) {
             if ($format === null) {

--- a/src/Faker/Provider/Payment.php
+++ b/src/Faker/Provider/Payment.php
@@ -211,7 +211,7 @@ class Payment extends Base
      * @param  integer $length      total length without country code and 2 check digits
      * @return string
      */
-    public static function iban($countryCode = null, $prefix = '', $length = null)
+    public static function iban($countryCode, $prefix = '', $length = null)
     {
         $countryCode = is_null($countryCode) ? array_rand(self::$ibanFormats) : strtoupper($countryCode);
 

--- a/src/Faker/Provider/Payment.php
+++ b/src/Faker/Provider/Payment.php
@@ -213,7 +213,7 @@ class Payment extends Base
      */
     public static function iban($countryCode, $prefix = '', $length = null)
     {
-        $countryCode = is_null($countryCode) ? array_rand(self::$ibanFormats) : strtoupper($countryCode);
+        $countryCode = is_null($countryCode) ? self::randomKey(self::$ibanFormats) : strtoupper($countryCode);
 
         $format = !isset(static::$ibanFormats[$countryCode]) ? null : static::$ibanFormats[$countryCode];
         if ($length === null) {

--- a/src/Faker/Provider/hu_HU/Payment.php
+++ b/src/Faker/Provider/hu_HU/Payment.php
@@ -1,23 +1,9 @@
 <?php
 
-namespace Faker\Provider\kk_KZ;
+namespace Faker\Provider\hu_HU;
 
 class Payment extends \Faker\Provider\Payment
 {
-
-    protected static $banks = array(
-        'Қазкоммерцбанк',
-        'Халық Банкі',
-    );
-
-    /**
-     * @example 'Қазкоммерцбанк'
-     */
-    public static function bank()
-    {
-        return static::randomElement(static::$banks);
-    }
-
     /**
      * International Bank Account Number (IBAN)
      * @link http://en.wikipedia.org/wiki/International_Bank_Account_Number
@@ -26,7 +12,7 @@ class Payment extends \Faker\Provider\Payment
      * @param  integer $length      total length without country code and 2 check digits
      * @return string
      */
-    public static function bankAccountNumber($prefix = '', $countryCode = 'KZ', $length = null)
+    public static function bankAccountNumber($prefix = '', $countryCode = 'HU', $length = null)
     {
         return static::iban($countryCode, $prefix, $length);
     }

--- a/src/Faker/Provider/ka_GE/Payment.php
+++ b/src/Faker/Provider/ka_GE/Payment.php
@@ -1,23 +1,9 @@
 <?php
 
-namespace Faker\Provider\kk_KZ;
+namespace Faker\Provider\ka_GE;
 
 class Payment extends \Faker\Provider\Payment
 {
-
-    protected static $banks = array(
-        'Қазкоммерцбанк',
-        'Халық Банкі',
-    );
-
-    /**
-     * @example 'Қазкоммерцбанк'
-     */
-    public static function bank()
-    {
-        return static::randomElement(static::$banks);
-    }
-
     /**
      * International Bank Account Number (IBAN)
      * @link http://en.wikipedia.org/wiki/International_Bank_Account_Number
@@ -26,7 +12,7 @@ class Payment extends \Faker\Provider\Payment
      * @param  integer $length      total length without country code and 2 check digits
      * @return string
      */
-    public static function bankAccountNumber($prefix = '', $countryCode = 'KZ', $length = null)
+    public static function bankAccountNumber($prefix = '', $countryCode = 'GE', $length = null)
     {
         return static::iban($countryCode, $prefix, $length);
     }

--- a/src/Faker/Provider/no_NO/Payment.php
+++ b/src/Faker/Provider/no_NO/Payment.php
@@ -1,23 +1,9 @@
 <?php
 
-namespace Faker\Provider\kk_KZ;
+namespace Faker\Provider\no_NO;
 
 class Payment extends \Faker\Provider\Payment
 {
-
-    protected static $banks = array(
-        'Қазкоммерцбанк',
-        'Халық Банкі',
-    );
-
-    /**
-     * @example 'Қазкоммерцбанк'
-     */
-    public static function bank()
-    {
-        return static::randomElement(static::$banks);
-    }
-
     /**
      * International Bank Account Number (IBAN)
      * @link http://en.wikipedia.org/wiki/International_Bank_Account_Number
@@ -26,7 +12,7 @@ class Payment extends \Faker\Provider\Payment
      * @param  integer $length      total length without country code and 2 check digits
      * @return string
      */
-    public static function bankAccountNumber($prefix = '', $countryCode = 'KZ', $length = null)
+    public static function bankAccountNumber($prefix = '', $countryCode = 'NO', $length = null)
     {
         return static::iban($countryCode, $prefix, $length);
     }

--- a/src/Faker/Provider/ro_MD/Payment.php
+++ b/src/Faker/Provider/ro_MD/Payment.php
@@ -1,23 +1,9 @@
 <?php
 
-namespace Faker\Provider\kk_KZ;
+namespace Faker\Provider\ro_MD;
 
 class Payment extends \Faker\Provider\Payment
 {
-
-    protected static $banks = array(
-        'Қазкоммерцбанк',
-        'Халық Банкі',
-    );
-
-    /**
-     * @example 'Қазкоммерцбанк'
-     */
-    public static function bank()
-    {
-        return static::randomElement(static::$banks);
-    }
-
     /**
      * International Bank Account Number (IBAN)
      * @link http://en.wikipedia.org/wiki/International_Bank_Account_Number
@@ -26,7 +12,7 @@ class Payment extends \Faker\Provider\Payment
      * @param  integer $length      total length without country code and 2 check digits
      * @return string
      */
-    public static function bankAccountNumber($prefix = '', $countryCode = 'KZ', $length = null)
+    public static function bankAccountNumber($prefix = '', $countryCode = 'MD', $length = null)
     {
         return static::iban($countryCode, $prefix, $length);
     }

--- a/src/Faker/Provider/ro_RO/Payment.php
+++ b/src/Faker/Provider/ro_RO/Payment.php
@@ -1,23 +1,9 @@
 <?php
 
-namespace Faker\Provider\kk_KZ;
+namespace Faker\Provider\ro_RO;
 
 class Payment extends \Faker\Provider\Payment
 {
-
-    protected static $banks = array(
-        'Қазкоммерцбанк',
-        'Халық Банкі',
-    );
-
-    /**
-     * @example 'Қазкоммерцбанк'
-     */
-    public static function bank()
-    {
-        return static::randomElement(static::$banks);
-    }
-
     /**
      * International Bank Account Number (IBAN)
      * @link http://en.wikipedia.org/wiki/International_Bank_Account_Number
@@ -26,7 +12,7 @@ class Payment extends \Faker\Provider\Payment
      * @param  integer $length      total length without country code and 2 check digits
      * @return string
      */
-    public static function bankAccountNumber($prefix = '', $countryCode = 'KZ', $length = null)
+    public static function bankAccountNumber($prefix = '', $countryCode = 'RO', $length = null)
     {
         return static::iban($countryCode, $prefix, $length);
     }

--- a/src/Faker/Provider/sv_SE/Payment.php
+++ b/src/Faker/Provider/sv_SE/Payment.php
@@ -1,23 +1,9 @@
 <?php
 
-namespace Faker\Provider\kk_KZ;
+namespace Faker\Provider\sv_SE;
 
 class Payment extends \Faker\Provider\Payment
 {
-
-    protected static $banks = array(
-        'Қазкоммерцбанк',
-        'Халық Банкі',
-    );
-
-    /**
-     * @example 'Қазкоммерцбанк'
-     */
-    public static function bank()
-    {
-        return static::randomElement(static::$banks);
-    }
-
     /**
      * International Bank Account Number (IBAN)
      * @link http://en.wikipedia.org/wiki/International_Bank_Account_Number
@@ -26,7 +12,7 @@ class Payment extends \Faker\Provider\Payment
      * @param  integer $length      total length without country code and 2 check digits
      * @return string
      */
-    public static function bankAccountNumber($prefix = '', $countryCode = 'KZ', $length = null)
+    public static function bankAccountNumber($prefix = '', $countryCode = 'SE', $length = null)
     {
         return static::iban($countryCode, $prefix, $length);
     }


### PR DESCRIPTION
Here I've:
* Added implementations of `bankAccountNumber` to all existing, supported locales
* Made made the `iban()` function public
* Allow `null` as the `$countryCode` (where it chooses a random, supported country)
* Added unit tests for all supported countries

This allows the explicit use of `iban()` for any locale and allows for the generation of IBANs from random countries.

The unit tests also warn (skip tests) about locales where bankAccountNumber is not implemented, even though an IBAN format is available. This currently warns about the "fake" locales at_AT and be_BE, which are deprecated in #594.

The one point I'm not sure on is the default value of iban($countryCode). I've set it to the current locale for IBAN countries and null (random) on the base class. For example, it would currently work like this:
````php
Faker\Factory::create('it_IT')->bankAccountNumber; // 'IT66F5186468682C65NOP68ZYK9'
Faker\Factory::create('it_IT')->iban; // 'IT04U8856763833CPN8P3H3QDJ4'
Faker\Factory::create('it_IT')->iban(null); // 'AT681337042751049061'

Faker\Factory::create('en_US')->iban; // 'HR6628746829188144538'
Faker\Factory::create('en_US')->bankAccountNumber;
// InvalidArgumentException with message 'Unknown formatter "bankAccountNumber"''
````
