### PR TITLE
Serialized `$res` key

### DIFF
--- a/src/Faker/UniqueGenerator.php
+++ b/src/Faker/UniqueGenerator.php
@@ -47,8 +47,8 @@ class UniqueGenerator
             if ($i > $this->maxRetries) {
                 throw new \OverflowException(sprintf('Maximum retries of %d reached without finding a unique value', $this->maxRetries));
             }
-        } while (array_key_exists($res, $this->uniques[$name]));
-        $this->uniques[$name][$res]= null;
+        } while (array_key_exists(serialize($res), $this->uniques[$name]));
+        $this->uniques[$name][serialize($res)]= null;
 
         return $res;
     }


### PR DESCRIPTION
Closes https://github.com/fzaninotto/Faker/issues/748

Since `$res` could be anything, it could also be an array or an object, so it must be serialized to be used for key checking.