### PR TITLE
Add missing lowercasing to the "no intl-ext" fallback

### DIFF
--- a/src/Faker/Provider/Internet.php
+++ b/src/Faker/Provider/Internet.php
@@ -150,7 +150,7 @@ class Internet extends \Faker\Provider\Base
         if (function_exists('transliterator_transliterate') && $transliterator = \Transliterator::create($transId)) {
             $transString = $transliterator->transliterate($string);
         } else {
-            $transString = static::toAscii($string);
+            $transString = static::toLower(static::toAscii($string));
         }
 
         return preg_replace('/[^A-Za-z0-9_.]/u', '', $transString);


### PR DESCRIPTION
Follow-up to #711.

* Looking at #333, it clearly seems to be an overlook.
* Makes results consistent with/without intl-ext.