### PR TITLE
Adds time zone support for provider methods returning DateTime instance

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -180,13 +180,13 @@ Each of the generator properties (like `name`, `address`, and `lorem`) are calle
 ### `Faker\Provider\DateTime`
 
     unixTime($max = 'now')                // 58781813
-    dateTime($max = 'now')                // DateTime('2008-04-25 08:37:17')
-    dateTimeAD($max = 'now')              // DateTime('1800-04-29 20:38:49')
+    dateTime($max = 'now', $timezone = date_default_timezone_get()) // DateTime('2008-04-25 08:37:17', 'UTC')
+    dateTimeAD($max = 'now', $timezone = date_default_timezone_get()) // DateTime('1800-04-29 20:38:49', 'Europe/Paris')
     iso8601($max = 'now')                 // '1978-12-09T10:10:29+0000'
     date($format = 'Y-m-d', $max = 'now') // '1979-06-09'
     time($format = 'H:i:s', $max = 'now') // '20:49:42'
-    dateTimeBetween($startDate = '-30 years', $endDate = 'now') // DateTime('2003-03-15 02:00:49')
-    dateTimeInInterval($startDate = '-30 years', $interval = '+ 5 days') // DateTime('2003-03-15 02:00:49')
+    dateTimeBetween($startDate = '-30 years', $endDate = 'now', $timezone = date_default_timezone_get()) // DateTime('2003-03-15 02:00:49', 'Africa/Lagos')
+    dateTimeInInterval($startDate = '-30 years', $interval = '+ 5 days', $timezone = date_default_timezone_get()) // DateTime('2003-03-15 02:00:49', 'Antartica/Vostok')
     dateTimeThisCentury($max = 'now')     // DateTime('1915-05-30 19:28:21')
     dateTimeThisDecade($max = 'now')      // DateTime('2007-05-29 22:30:48')
     dateTimeThisYear($max = 'now')        // DateTime('2011-02-27 20:52:14')

--- a/src/Faker/Provider/DateTime.php
+++ b/src/Faker/Provider/DateTime.php
@@ -36,24 +36,34 @@ class DateTime extends \Faker\Provider\Base
      * Get a datetime object for a date between January 1, 1970 and now
      *
      * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
+     * @param string $timezone time zone in which the date time should be set, default to 'UTC'
      * @example DateTime('2005-08-16 20:39:21')
      * @return \DateTime
+     * @see http://php.net/manual/en/timezones.php
      */
-    public static function dateTime($max = 'now')
+    public static function dateTime($max = 'now', $timezone = 'UTC')
     {
-        return new \DateTime('@' . static::unixTime($max));
+        return static::setTimezone(
+            new \DateTime('@' . static::unixTime($max)),
+            $timezone
+        );
     }
 
     /**
      * Get a datetime object for a date between January 1, 001 and now
      *
      * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
+     * @param string $timezone time zone in which the date time should be set, default to 'UTC'
      * @example DateTime('1265-03-22 21:15:52')
      * @return \DateTime
+     * @see http://php.net/manual/en/timezones.php
      */
-    public static function dateTimeAD($max = 'now')
+    public static function dateTimeAD($max = 'now', $timezone = 'UTC')
     {
-        return new \DateTime('@' . mt_rand(-62135597361, static::getMaxTimestamp($max)));
+        return static::setTimezone(
+            new \DateTime('@' . mt_rand(-62135597361, static::getMaxTimestamp($max))),
+            $timezone
+        );
     }
 
     /**
@@ -100,10 +110,12 @@ class DateTime extends \Faker\Provider\Base
      *
      * @param \DateTime|string $startDate Defaults to 30 years ago
      * @param \DateTime|string $endDate   Defaults to "now"
+     * @param string $timezone time zone in which the date time should be set, default to 'UTC'
      * @example DateTime('1999-02-02 11:42:52')
      * @return \DateTime
+     * @see http://php.net/manual/en/timezones.php
      */
