### PR TITLE
Modify numberBetween() to be order agnostic

### DIFF
--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -121,16 +121,18 @@ class Base
     }
 
     /**
-     * Returns a random number between $min and $max
+     * Returns a random number between $int1 and $int2 (any order)
      *
-     * @param integer $min default to 0
-     * @param integer $max defaults to 32 bit max integer, ie 2147483647
+     * @param integer $int1 default to 0
+     * @param integer $int2 defaults to 32 bit max integer, ie 2147483647
      * @example 79907610
      *
      * @return integer
      */
-    public static function numberBetween($min = 0, $max = 2147483647)
+    public static function numberBetween($int1 = 0, $int2 = 2147483647)
     {
+        $min = $int1 < $int2 ? $int1 : $int2;
+        $max = $int1 < $int2 ? $int2 : $int1;
         return mt_rand($min, $max);
     }
 


### PR DESCRIPTION
Hi, modified numberBetween() to be order agnostic (allow min/max to be supplied in either order).

I've done this as I found without this here, I had to put a *lot* of supporting conditional ordering code in my seeder script for a few specific usecases.  This makes using it much cleaner and won't break anything that currently uses it.

(And yes, am aware of randomFloat())

Thanks!