### PR TITLE
Optimize userName and domainWord

### DIFF
--- a/src/Faker/Provider/Internet.php
+++ b/src/Faker/Provider/Internet.php
@@ -225,7 +225,7 @@ class Internet extends \Faker\Provider\Base
         $format = static::randomElement(static::$userNameFormats);
         $username = static::bothify($this->generator->parse($format));
 
-        return static::toLower(static::transliterate($username));
+        return strtolower(static::transliterate($username));
     }
     /**
      * @example 'fY4èHdZv68'
@@ -252,7 +252,7 @@ class Internet extends \Faker\Provider\Base
     {
         $lastName = $this->generator->format('lastName');
 
-        return static::toLower(static::transliterate($lastName));
+        return strtolower(static::transliterate($lastName));
     }
 
     /**


### PR DESCRIPTION
My apologies for the amount of PRs! (and there is one more to come after)

Something I forgot when moving from #723 to #725.
`transliterate()` result is surely ascii compatible[1]. And in any hypothetical worst-case scenario (like user messing low level), `mb_strtolower()` wouldn't fix anything anyways, but make upfront bug less noticeable.

The contract is clear: `transliterate()` result is ascii compatible. And with this commit we save 2 function calls each time, which is great.

[1] `return preg_replace('/[^A-Za-z0-9_.]/u', '', $transString);`