-    public static function dateTimeBetween($startDate = '-30 years', $endDate = 'now')
+    public static function dateTimeBetween($startDate = '-30 years', $endDate = 'now', $timezone = 'UTC')
     {
         $startTimestamp = $startDate instanceof \DateTime ? $startDate->getTimestamp() : strtotime($startDate);
         $endTimestamp = static::getMaxTimestamp($endDate);
@@ -114,10 +126,10 @@ class DateTime extends \Faker\Provider\Base
 
         $timestamp = mt_rand($startTimestamp, $endTimestamp);
 
-        $ts = new \DateTime('@' . $timestamp);
-        $ts->setTimezone(new \DateTimeZone(date_default_timezone_get()));
-
-        return $ts;
+        return static::setTimezone(
+            new \DateTime('@' . $timestamp),
+            $timezone
+        );
     }
 
     /**
@@ -127,10 +139,12 @@ class DateTime extends \Faker\Provider\Base
      *
      * @param string $date      Defaults to 30 years ago
      * @param string $interval  Defaults to 5 days after
+     * @param string $timezone time zone in which the date time should be set, default to 'UTC'
      * @example dateTimeInInterval('1999-02-02 11:42:52', '+ 5 days')
      * @return \DateTime
+     * @see http://php.net/manual/en/timezones.php
      */
-    public static function dateTimeInInterval($date = '-30 years', $interval = '+5 days')
+    public static function dateTimeInInterval($date = '-30 years', $interval = '+5 days', $timezone = 'UTC')
     {
         $intervalObject = \DateInterval::createFromDateString($interval);
         $datetime       = $date instanceof \DateTime ? $date : new \DateTime($date);
@@ -140,7 +154,7 @@ class DateTime extends \Faker\Provider\Base
         $begin = $datetime > $otherDatetime ? $otherDatetime : $datetime;
         $end = $datetime===$begin ? $otherDatetime : $datetime;
 
-        return static::dateTimeBetween($begin, $end);
+        return static::dateTimeBetween($begin, $end, $timezone);
     }
 
     /**
@@ -259,5 +273,13 @@ class DateTime extends \Faker\Provider\Base
     public static function timezone()
     {
         return static::randomElement(\DateTimeZone::listIdentifiers());
+    }
+
+    /**
+     * Internal method to set the time zone on a DateTime.
+     */
+    private static function setTimezone(\DateTime $dt, $timezone)
+    {
+        return $dt->setTimezone(new \DateTimeZone($timezone));
     }
 }

--- a/src/Faker/Provider/DateTime.php
+++ b/src/Faker/Provider/DateTime.php
@@ -36,16 +36,17 @@ class DateTime extends \Faker\Provider\Base
      * Get a datetime object for a date between January 1, 1970 and now
      *
      * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
-     * @param string $timezone time zone in which the date time should be set, default to 'UTC'
+     * @param string $timezone time zone in which the date time should be set, default to result of `date_default_timezone_get`
      * @example DateTime('2005-08-16 20:39:21')
      * @return \DateTime
      * @see http://php.net/manual/en/timezones.php
+     * @see http://php.net/manual/en/function.date-default-timezone-get.php
      */
-    public static function dateTime($max = 'now', $timezone = 'UTC')
+    public static function dateTime($max = 'now', $timezone = null)
     {
         return static::setTimezone(
             new \DateTime('@' . static::unixTime($max)),
-            $timezone
+            (null === $timezone ? date_default_timezone_get() : $timezone)
         );
     }
 
@@ -53,16 +54,17 @@ class DateTime extends \Faker\Provider\Base
      * Get a datetime object for a date between January 1, 001 and now
      *
      * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
-     * @param string $timezone time zone in which the date time should be set, default to 'UTC'
+     * @param string $timezone time zone in which the date time should be set, default to result of `date_default_timezone_get`
      * @example DateTime('1265-03-22 21:15:52')
      * @return \DateTime
      * @see http://php.net/manual/en/timezones.php
+     * @see http://php.net/manual/en/function.date-default-timezone-get.php
      */
