### PR TITLE
updated regexify to ignore escaped parenthesis

### DIFF
--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -420,7 +420,7 @@ class Base
             return str_repeat($matches[1], Base::randomElement(range($matches[2], $matches[3])));
         }, $regex);
         // (this|that) becomes 'this' or 'that'
-        $regex = preg_replace_callback('/\((.*?)\)/', function ($matches) {
+        $regex = preg_replace_callback('/(?<!\\\)\((.*?)\)/', function ($matches) {
             return Base::randomElement(explode('|', str_replace(array('(', ')'), '', $matches[1])));
         }, $regex);
         // All A-F inside of [] become ABCDEF


### PR DESCRIPTION
I wanted to do something like the following to generate a specific id format, but the parenthesis were missing in the result. This pull request fixes this issue.

`$faker->regexify('(Q|O)-\([0-9]{4}\)-[0-9A-Z]{6}')`

The above results in something like `Q-(2297)-ZNS2IJ` instead of `Q-2297-ZNS2IJ`
