### PR TITLE
Fix: Dev dependencies are installed by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,6 @@ sudo: false
 
 before_script:
     - travis_retry composer self-update
-    - travis_retry composer install --no-interaction --prefer-source --dev
+    - travis_retry composer install --no-interaction --prefer-source
 
 script: make sniff test

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 vendor/autoload.php:
-	composer install --no-interaction --prefer-source --dev
+	composer install --no-interaction --prefer-source
 
 .PHONY: sniff
 sniff: vendor/autoload.php


### PR DESCRIPTION
This PR

* [x] removes the `--dev` option when installing dependencies with Composer, as this is the default anyway