### PR TITLE
StyleCI / PHP-CS-Fixer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
 composer.lock
+.php_cs.cache

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,10 @@
+<?php
+
+// Needed to get styleci-bridge loaded
+require_once './vendor/autoload.php';
+
+use SLLH\StyleCIBridge\ConfigBridge;
+
+return ConfigBridge::create()
+    ->setUsingCache(true)
+;

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,0 +1,1 @@
+preset: psr2

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ before_script:
     - travis_retry composer self-update
     - travis_retry composer install --no-interaction --prefer-dist
 
-script: make sniff test
+script: make test

--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,6 @@ sniff: vendor/autoload.php
 .PHONY: test
 test: vendor/autoload.php
 	vendor/bin/phpunit --verbose
+
+cs:
+	php-cs-fixer fix . --verbose

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     "require-dev": {
         "phpunit/phpunit": "~4.0",
         "squizlabs/php_codesniffer": "~1.5",
+        "sllh/php-cs-fixer-styleci-bridge": "~1.3",
         "ext-intl": "*"
     },
     "autoload": {

--- a/src/Faker/Calculator/Iban.php
+++ b/src/Faker/Calculator/Iban.php
@@ -16,7 +16,7 @@ class Iban
         $checkString = substr($iban, 4) . substr($iban, 0, 2) . '00';
 
         // Replace all letters with their number equivalents
-        $checkString = preg_replace_callback('/[A-Z]/', array('self','alphaToNumberCallback'), $checkString);
+        $checkString = preg_replace_callback('/[A-Z]/', array('self', 'alphaToNumberCallback'), $checkString);
 
         // Perform mod 97 and subtract from 98
         $checksum = 98 - self::mod97($checkString);

--- a/src/Faker/ORM/CakePHP/Populator.php
+++ b/src/Faker/ORM/CakePHP/Populator.php
@@ -4,7 +4,6 @@ namespace Faker\ORM\CakePHP;
 
 class Populator
 {
-
     protected $generator;
     protected $entities = [];
     protected $quantities = [];

--- a/src/Faker/Provider/File.php
+++ b/src/Faker/Provider/File.php
@@ -3,7 +3,6 @@ namespace Faker\Provider;
 
 class File extends \Faker\Provider\Base
 {
-
     /**
      * MIME types from the apache.org file. Some types are truncated.
      *

--- a/src/Faker/Provider/en_NZ/Address.php
+++ b/src/Faker/Provider/en_NZ/Address.php
@@ -4,7 +4,6 @@ namespace Faker\Provider\en_NZ;
 
 class Address extends \Faker\Provider\Address
 {
-
     /**
      * An array of en_NZ (New Zealand) building number formats
      * @var array

--- a/src/Faker/Provider/kk_KZ/Payment.php
+++ b/src/Faker/Provider/kk_KZ/Payment.php
@@ -4,7 +4,6 @@ namespace Faker\Provider\kk_KZ;
 
 class Payment extends \Faker\Provider\Payment
 {
-
     protected static $banks = array(
         'Қазкоммерцбанк',
         'Халық Банкі',

--- a/src/Faker/Provider/kk_KZ/Person.php
+++ b/src/Faker/Provider/kk_KZ/Person.php
@@ -4,7 +4,6 @@ namespace Faker\Provider\kk_KZ;
 
 class Person extends \Faker\Provider\Person
 {
-
     /**
      * @see https://ru.wikipedia.org/wiki/%D0%9A%D0%B0%D0%B7%D0%B0%D1%85%D1%81%D0%BA%D0%B0%D1%8F_%D1%84%D0%B0%D0%BC%D0%B8%D0%BB%D0%B8%D1%8F
      *

--- a/src/Faker/Provider/no_NO/Person.php
+++ b/src/Faker/Provider/no_NO/Person.php
@@ -300,12 +300,12 @@ class Person extends \Faker\Provider\Person
         */
         $randomDigits = (string)static::numerify('##');
         
-        switch($gender) {
+        switch ($gender) {
             case static::GENDER_MALE:
-                $genderDigit = static::randomElement(array(1,3,5,7,9));
+                $genderDigit = static::randomElement(array(1, 3, 5, 7, 9));
                 break;
             case static::GENDER_FEMALE:
-                $genderDigit = static::randomElement(array(0,2,4,6,8));
+                $genderDigit = static::randomElement(array(0, 2, 4, 6, 8));
                 break;
             default:
                 $genderDigit = (string)static::numerify('#');

--- a/src/Faker/Provider/pt_BR/PhoneNumber.php
+++ b/src/Faker/Provider/pt_BR/PhoneNumber.php
@@ -4,7 +4,6 @@ namespace Faker\Provider\pt_BR;
 
 class PhoneNumber extends \Faker\Provider\PhoneNumber
 {
-
     protected static $landlineFormats = array('2###-####', '3###-####');
 
     protected static $cellphoneFormats = array('7###-####', '8###-####', '9###-####');

--- a/src/Faker/Provider/pt_PT/PhoneNumber.php
+++ b/src/Faker/Provider/pt_PT/PhoneNumber.php
@@ -4,7 +4,7 @@ namespace Faker\Provider\pt_PT;
 
 class PhoneNumber extends \Faker\Provider\PhoneNumber
 {
-     /*
+    /*
      * @link http://en.wikipedia.org/wiki/Telephone_numbers_in_Portugal
      */
     protected static $formats = array(

--- a/src/Faker/Provider/sk_SK/Address.php
+++ b/src/Faker/Provider/sk_SK/Address.php
@@ -4,7 +4,6 @@ namespace Faker\Provider\sk_SK;
 
 class Address extends \Faker\Provider\Address
 {
-
     protected static $cityName = array(
         'Ábelová', 'Abovce', 'Abrahám', 'Abrahámovce', 'Abrahámovce', 'Abramová', 'Abranovce', 'Adamovské Kochanovce', 'Adidovce', 'Alekšince',
         'Andovce', 'Andrejová', 'Ardanovce', 'Ardovo', 'Arnutovce', 'Báb', 'Babie', 'Babín', 'Babiná', 'Babindol', 'Babinec', 'Bacúch', 'Bacúrov',

--- a/src/Faker/Provider/sl_SI/Address.php
+++ b/src/Faker/Provider/sl_SI/Address.php
@@ -4,7 +4,6 @@ namespace Faker\Provider\sl_SI;
 
 class Address extends \Faker\Provider\Address
 {
-
     /**
      * @link http://www.rtvslo.si/strani/abecedni-seznam-obcin/3103
      **/

--- a/src/Faker/Provider/sl_SI/Internet.php
+++ b/src/Faker/Provider/sl_SI/Internet.php
@@ -4,7 +4,6 @@ namespace Faker\Provider\sl_SI;
 
 class Internet extends \Faker\Provider\Internet
 {
-
     protected static $freeEmailDomain = array('gmail.com', 'gmail.com', 'gmail.com', 'hotmail.com', 'yahoo.com', 'siol.net', 't-2.net');
 
     protected static $tld = array('si', 'si', 'si', 'si', 'eu', 'com', 'info', 'net', 'org');

--- a/src/Faker/Provider/sl_SI/Person.php
+++ b/src/Faker/Provider/sl_SI/Person.php
@@ -4,7 +4,6 @@ namespace Faker\Provider\sl_SI;
 
 class Person extends \Faker\Provider\Person
 {
-
     protected static $maleNameFormats = array(
         '{{firstNameMale}} {{lastName}}',
         '{{firstNameMale}} {{lastName}}',

--- a/src/Faker/Provider/sv_SE/Person.php
+++ b/src/Faker/Provider/sv_SE/Person.php
@@ -128,9 +128,9 @@ class Person extends \Faker\Provider\Person
         $datePart = $birthdate->format('ymd');
 
         if ($gender && $gender == static::GENDER_MALE) {
-            $randomDigits = (string)static::numerify('##') . static::randomElement(array(1,3,5,7,9));
+            $randomDigits = (string)static::numerify('##') . static::randomElement(array(1, 3, 5, 7, 9));
         } elseif ($gender && $gender == static::GENDER_FEMALE) {
-            $randomDigits = (string)static::numerify('##') . static::randomElement(array(0,2,4,6,8));
+            $randomDigits = (string)static::numerify('##') . static::randomElement(array(0, 2, 4, 6, 8));
         } else {
             $randomDigits = (string)static::numerify('###');
         }

--- a/src/Faker/Provider/zh_CN/Address.php
+++ b/src/Faker/Provider/zh_CN/Address.php
@@ -4,7 +4,6 @@ namespace Faker\Provider\zh_CN;
 
 class Address extends \Faker\Provider\Address
 {
-
     protected static $cites = array('北京', '上海', '天津', '重庆', '哈尔滨', '长春', '沈阳', '呼和浩特', '石家庄', '乌鲁木齐', '兰州', '西宁', '西安', '银川', '郑州', '济南', '太原', '合肥', '武汉', '长沙', '南京', '成都', '贵阳', '昆明', '南宁', '拉萨', '杭州', '南昌', '广州', '福州', '海口', '香港', '澳门');
 
     protected static $areas = array('西夏区', '永川区', '秀英区', '高港区', '清城区', '兴山区', '锡山区', '清河区', '龙潭区', '华龙区', '海陵区', '滨城区', '东丽区', '高坪区', '沙湾区', '平山区', '城北区', '海港区', '沙市区', '双滦区', '长寿区', '山亭区', '南湖区', '浔阳区', '南长区', '友好区', '安次区', '翔安区', '沈河区', '魏都区', '西峰区', '萧山区', '金平区', '沈北新区', '孝南区', '上街区', '城东区', '牧野区', '大东区', '白云区', '花溪区', '吉利区', '新城区', '怀柔区', '六枝特区', '涪城区', '清浦区', '南溪区', '淄川区', '高明区');
@@ -20,17 +19,17 @@ class Address extends \Faker\Provider\Address
 
     public static function area()
     {
-         return static::randomElement(static::$areas);
+        return static::randomElement(static::$areas);
     }
 
     public static function country()
     {
-         return static::randomElement(static::$country);
+        return static::randomElement(static::$country);
     }
 
     public function address()
     {
-         return $this->city() . static::area();
+        return $this->city() . static::area();
     }
 
     public static function postcode()

--- a/test/Faker/Calculator/IbanTest.php
+++ b/test/Faker/Calculator/IbanTest.php
@@ -6,7 +6,6 @@ use Faker\Calculator\Iban;
 
 class IbanTest extends \PHPUnit_Framework_TestCase
 {
-
     public function checksumProvider()
     {
         return array(

--- a/test/Faker/Calculator/LuhnTest.php
+++ b/test/Faker/Calculator/LuhnTest.php
@@ -6,7 +6,6 @@ use Faker\Calculator\Luhn;
 
 class LuhnTest extends \PHPUnit_Framework_TestCase
 {
-
     public function checkDigitProvider()
     {
         return array(

--- a/test/Faker/Provider/BiasedTest.php
+++ b/test/Faker/Provider/BiasedTest.php
@@ -21,7 +21,7 @@ class BiasedTest extends \PHPUnit_Framework_TestCase
     
     public function performFake($function)
     {
-        for($i = 0; $i < self::NUMBERS; $i++) {
+        for ($i = 0; $i < self::NUMBERS; $i++) {
             $this->results[$this->generator->biasedNumberBetween(1, self::MAX, $function)]++;
         }
     }

--- a/test/Faker/Provider/ColorTest.php
+++ b/test/Faker/Provider/ColorTest.php
@@ -6,7 +6,6 @@ use Faker\Provider\Color;
 
 class ColorTest extends \PHPUnit_Framework_TestCase
 {
-
     public function testHexColor()
     {
         $this->assertRegExp('/^#[a-f0-9]{6}$/i', Color::hexColor());

--- a/test/Faker/Provider/DateTimeTest.php
+++ b/test/Faker/Provider/DateTimeTest.php
@@ -85,10 +85,10 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
         
         $_interval = \DateInterval::createFromDateString($interval);
         $_start = new \DateTime($start);
-        if($isInFutur){
+        if ($isInFutur) {
             $this->assertGreaterThanOrEqual($_start, $date);
             $this->assertLessThanOrEqual($_start->add($_interval), $date);
-        }else{
+        } else {
             $this->assertLessThanOrEqual($_start, $date);
             $this->assertGreaterThanOrEqual($_start->add($_interval), $date);
         }

--- a/test/Faker/Provider/LoremTest.php
+++ b/test/Faker/Provider/LoremTest.php
@@ -51,7 +51,7 @@ class LoremTest extends \PHPUnit_Framework_TestCase
 
     public function testSentenceWithPositiveNbWordsReturnsAtLeastOneWord()
     {
-         $sentence = Lorem::sentence(1);
+        $sentence = Lorem::sentence(1);
 
         $this->assertGreaterThan(1, strlen($sentence));
         $this->assertGreaterThanOrEqual(1, count(explode(' ', $sentence)));
@@ -90,7 +90,6 @@ class LoremTest extends \PHPUnit_Framework_TestCase
 
 class TestableLorem extends Lorem
 {
-
     public static function word()
     {
         return 'word';

--- a/test/Faker/Provider/MiscellaneousTest.php
+++ b/test/Faker/Provider/MiscellaneousTest.php
@@ -6,7 +6,6 @@ use Faker\Provider\Miscellaneous;
 
 class MiscellaneousTest extends \PHPUnit_Framework_TestCase
 {
-
     public function testBoolean()
     {
         $this->assertContains(Miscellaneous::boolean(), array(true, false));

--- a/test/Faker/Provider/ProviderOverrideTest.php
+++ b/test/Faker/Provider/ProviderOverrideTest.php
@@ -168,7 +168,7 @@ class ProviderOverrideTest extends \PHPUnit_Framework_TestCase
     {
         static $locales = array();
 
-        if ( ! empty($locales)) {
+        if (! empty($locales)) {
             return $locales;
         }
 

--- a/test/Faker/Provider/TextTest.php
+++ b/test/Faker/Provider/TextTest.php
@@ -24,10 +24,10 @@ class TextTest extends \PHPUnit_Framework_TestCase
      */
     public function testTextMaxIndex()
     {
-    $generator = new Generator();
+        $generator = new Generator();
         $generator->addProvider(new Text($generator));
         $generator->seed(0);
-    $generator->realText(200, 11);
+        $generator->realText(200, 11);
     }
 
     /**
@@ -35,7 +35,7 @@ class TextTest extends \PHPUnit_Framework_TestCase
      */
     public function testTextMinIndex()
     {
-    $generator = new Generator();
+        $generator = new Generator();
         $generator->addProvider(new Text($generator));
         $generator->seed(0);
         $generator->realText(200, 0);
@@ -46,7 +46,7 @@ class TextTest extends \PHPUnit_Framework_TestCase
      */
     public function testTextMinLength()
     {
-    $generator = new Generator();
+        $generator = new Generator();
         $generator->addProvider(new Text($generator));
         $generator->seed(0);
         $generator->realText(9);

--- a/test/Faker/Provider/at_AT/PaymentTest.php
+++ b/test/Faker/Provider/at_AT/PaymentTest.php
@@ -7,7 +7,6 @@ use Faker\Provider\at_AT\Payment;
 
 class PaymentTest extends \PHPUnit_Framework_TestCase
 {
-
     /**
      * @var Generator
      */

--- a/test/Faker/Provider/be_BE/PaymentTest.php
+++ b/test/Faker/Provider/be_BE/PaymentTest.php
@@ -7,7 +7,6 @@ use Faker\Provider\be_BE\Payment;
 
 class PaymentTest extends \PHPUnit_Framework_TestCase
 {
-
     /**
      * @var Generator
      */

--- a/test/Faker/Provider/bg_BG/PaymentTest.php
+++ b/test/Faker/Provider/bg_BG/PaymentTest.php
@@ -7,7 +7,6 @@ use Faker\Provider\bg_BG\Payment;
 
 class PaymentTest extends \PHPUnit_Framework_TestCase
 {
-
     /**
      * @var Generator
      */

--- a/test/Faker/Provider/cs_CZ/PersonTest.php
+++ b/test/Faker/Provider/cs_CZ/PersonTest.php
@@ -14,7 +14,7 @@ class PersonTest extends \PHPUnit_Framework_TestCase
         $faker->addProvider(new Person($faker));
         $faker->addProvider(new Miscellaneous($faker));
 
-        for ($i = 0; $i < 1000; $i++) { 
+        for ($i = 0; $i < 1000; $i++) {
             $birthNumber = $faker->birthNumber();
             $birthNumber = str_replace('/', '', $birthNumber);
 
@@ -27,8 +27,12 @@ class PersonTest extends \PHPUnit_Framework_TestCase
             $year += $year < 54 ? 2000 : 1900;
 
             // adjust special cases for month
-            if ($month > 50) $month -= 50;
-            if ($year >= 2004 && $month > 20) $month -= 20;
+            if ($month > 50) {
+                $month -= 50;
+            }
+            if ($year >= 2004 && $month > 20) {
+                $month -= 20;
+            }
 
             $this->assertTrue(checkdate($month, $day, $year), "Birth number $birthNumber: date $year/$month/$day is invalid.");
 
@@ -39,7 +43,8 @@ class PersonTest extends \PHPUnit_Framework_TestCase
                 if ($refCrc == 10) {
                     $refCrc = 0;
                 }
-                $this->assertEquals($crc, $refCrc, "Birth number $birthNumber: checksum $crc doesn't match expected $refCrc.");;
+                $this->assertEquals($crc, $refCrc, "Birth number $birthNumber: checksum $crc doesn't match expected $refCrc.");
+                ;
             }
         }
     }

--- a/test/Faker/Provider/de_AT/InternetTest.php
+++ b/test/Faker/Provider/de_AT/InternetTest.php
@@ -9,7 +9,6 @@ use Faker\Provider\de_AT\Company;
 
 class InternetTest extends \PHPUnit_Framework_TestCase
 {
-
     /**
      * @var Generator
      */

--- a/test/Faker/Provider/de_AT/PhoneNumberTest.php
+++ b/test/Faker/Provider/de_AT/PhoneNumberTest.php
@@ -7,7 +7,6 @@ use Faker\Provider\de_AT\PhoneNumber;
 
 class PhoneNumberTest extends \PHPUnit_Framework_TestCase
 {
-
     /**
      * @var Generator
      */

--- a/test/Faker/Provider/en_US/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_US/PhoneNumberTest.php
@@ -7,7 +7,6 @@ use Faker\Provider\en_US\PhoneNumber;
 
 class PhoneNumberTest extends \PHPUnit_Framework_TestCase
 {
-
     /**
      * @var Generator
      */

--- a/test/Faker/Provider/pt_BR/CompanyTest.php
+++ b/test/Faker/Provider/pt_BR/CompanyTest.php
@@ -7,7 +7,6 @@ use Faker\Provider\pt_BR\Company;
 
 class CompanyTest extends \PHPUnit_Framework_TestCase
 {
-
     public function setUp()
     {
         $faker = new Generator();

--- a/test/Faker/Provider/pt_BR/PersonTest.php
+++ b/test/Faker/Provider/pt_BR/PersonTest.php
@@ -7,7 +7,6 @@ use Faker\Provider\pt_BR\Person;
 
 class PersonTest extends \PHPUnit_Framework_TestCase
 {
-
     public function setUp()
     {
         $faker = new Generator();

--- a/test/Faker/Provider/pt_PT/AddressTest.php
+++ b/test/Faker/Provider/pt_PT/AddressTest.php
@@ -7,7 +7,6 @@ use Faker\Provider\pt_PT\Address;
 
 class AddressTest extends \PHPUnit_Framework_TestCase
 {
-
     /**
      * @var Generator
      */

--- a/test/Faker/Provider/pt_PT/PersonTest.php
+++ b/test/Faker/Provider/pt_PT/PersonTest.php
@@ -7,7 +7,6 @@ use Faker\Provider\pt_PT\Person;
 
 class PersonTest extends \PHPUnit_Framework_TestCase
 {
-
     public function setUp()
     {
         $faker = new Generator();

--- a/test/Faker/Provider/ro_RO/PersonTest.php
+++ b/test/Faker/Provider/ro_RO/PersonTest.php
@@ -73,7 +73,7 @@ class PersonTest extends \PHPUnit_Framework_TestCase
             is_string($cnp)
             && (bool) preg_match(static::TEST_CNP_REGEX, $cnp)
             && checkdate(substr($cnp, 3, 2), substr($cnp, 5, 2), substr($cnp, 1, 2))
-        ){
+        ) {
             $checkNumber = 279146358279;
 
             $checksum = 0;
@@ -85,7 +85,7 @@ class PersonTest extends \PHPUnit_Framework_TestCase
             if (
                 ($checksum < 10 && $checksum == substr($cnp, -1))
                 || ($checksum == 10 && substr($cnp, -1) == 1)
-            ){
+            ) {
                 return true;
             }
         }

--- a/test/Faker/Provider/uk_UA/AddressTest.php
+++ b/test/Faker/Provider/uk_UA/AddressTest.php
@@ -7,7 +7,6 @@ use Faker\Provider\uk_UA\Address;
 
 class AddressTest extends \PHPUnit_Framework_TestCase
 {
-
     /**
      * @var Generator
      */

--- a/test/Faker/Provider/uk_UA/PhoneNumberTest.php
+++ b/test/Faker/Provider/uk_UA/PhoneNumberTest.php
@@ -7,7 +7,6 @@ use Faker\Provider\uk_UA\PhoneNumber;
 
 class PhoneNumberTest extends \PHPUnit_Framework_TestCase
 {
-
     /**
      * @var Generator
      */
@@ -29,7 +28,5 @@ class PhoneNumberTest extends \PHPUnit_Framework_TestCase
             1,
             'Phone number format ' . $phoneNumber . ' is wrong!'
         );
-
     }
-
 }


### PR DESCRIPTION
I recommend you to use [StyleCI](https://styleci.io/) for CS sniffing instead of a rules on Travis.

This will be more reliable (see CS fix commit) and quicker (quasi-instant result on PR).

To enabled it, just go to the related website, login though GitHub, and activate your repository. I can update PR to trigger StyleCI event if you want to check that before.

I also provided a bridge to parse `.styleci.yml` config file and automatically configure PHP-CS-Fixer.

With that, contributors will just have to run `make cs` command to get CS fixed.

For the moment, I set `psr2` rules as you did on your Makefile, but I would suggest to use a higher CS preset like symfony one, and add some extra rules like `aligne_double_arrow` or `phpunit_strict`.

Please tell me if you want to add it, i'll update my PR.

Kind regards.