### PR TITLE
Support an asterisk in bothify and optimize

### DIFF
--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -317,6 +317,19 @@ class Base
         return join('', static::shuffleArray($array));
     }
 
+    private static function replaceWildcard($string, $wildcard = '#', $callback = 'static::randomDigit')
+    {
+        if (($pos = strpos($string, $wildcard)) === false) {
+            return $string;
+        }
+        for ($i = $pos, $last = strrpos($string, $wildcard, $pos) + 1; $i < $last; $i++) {
+            if ($string[$i] === $wildcard) {
+                $string[$i] = call_user_func($callback);
+            }
+        }
+        return $string;
+    }
+
     /**
      * Replaces all hash sign ('#') occurrences with a random number
      * Replaces all percentage sign ('%') occurrences with a not null number
@@ -329,9 +342,11 @@ class Base
         // instead of using randomDigit() several times, which is slow,
         // count the number of hashes and generate once a large number
         $toReplace = array();
-        for ($i = 0, $count = strlen($string); $i < $count; $i++) {
-            if ($string[$i] === '#') {
-                $toReplace []= $i;
+        if (($pos = strpos($string, '#')) !== false) {
+            for ($i = $pos, $last = strrpos($string, '#', $pos) + 1; $i < $last; $i++) {
+                if ($string[$i] === '#') {
+                    $toReplace[] = $i;
+                }
             }
         }
         if ($nbReplacements = count($toReplace)) {
@@ -347,7 +362,7 @@ class Base
                 $string[$toReplace[$i]] = $numbers[$i];
             }
         }
-        $string = preg_replace_callback('/\%/u', 'static::randomDigitNotNull', $string);
+        $string = self::replaceWildcard($string, '%', 'static::randomDigitNotNull');
 
         return $string;
     }
@@ -360,17 +375,21 @@ class Base
      */
     public static function lexify($string = '????')
     {
-        return preg_replace_callback('/\?/u', 'static::randomLetter', $string);
+        return self::replaceWildcard($string, '?', 'static::randomLetter');
     }
 
     /**
-     * Replaces hash signs and question marks with random numbers and letters
+     * Replaces hash signs ('#') and question marks ('?') with random numbers and letters
+     * An asterisk ('*') is replaced with either a random number or a random letter
      *
      * @param  string $string String that needs to bet parsed
      * @return string
      */
     public static function bothify($string = '## ??')
     {
+        $string = self::replaceWildcard($string, '*', function () {
+            return mt_rand(0, 1) ? '#' : '?';
+        });
         return static::lexify(static::numerify($string));
     }
 

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -276,6 +276,11 @@ class BaseTest extends \PHPUnit_Framework_TestCase
         $this->assertRegExp('/foo[a-z]Ba\dr/', BaseProvider::bothify('foo?Ba#r'));
     }
 
+    public function testBothifyAsterisk()
+    {
+        $this->assertRegExp('/foo([a-z]|\d)Ba([a-z]|\d)r/', BaseProvider::bothify('foo*Ba*r'));
+    }
+
     public function testAsciifyReturnsSameStringWhenItContainsNoStarSign()
     {
         $this->assertEquals('fooBar?', BaseProvider::asciify('fooBar?'));

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -276,53 +276,15 @@ class BaseTest extends \PHPUnit_Framework_TestCase
         $this->assertRegExp('/foo[a-z]Ba\dr/', BaseProvider::bothify('foo?Ba#r'));
     }
 
