### PR TITLE
pt_BR: more flexibility to cellphone generation

### DIFF
--- a/src/Faker/Provider/pt_BR/PhoneNumber.php
+++ b/src/Faker/Provider/pt_BR/PhoneNumber.php
@@ -32,15 +32,15 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     /**
      * Generates a 8/9-digit cellphone number without formatting characters.
      * @param bool $formatted [def: true] If it should return a formatted number or not.
-     * @param bool $ninth     [def: false] If the number should have a nine in the beginning or not.
-     *                        If the generated number begins with 7 this is ignored.
+     * @param int|bool $area  [def: false] A specific area code to which the number will belong.
+     *                        If a boolean is used, will add (or not) the ninth digit.
      * @return string
      */
-    public static function cellphone($formatted = true, $ninth = false)
+    public static function cellphone($formatted = true, $area = false)
     {
         $number = static::numerify(static::randomElement(static::$cellphoneFormats));
 
-        if ($ninth && $number[0] != 7) {
+        if ($area === true || in_array($area, static::$ninthDigitAreaCodes)) {
             $number = "9$number";
         }
 


### PR DESCRIPTION
Currently a boolean is used to define if the cellphone should
contain the ninth digit or not. This was extended so if an area
code needs to be enforced, it can be generated externally and given
to the cellphone generator, and it will create a correct number.

> This wasn't made in the same branch as #622 since it's changing a method's argument, and it could create a little controversy. But in the end the behaviour is still backwards compatible :)