### PR TITLE
Fix: Namespace is Faker\Test, not Faker\PHPUnit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Faker\\PHPUnit\\": "test/Faker/"
+            "Faker\\Test\\": "test/Faker/"
         }
     },
     "extra": {


### PR DESCRIPTION
This PR

* [x] fixes the namespace in `autoload-dev`

:information_desk_person: The namespace is `Faker\Test`, not `Faker\PHPUnit`.