### PR TITLE
CakePHP ORM: Fix primaryKey warning

### DIFF
--- a/src/Faker/ORM/CakePHP/EntityPopulator.php
+++ b/src/Faker/ORM/CakePHP/EntityPopulator.php
@@ -130,7 +130,11 @@ class EntityPopulator
         }
 
         $pk = $table->primaryKey();
-        return $entity->{$pk};
+        if (is_string($pk)) {
+            return $entity->{$pk};
+        }
+
+        return $entity->{$pk[0]};
     }
 
     public function setConnection($name)


### PR DESCRIPTION
The return from the `primaryKey()` method can be both array and string, so this should be accounted for.

/cc @jadb 