### PR TITLE
Add en_US implementation for bank information

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -239,7 +239,9 @@ Each of the generator properties (like `name`, `address`, and `lorem`) are calle
     creditCardDetails       // array('MasterCard', '4485480221084675', 'Aleksander Nowak', '04/13')
     // Generates a random IBAN. Set $countryCode to null for a random country
     iban($countryCode)      // 'IT31A8497112740YZ575DJ28BP4'
-    swiftBicNumber          // RZTIAT22263
+    swiftBicNumber          // 'RZTIAT22263'
+    bankAccountNumber       // '51915734310'
+    bankRoutingNumber       // '212240302'
 
 ### `Faker\Provider\Color`
 

--- a/src/Faker/Provider/en_US/Payment.php
+++ b/src/Faker/Provider/en_US/Payment.php
@@ -9,14 +9,14 @@ class Payment extends \Faker\Provider\Payment
     public function bankAccountNumber()
     {
         // Length between 5 and 17, biased towards center
-        $length = self::numberBetween(0,3) + self::numberBetween(0,3) + self::numberBetween(0,3) + self::numberBetween(0,3) + 5;
+        $length = self::numberBetween(0, 3) + self::numberBetween(0, 3) + self::numberBetween(0, 3) + self::numberBetween(0, 3) + 5;
 
         return self::numerify(str_repeat('#', $length));
     }
 
     public function bankRoutingNumber()
     {
-        $district = self::numberBetween(1,12);
+        $district = self::numberBetween(1, 12);
         $type = self::randomElement(array(0, 0, 0, 0, 20, 20, 60));
         $clearingCenter = self::randomDigitNotNull();
         $state = self::randomDigit();

--- a/src/Faker/Provider/en_US/Payment.php
+++ b/src/Faker/Provider/en_US/Payment.php
@@ -1,0 +1,38 @@
+<?php
+
+
+namespace Faker\Provider\en_US;
+
+
+class Payment extends \Faker\Provider\Payment
+{
+    public function bankAccountNumber()
+    {
+        // Length between 5 and 17, biased towards center
+        $length = self::numberBetween(0,3) + self::numberBetween(0,3) + self::numberBetween(0,3) + self::numberBetween(0,3) + 5;
+
+        return self::numerify(str_repeat('#', $length));
+    }
+
+    public function bankRoutingNumber()
+    {
+        $district = self::numberBetween(1,12);
+        $type = self::randomElement(array(0, 0, 0, 0, 20, 20, 60));
+        $clearingCenter = self::randomDigitNotNull();
+        $state = self::randomDigit();
+        $institution = self::randomNumber(4, true);
+
+        $result = sprintf('%02d%01d%01d%04d', $district + $type, $clearingCenter, $state, $institution);
+
+        return $result . self::calculateRoutingNumberChecksum($result);
+    }
+
+    public static function calculateRoutingNumberChecksum($routing)
+    {
+        return (
+            7 * ($routing[0] + $routing[3] + $routing[6]) +
+            3 * ($routing[1] + $routing[4] + $routing[7]) +
+            9 * ($routing[2] + $routing[5])
+        ) % 10;
+    }
+}

--- a/test/Faker/Provider/en_US/PaymentTest.php
+++ b/test/Faker/Provider/en_US/PaymentTest.php
@@ -1,0 +1,85 @@
+<?php
+
+
+namespace Faker\Provider\en_US;
+
+use Faker\Generator;
+use Faker\Provider\en_US\Payment;
+
+class PaymentTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Generator
+     */
+    private $faker;
+
+    public function setUp()
+    {
+        $faker = new Generator();
+        $faker->addProvider(new Payment($faker));
+        $this->faker = $faker;
+    }
+
+    public function testBankAccountNumber()
+    {
+        $accNo = $this->faker->bankAccountNumber;
+        $this->assertTrue(ctype_digit($accNo));
+        $this->assertLessThanOrEqual(17, strlen($accNo));
+    }
+
+    public function testBankRoutingNumber()
+    {
+        $routingNo = $this->faker->bankRoutingNumber;
+        $this->assertRegExp('/^\d{9}$/', $routingNo);
+        $this->assertEquals(Payment::calculateRoutingNumberChecksum($routingNo), $routingNo[8]);
+    }
+
+    public function routingNumberProvider()
+    {
+        return array(
+            array('122105155'),
+            array('082000549'),
+            array('121122676'),
+            array('122235821'),
+            array('102101645'),
+            array('102000021'),
+            array('123103729'),
+            array('071904779'),
+            array('081202759'),
+            array('074900783'),
+            array('104000029'),
+            array('073000545'),
+            array('101000187'),
+            array('042100175'),
+            array('083900363'),
+            array('091215927'),
+            array('091300023'),
+            array('091000022'),
+            array('081000210'),
+            array('101200453'),
+            array('092900383'),
+            array('104000029'),
+            array('121201694'),
+            array('107002312'),
+            array('091300023'),
+            array('041202582'),
+            array('042000013'),
+            array('123000220'),
+            array('091408501'),
+            array('064000059'),
+            array('124302150'),
+            array('125000105'),
+            array('075000022'),
+            array('307070115'),
+            array('091000022'),
+        );
+    }
+
+    /**
+     * @dataProvider routingNumberProvider
+     */
+    public function testCalculateRoutingNumberChecksum($routingNo)
+    {
+        $this->assertEquals($routingNo[8], Payment::calculateRoutingNumberChecksum($routingNo), $routingNo);
+    }
+}

--- a/test/Faker/Provider/en_US/PaymentTest.php
+++ b/test/Faker/Provider/en_US/PaymentTest.php
@@ -4,7 +4,6 @@
 namespace Faker\Provider\en_US;
 
 use Faker\Generator;
-use Faker\Provider\en_US\Payment;
 
 class PaymentTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
This adds formatters for US account and routing numbers.

https://en.wikipedia.org/wiki/Routing_transit_number#MICR_Routing_number_format
