### PR TITLE
Do not generate special purpose IPv4s

### DIFF
--- a/src/Faker/Provider/Internet.php
+++ b/src/Faker/Provider/Internet.php
@@ -288,7 +288,7 @@ class Internet extends \Faker\Provider\Base
      */
     public function ipv4()
     {
-        return long2ip(mt_rand(0, 1) == 0 ? mt_rand(-2147483648, 0) : mt_rand(1, 2147483647));
+        return long2ip(mt_rand(0, 1) == 0 ? mt_rand(-2147483648, -2) : mt_rand(16777216, 2147483647));
     }
 
     /**

--- a/test/Faker/Provider/InternetTest.php
+++ b/test/Faker/Provider/InternetTest.php
@@ -110,7 +110,7 @@ class InternetTest extends \PHPUnit_Framework_TestCase
 
     public function testIpv4NotLocalNetwork()
     {
-        $this->assertNotEquals('1.0.0.0', long2ip(ip2long($this->faker->ipv4()) & (-1 << (32 - 8))));
+        $this->assertNotRegExp('/\A1\./', $this->faker->ipv4());
     }
 
     public function testIpv4NotBroadcast()

--- a/test/Faker/Provider/InternetTest.php
+++ b/test/Faker/Provider/InternetTest.php
@@ -108,6 +108,16 @@ class InternetTest extends \PHPUnit_Framework_TestCase
         $this->assertNotFalse(filter_var($this->faker->ipv4(), FILTER_VALIDATE_IP, FILTER_FLAG_IPV4));
     }
 
+    public function testIpv4NotLocalNetwork()
+    {
+        $this->assertNotEquals('1.0.0.0', long2ip(ip2long($this->faker->ipv4()) & (-1 << (32 - 8))));
+    }
+
+    public function testIpv4NotBroadcast()
+    {
+        $this->assertNotEquals('255.255.255.255', $this->faker->ipv4());
+    }
+
     public function testIpv6()
     {
         $this->assertNotFalse(filter_var($this->faker->ipv6(), FILTER_VALIDATE_IP, FILTER_FLAG_IPV6));


### PR DESCRIPTION
Do not genate 255.255.255.255 (Broadcast) and IPs between 0.0.0.0 and 0.255.255.255 (0.0.0.0/8, current network).

https://en.wikipedia.org/wiki/IPv4#Special-use_addresses

> 0.0.0.0/8 	Current network (only valid as source address) 	RFC 6890

https://en.wikipedia.org/wiki/List_of_assigned_/8_IPv4_address_blocks

And 255.255.255.255 (Broadcast) must not be used, also.

````
16777216 = 1.0.0.0 (new lowest generatable IPv4)
-2 = 255.255.255.254 (new highest generatable IPv4)
````