### PR TITLE
Latest craze in TLD's in South Africa

### DIFF
--- a/src/Faker/Provider/en_ZA/Internet.php
+++ b/src/Faker/Provider/en_ZA/Internet.php
@@ -5,5 +5,5 @@ namespace Faker\Provider\en_ZA;
 class Internet extends \Faker\Provider\Internet
 {
     protected static $freeEmailDomain = array('gmail.com', 'yahoo.com', 'hotmail.com', 'webmail.co.za', 'vodamail.co.za');
-    protected static $tld = array('co.za', 'co.za', 'co.za', 'co.za', 'com', 'com', 'net');
+    protected static $tld = array('co.za', 'co.za', 'co.za', 'co.za', 'com', 'com', 'net', 'org.za', 'joburg', 'durban', 'capetown');
 }


### PR DESCRIPTION
Added org.za which is common, but more importantly the 3 primary city ones that are used lately.