### PR TITLE
Enhancement: Implement GeneratorTrait

### DIFF
--- a/src/Faker/GeneratorTrait.php
+++ b/src/Faker/GeneratorTrait.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Faker;
+
+trait GeneratorTrait
+{
+    /**
+     * @var Generator
+     */
+    protected $generator;
+
+    /**
+     * @param string $locale
+     * @param int    $seed
+     *
+     * @return Generator
+     */
+    protected function getGenerator($locale = Factory::DEFAULT_LOCALE, $seed = 9000)
+    {
+        if ($this->generator === null) {
+            $this->generator = Factory::create($locale);
+            $this->generator->seed($seed);
+        }
+
+        return $this->generator;
+    }
+}


### PR DESCRIPTION
This PR

* [x] implements a `GeneratorTrait`

:information_desk_person: Not sure if anyone else finds this useful, but I find myself repeatedly creating a `GeneratorTrait` for different projects, where I then use it in tests.

:person_with_pouting_face: Adding tests is blocked by #663.