### PR TITLE
Fix call to missing method typo

### DIFF
--- a/src/Faker/ORM/CakePHP/Populator.php
+++ b/src/Faker/ORM/CakePHP/Populator.php
@@ -60,7 +60,7 @@ class Populator
 
         $entity->modifiers = $entity->guessModifiers($this);
         if ($customModifiers) {
-            $entity->mergeModifiers($customModifiers);
+            $entity->mergeModifiersWith($customModifiers);
         }
 
         $class = $entity->class;


### PR DESCRIPTION
Fixes a call to a missing method in the CakePHP ORM provider.

```php
$this->populator->addEntity('Articles', 50, $formatter, $modifier);
$this->populator->execute();  // Fatal error
```