### PR TITLE
Modification to randomKey Method to support array_key searches

### DIFF
--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -195,12 +195,12 @@ class Base
      * @param  array $array
      * @return int|string|null
      */
-    public static function randomKey($array = array())
+    public static function randomKey($array = array(), $search = null)
     {
         if (!$array) {
             return null;
         }
-        $keys = array_keys($array);
+        $keys = ($search === null) ? array_keys($array) : array_keys($array, $search);
         $key = $keys[mt_rand(0, count($keys) - 1)];
 
         return $key;

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -192,7 +192,12 @@ class Base
     /**
      * Returns a random key from a passed associative array
      *
-     * @param  array $array
+     * @param array       $array  Array to return key from
+     * @param null|string $search Value to search within Array for
+     *
+     * @example 'static::randomKey(array('foo' => 'bar', 'boo' => 'baz'));'
+     * @example 'static::randomKey(array('foo', 'bar', 'boo' => 'baz'), 'bar');'
+     *
      * @return int|string|null
      */
     public static function randomKey($array = array(), $search = null)


### PR DESCRIPTION
While working on a Provider addition to Faker I came across a use case where I wanted to use the Faker method for randomKey to return only a subset of the keys which contain a particular value (e.g. category or type as a value). The php function array_keys function supports search value as an optional second argument and I saw that the randomKey method uses the array_keys function to return the array keys for randomization. 

This modification edits Base::randomKey method to accept an optional input for $search. In certain use cases, this will ensure that only a subset of the array keys are returned for randomization.

This is my first pull request. I hope I didn't screw anything up. If so, your constructive criticism is appreciated.