-    public static function dateTimeAD($max = 'now', $timezone = 'UTC')
+    public static function dateTimeAD($max = 'now', $timezone = null)
     {
         return static::setTimezone(
             new \DateTime('@' . mt_rand(-62135597361, static::getMaxTimestamp($max))),
-            $timezone
+            (null === $timezone ? date_default_timezone_get() : $timezone)
         );
     }
 
@@ -110,12 +112,13 @@ class DateTime extends \Faker\Provider\Base
      *
      * @param \DateTime|string $startDate Defaults to 30 years ago
      * @param \DateTime|string $endDate   Defaults to "now"
-     * @param string $timezone time zone in which the date time should be set, default to 'UTC'
+     * @param string $timezone time zone in which the date time should be set, default to result of `date_default_timezone_get`
      * @example DateTime('1999-02-02 11:42:52')
      * @return \DateTime
      * @see http://php.net/manual/en/timezones.php
+     * @see http://php.net/manual/en/function.date-default-timezone-get.php
      */
-    public static function dateTimeBetween($startDate = '-30 years', $endDate = 'now', $timezone = 'UTC')
+    public static function dateTimeBetween($startDate = '-30 years', $endDate = 'now', $timezone = null)
     {
         $startTimestamp = $startDate instanceof \DateTime ? $startDate->getTimestamp() : strtotime($startDate);
         $endTimestamp = static::getMaxTimestamp($endDate);
@@ -128,7 +131,7 @@ class DateTime extends \Faker\Provider\Base
 
         return static::setTimezone(
             new \DateTime('@' . $timestamp),
-            $timezone
+            (null === $timezone ? date_default_timezone_get() : $timezone)
         );
     }
 
@@ -139,12 +142,13 @@ class DateTime extends \Faker\Provider\Base
      *
      * @param string $date      Defaults to 30 years ago
      * @param string $interval  Defaults to 5 days after
-     * @param string $timezone time zone in which the date time should be set, default to 'UTC'
+     * @param string $timezone time zone in which the date time should be set, default to result of `date_default_timezone_get`
      * @example dateTimeInInterval('1999-02-02 11:42:52', '+ 5 days')
      * @return \DateTime
      * @see http://php.net/manual/en/timezones.php
+     * @see http://php.net/manual/en/function.date-default-timezone-get.php
      */
