### PR TITLE
Enhancement: Add take() modifier, yielding a given number of results

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ Faker requires PHP >= 5.3.3.
 	- [Barcode](#fakerproviderbarcode)
 	- [Miscellaneous](#fakerprovidermiscellaneous)
 	- [Biased](#fakerproviderbiased)
-- [Unique and Optional modifiers](#unique-and-optional-modifiers)
+- [Unique, Optional and Take modifiers](#unique-optional-and-take-modifiers)
 - [Localization](#localization)
 - [Populating Entities Using an ORM or an ODM](#populating-entities-using-an-orm-or-an-odm)
 - [Seeding the Generator](#seeding-the-generator)
@@ -291,9 +291,9 @@ Each of the generator properties (like `name`, `address`, and `lorem`) are calle
     // with more chances to be close to 20
     biasedNumberBetween($min = 10, $max = 20, $function = 'sqrt')
 
-## Unique and Optional modifiers
+## Unique, Optional and Take modifiers
 
-Faker provides two special providers, `unique()` and `optional()`, to be called before any provider. `optional()` can be useful for seeding non-required fields, like a mobile telephone number; `unique()` is required to populate fields that cannot accept twice the same value, like primary identifiers.
+Faker provides three special providers, `unique()`, `optional()` and `take()`,  to be called before any provider. `optional()` can be useful for seeding non-required fields, like a mobile telephone number; `unique()` is required to populate fields that cannot accept twice the same value, like primary identifiers; `take()` can be useful when you need an array of results.
 
 ```php
 // unique() forces providers to return unique values
@@ -335,6 +335,10 @@ $faker->optional($weight = 0.9)->randomDigit; // 10% chance of NULL
 // Defaults to NULL.
 $faker->optional($weight = 0.5, $default = false)->randomDigit; // 50% chance of FALSE
 $faker->optional($weight = 0.9, $default = 'abc')->word; // 10% chance of 'abc'
+
+// take() accepts an integer greater than 0
+$faker->take(5)->sentence(); // returns an array with 5 sentences
+$faker->take(3)->randomNumber; // returns an array with 3 random numbers
 ```
 
 ## Localization

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -4,6 +4,7 @@ namespace Faker\Provider;
 
 use Faker\Generator;
 use Faker\DefaultGenerator;
+use Faker\TakeGenerator;
 use Faker\UniqueGenerator;
 
 class Base
@@ -541,5 +542,18 @@ class Base
         }
 
         return $this->unique;
+    }
+
+    /**
+     * @param int $count
+     *
+     * @return TakeGenerator
+     */
+    public function take($count)
+    {
+        return new TakeGenerator(
+            $this->generator,
+            $count
+        );
     }
 }

--- a/src/Faker/TakeGenerator.php
+++ b/src/Faker/TakeGenerator.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Faker;
+
+class TakeGenerator
+{
+    /**
+     * @var Generator
+     */
+    protected $generator;
+
+    /**
+     * @var int
+     */
+    protected $count;
+
+    public function __construct(Generator $generator, $count)
+    {
+        if (!is_int($count) || 1 > $count) {
+            throw new \InvalidArgumentException('Parameter "count" needs to be an integer greater than 0');
+        }
+
+        $this->generator = $generator;
+        $this->count = $count;
+    }
+
+    /**
+     * @param string $attribute
+     *
+     * @return array
+     */
+    public function __get($attribute)
+    {
+        return $this->__call($attribute, array());
+    }
+
+    /**
+     * Catch and proxy all generator calls with arguments but return a number of values.
+     *
+     * @param string $name
+     * @param array $arguments
+     * @return array
+     */
+    public function __call($name, $arguments)
+    {
+        $result = array();
+
+        for ($i = 0; $i < $this->count; $i++) {
+            $result[] = call_user_func_array(array($this->generator, $name), $arguments);
+        }
+
+        return $result;
+    }
+}

--- a/test/Faker/TakeGeneratorTest.php
+++ b/test/Faker/TakeGeneratorTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Faker\Test;
+
+use Faker\Generator;
+use Faker\TakeGenerator;
+use stdClass;
+
+class TakeGeneratorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider providerConstructorRejectsInvalidCount
+     *
+     * @param mixed $count
+     */
+    public function testConstructorRejectsInvalidCount($count)
+    {
+        $this->setExpectedException('InvalidArgumentException');
+
+        new TakeGenerator(
+            $this->getGeneratorMock(),
+            $count
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function providerConstructorRejectsInvalidCount()
+    {
+        return array(
+            array(new stdClass()),
+            array(false),
+            array(null),
+            array(0),
+            array(3.14),
+        );
+    }
+
+    public function testReturnsExactlyCountResultsWhenUsingMethod()
+    {
+        $count = 5;
+        $provider = 'foo';
+
+        $composedGenerator = $this->getGeneratorMock(array(
+            $provider,
+        ));
+
+        $composedGenerator
+            ->expects($this->exactly($count))
+            ->method($provider)
+            ->willReturnCallback(function () {
+                static $invocation = 0;
+
+                return ++$invocation;
+            })
+        ;
+
+        $generator = new TakeGenerator(
+            $composedGenerator,
+            $count
+        );
+
+        $result = $generator->{$provider}();
+
+        $this->assertInternalType('array', $result);
+        $this->assertCount($count, $result);
+    }
+
+    public function testReturnsExactlyCountResultsForPropertyAccess()
+    {
+        $count = 5;
+        $provider = 'bar';
+
+        $composedGenerator = $this->getGeneratorMock(array(
+            '__get',
+            $provider,
+        ));
+
+        $composedGenerator
+            ->expects($this->exactly($count))
+            ->method($provider)
+            ->willReturnCallback(function () {
+                static $invocation = 0;
+
+                return ++$invocation;
+            })
+        ;
+
+        $generator = new TakeGenerator(
+            $composedGenerator,
+            $count
+        );
+
+        $result = $generator->{$provider};
+
+        $this->assertInternalType('array', $result);
+        $this->assertCount($count, $result);
+    }
+
+    /**
+     * @param array $methods
+     * @return Generator|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getGeneratorMock(array $methods = array())
+    {
+        return $this->getMockBuilder('Faker\Generator')
+            ->setMethods($methods)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+    }
+}


### PR DESCRIPTION
This PR

* [x] implements a `TakeGenerator` and provides it via `Faker\Provider\Base`
* [x] updates `README.md`

:information_desk_person: Instead of doing this all the time

```php
$count = 5;

$randomNumbers = [];
for ($i = 0; $i < $count; $i++) {
    $randomNumbers[] = $faker->randomNumber;
}
```

you will like this:

```php
$count = 5;

$randomNumbers = $faker->take($count)->randomNumber;
```