-    public function allUtfCharsDataProvider()
-    {
-        // create test data
-        /** @link http://stackoverflow.com/questions/2748956/how-would-you-create-a-string-of-all-utf-8-characters */
-        function unichr($i)
-        {
-            return iconv('UCS-4LE', 'UTF-8', pack('V', $i));
-        }
-        $codeunits = array();
-        for ($i = 0; $i<0xD800; $i++) {
-            $codeunits[] = unichr($i);
-        }
-        for ($i = 0xE000; $i<0xFFFF; $i++) {
-            $codeunits[] = unichr($i);
-        }
-        $data = implode($codeunits);
-        // end of test data
-
-        return array(
-            array('#', $data),
-            array('?', $data),
-            array('*', $data),
-        );
-    }
-
-    /**
-     * @dataProvider allUtfCharsDataProvider
-     */
-    public function testStrposOnUtf($char, $data)
-    {
-        $pos = 0;
-        $mbpos = 0;
-        $count = 0;
-        $mbcount = 0;
-        while (($mbpos = mb_strpos($data, $char, $mbpos + 1, 'UTF-8')) !== false) {
-            $mbcount++;
-        }
-        while (($pos = strpos($data, $char, $pos + 1)) !== false) {
-            $count++;
-        }
-        $this->assertEquals(1, $mbcount);
-        $this->assertEquals(1, $count);
-    }
-
     public function testBothifyAsterisk()
     {
         $this->assertRegExp('/foo([a-z]|\d)Ba([a-z]|\d)r/', BaseProvider::bothify('foo*Ba*r'));
+    }
+
+    public function testBothifyUtf()
+    {
+        $utf = 'œ∑´®†¥¨ˆøπ“‘和製╯°□°╯︵ ┻━┻🐵 🙈 ﺚﻣ ﻦﻔﺳ ﺲﻘﻄﺗ ﻮﺑﺎﻠﺘﺣﺪﻳﺩ،, ﺝﺰﻳﺮﺘﻳ ﺏﺎﺴﺘﺧﺩﺎﻣ ﺄﻧ ﺪﻧﻭ. ﺇﺫ ﻪﻧﺍ؟ ﺎﻠﺴﺗﺍﺭ ﻮﺘ';
+        $this->assertRegExp('/'.$utf.'foo\dB[a-z]a([a-z]|\d)r/u', BaseProvider::bothify($utf.'foo#B?a*r'));
     }
 
     public function testAsciifyReturnsSameStringWhenItContainsNoStarSign()

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -276,6 +276,50 @@ class BaseTest extends \PHPUnit_Framework_TestCase
         $this->assertRegExp('/foo[a-z]Ba\dr/', BaseProvider::bothify('foo?Ba#r'));
     }
 
+    public function allUtfCharsDataProvider()
+    {
+        // create test data
+        /** @link http://stackoverflow.com/questions/2748956/how-would-you-create-a-string-of-all-utf-8-characters */
+        function unichr($i)
+        {
+            return iconv('UCS-4LE', 'UTF-8', pack('V', $i));
+        }
+        $codeunits = array();
+        for ($i = 0; $i<0xD800; $i++) {
+            $codeunits[] = unichr($i);
+        }
+        for ($i = 0xE000; $i<0xFFFF; $i++) {
+            $codeunits[] = unichr($i);
+        }
+        $data = implode($codeunits);
+        // end of test data
+
+        return array(
+            array('#', $data),
+            array('?', $data),
+            array('*', $data),
+        );
+    }
+
+    /**
+     * @dataProvider allUtfCharsDataProvider
+     */
+    public function testStrposOnUtf($char, $data)
+    {
+        $pos = 0;
+        $mbpos = 0;
+        $count = 0;
+        $mbcount = 0;
+        while (($mbpos = mb_strpos($data, $char, $mbpos + 1, 'UTF-8')) !== false) {
+            $mbcount++;
+        }
+        while (($pos = strpos($data, $char, $pos + 1)) !== false) {
+            $count++;
+        }
+        $this->assertEquals(1, $mbcount);
+        $this->assertEquals(1, $count);
+    }
+
     public function testBothifyAsterisk()
     {
         $this->assertRegExp('/foo([a-z]|\d)Ba([a-z]|\d)r/', BaseProvider::bothify('foo*Ba*r'));


### PR DESCRIPTION
`Base::bothify()` now replaces an asterisk ('*') with either a random number or a random letter.

I also replaced `preg_replace_callback` in `numerify` and `lexify` as it is slower than iterating over a range of chars found by using `strpos` and `strrpos`.

Benchmarks are available here: https://gist.github.com/nineinchnick/84895a560910e3ead9cc

The biggest question is should we worry about UTF-8? I guess in a worst case it could replace the wrong byte. There are a few SO questions how to iterate over UTF-8 strings efficiently.

Should the new helper method `Base::replaceWildcard` be public?