### PR TITLE
Update Generator.php

### DIFF
--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -184,7 +184,7 @@ class Generator
         if ($seed === null) {
             mt_srand();
         } else {
-            mt_srand($seed);
+            mt_srand((int) $seed);
         }
     }
 

--- a/test/Faker/GeneratorTest.php
+++ b/test/Faker/GeneratorTest.php
@@ -119,6 +119,9 @@ class GeneratorTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEquals($mtRandWithSeedZero, $mtRandWithoutSeed, 'seed() should be different than seed(0)');
         $generator->seed();
         $this->assertNotEquals($mtRandWithoutSeed, mt_rand(), 'seed() should not be deterministic.');
+
+        $generator->seed('10');
+        $this->assertTrue(true, 'seeding with a non int value doesn\'t throw an exception');
     }
 }
 


### PR DESCRIPTION
Cast `$seed` instead of checking if `null`. This way it does not throw an error if we passed a stringified int value either.