-    public static function dateTimeInInterval($date = '-30 years', $interval = '+5 days', $timezone = 'UTC')
+    public static function dateTimeInInterval($date = '-30 years', $interval = '+5 days', $timezone = null)
     {
         $intervalObject = \DateInterval::createFromDateString($interval);
         $datetime       = $date instanceof \DateTime ? $date : new \DateTime($date);
@@ -154,7 +158,11 @@ class DateTime extends \Faker\Provider\Base
         $begin = $datetime > $otherDatetime ? $otherDatetime : $datetime;
         $end = $datetime===$begin ? $otherDatetime : $datetime;
 
-        return static::dateTimeBetween($begin, $end, $timezone);
+        return static::dateTimeBetween(
+            $begin,
+            $end,
+            (null === $timezone ? date_default_timezone_get() : $timezone)
+        );
     }
 
     /**

--- a/test/Faker/Provider/DateTimeTest.php
+++ b/test/Faker/Provider/DateTimeTest.php
@@ -6,6 +6,18 @@ use Faker\Provider\DateTime as DateTimeProvider;
 
 class DateTimeTest extends \PHPUnit_Framework_TestCase
 {
+    public function setUp()
+    {
+        $this->originalTz = date_default_timezone_get();
+        $this->defaultTz = 'UTC';
+        date_default_timezone_set($this->defaultTz);
+    }
+
+    public function tearDown()
+    {
+        date_default_timezone_set($this->originalTz);
+    }
+
     public function testUnixTime()
     {
         $timestamp = DateTimeProvider::unixTime();
@@ -20,7 +32,7 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('\DateTime', $date);
         $this->assertGreaterThanOrEqual(new \DateTime('@0'), $date);
         $this->assertLessThanOrEqual(new \DateTime(), $date);
-        $this->assertEquals($date->getTimezone(), new \DateTimeZone('UTC'));
+        $this->assertEquals(new \DateTimeZone($this->defaultTz), $date->getTimezone());
     }
 
     public function testDateTimeWithTimezone()
@@ -35,7 +47,7 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('\DateTime', $date);
         $this->assertGreaterThanOrEqual(new \DateTime('0000-01-01 00:00:00'), $date);
         $this->assertLessThanOrEqual(new \DateTime(), $date);
-        $this->assertEquals($date->getTimezone(), new \DateTimeZone('UTC'));
+        $this->assertEquals(new \DateTimeZone($this->defaultTz), $date->getTimezone());
     }
 
     public function testIso8601()
@@ -70,7 +82,7 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('\DateTime', $date);
         $this->assertGreaterThanOrEqual(new \DateTime($start), $date);
         $this->assertLessThanOrEqual(new \DateTime($end), $date);
-        $this->assertEquals($date->getTimezone(), new \DateTimeZone('UTC'));
+        $this->assertEquals(new \DateTimeZone($this->defaultTz), $date->getTimezone());
     }
 
     public function providerDateTimeBetween()

--- a/test/Faker/Provider/DateTimeTest.php
+++ b/test/Faker/Provider/DateTimeTest.php
@@ -20,6 +20,13 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('\DateTime', $date);
         $this->assertGreaterThanOrEqual(new \DateTime('@0'), $date);
         $this->assertLessThanOrEqual(new \DateTime(), $date);
+        $this->assertEquals($date->getTimezone(), new \DateTimeZone('UTC'));
+    }
+
+    public function testDateTimeWithTimezone()
+    {
+        $date = DateTimeProvider::dateTime('now', 'America/New_York');
+        $this->assertEquals($date->getTimezone(), new \DateTimeZone('America/New_York'));
     }
 
     public function testDateTimeAD()
@@ -28,6 +35,7 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('\DateTime', $date);
         $this->assertGreaterThanOrEqual(new \DateTime('0000-01-01 00:00:00'), $date);
         $this->assertLessThanOrEqual(new \DateTime(), $date);
+        $this->assertEquals($date->getTimezone(), new \DateTimeZone('UTC'));
     }
 
     public function testIso8601()
@@ -62,6 +70,7 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('\DateTime', $date);
         $this->assertGreaterThanOrEqual(new \DateTime($start), $date);
         $this->assertLessThanOrEqual(new \DateTime($end), $date);
+        $this->assertEquals($date->getTimezone(), new \DateTimeZone('UTC'));
     }
 
     public function providerDateTimeBetween()
@@ -78,17 +87,17 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
      *
      * @dataProvider providerDateTimeInInterval
      */
-    public function testDateTimeInInterval($start, $interval = "+5 days", $isInFutur)
+    public function testDateTimeInInterval($start, $interval = "+5 days", $isInFuture)
     {
         $date = DateTimeProvider::dateTimeInInterval($start, $interval);
         $this->assertInstanceOf('\DateTime', $date);
         
         $_interval = \DateInterval::createFromDateString($interval);
         $_start = new \DateTime($start);
-        if($isInFutur){
+        if ($isInFuture) {
             $this->assertGreaterThanOrEqual($_start, $date);
             $this->assertLessThanOrEqual($_start->add($_interval), $date);
-        }else{
+        } else {
             $this->assertLessThanOrEqual($_start, $date);
             $this->assertGreaterThanOrEqual($_start->add($_interval), $date);
         }


### PR DESCRIPTION
There are four `DateTime` returning methods: `dateTime`, `dateTimeAD`, `dateTimeBetween`, and `dateTimeInterval`,  Two of these (`dateTimeBetween` and `dateTimeInterval`) set the timezone on the returned object, while the other two do not.  This can lead to user land juggling timezones when comparing dates returned from the different generators.

This PR updates these four `DateTime` returning methods to set the time zone to result of `date_default_timezone_get` or the  user-specified timezone given in the final argument to all methods.  Test coverage updated to check that the default and custom time zones are handled.