### PR TITLE
Add Swiss names

### DIFF
--- a/src/Faker/Provider/de_CH/Person.php
+++ b/src/Faker/Provider/de_CH/Person.php
@@ -4,5 +4,86 @@ namespace Faker\Provider\de_CH;
 
 class Person extends \Faker\Provider\de_DE\Person
 {
+    /**
+     * @link http://www.bfs.admin.ch/bfs/portal/de/index/themen/01/02/blank/dos/prenoms/02.html
+     */
+    protected static $firstNameMale = array(
+        'Adolf', 'Adrian', 'Alain', 'Albert', 'Alessandro', 'Alex', 'Alexander', 'Alfred', 'Ali', 'Alois', 'Andrea', 'Andreas', 'Andrin', 'André', 'Angelo', 'Anton', 'Antonio', 'Armin', 'Arnold', 'Arthur',
+        'Beat', 'Benjamin', 'Bernhard', 'Bruno',
+        'Carlo', 'Carlos', 'Christian', 'Christoph', 'Claudio', 'Cyrill', 'Cédric',
+        'Damian', 'Daniel', 'Dario', 'David', 'Denis', 'Diego', 'Dieter', 'Dominic', 'Dominik',
+        'Eduard', 'Elia', 'Elias', 'Emil', 'Eric', 'Erich', 'Ernst', 'Erwin', 'Eugen',
+        'Fabian', 'Fabio', 'Felix', 'Flavio', 'Florian', 'Francesco', 'Frank', 'Franz', 'Friedrich', 'Fritz',
+        'Gabriel', 'Georg', 'Gerhard', 'Gian', 'Giovanni', 'Giuseppe', 'Guido',
+        'Hans', 'Hans-Peter', 'Hanspeter', 'Heinrich', 'Heinz', 'Herbert', 'Hermann', 'Hugo',
+        'Ivan', 'Ivo',
+        'Jakob', 'Jan', 'Jean', 'Joel', 'Johann', 'Johannes', 'Jonas', 'Jonathan', 'Josef', 'José', 'Joël', 'Julian', 'Jörg', 'Jürg', 'Jürgen',
+        'Karl', 'Kevin', 'Kilian', 'Klaus', 'Konrad', 'Kurt',
+        'Lars', 'Leandro', 'Leo', 'Leon', 'Levin', 'Livio', 'Lorenz', 'Loris', 'Louis', 'Luca', 'Luigi', 'Luis', 'Lukas',
+        'Manfred', 'Manuel', 'Marc', 'Marcel', 'Marco', 'Mario', 'Mark', 'Marko', 'Markus', 'Martin', 'Mathias', 'Matteo', 'Matthias', 'Mauro', 'Max', 'Mehmet', 'Michael', 'Michel', 'Michele', 'Mike', 'Moritz',
+        'Nico', 'Nicola', 'Nicolas', 'Niklaus', 'Nils', 'Noah', 'Norbert',
+        'Oliver', 'Olivier', 'Othmar', 'Otto',
+        'Pascal', 'Patrick', 'Patrik', 'Paul', 'Peter', 'Philip', 'Philipp', 'Philippe', 'Pius',
+        'Rafael', 'Rainer', 'Ralf', 'Ralph', 'Ramon', 'Raphael', 'Remo', 'Renato', 'René', 'Reto', 'Richard', 'Robert', 'Roberto', 'Robin', 'Roger', 'Roland', 'Rolf', 'Roman', 'Rudolf',
+        'Salvatore', 'Samuel', 'Sandro', 'Sascha', 'Sebastian', 'Severin', 'Silvan', 'Silvio', 'Simon', 'Stefan', 'Stephan', 'Sven',
+        'Theodor', 'Thomas', 'Tim', 'Timo', 'Tobias',
+        'Ulrich', 'Urs',
+        'Walter', 'Werner', 'Wilhelm', 'Willi', 'Willy', 'Wolfgang',
+        'Yannick', 'Yves',
+    );
 
+    /**
+     * @link http://www.bfs.admin.ch/bfs/portal/de/index/themen/01/02/blank/dos/prenoms/02.html
+     */
+    protected static $firstNameFemale = array(
+        'Adelheid', 'Agnes', 'Alessia', 'Alexandra', 'Alice', 'Alina', 'Aline', 'Ana', 'Andrea', 'Angela', 'Angelika', 'Anita', 'Anja', 'Anna', 'Annemarie', 'Antonia', 'Astrid',
+        'Barbara', 'Beatrice', 'Beatrix', 'Bernadette', 'Bertha', 'Bettina', 'Brigitta', 'Brigitte',
+        'Carla', 'Carmen', 'Caroline', 'Chantal', 'Charlotte', 'Chiara', 'Christa', 'Christina', 'Christine', 'Claudia', 'Corina', 'Corinne', 'Cornelia', 'Céline',
+        'Daniela', 'Deborah', 'Denise', 'Diana', 'Dora', 'Doris', 'Dorothea',
+        'Edith', 'Elena', 'Eliane', 'Elisabeth', 'Elsa', 'Elsbeth', 'Emma', 'Erika', 'Erna', 'Esther', 'Eva', 'Eveline',
+        'Fabienne', 'Fiona', 'Franziska', 'Frieda',
+        'Gabriela', 'Gabriele', 'Gertrud', 'Gisela',
+        'Hanna', 'Hedwig', 'Heidi', 'Helena', 'Helene', 'Hildegard',
+        'Ida', 'Ingrid', 'Irene', 'Iris', 'Irma', 'Isabel', 'Isabella', 'Isabelle',
+        'Jacqueline', 'Jana', 'Janine', 'Jasmin', 'Jeannette', 'Jennifer', 'Jessica', 'Johanna', 'Jolanda', 'Judith', 'Julia',
+        'Karin', 'Katharina', 'Kathrin', 'Katja', 'Katrin', 'Klara',
+        'Lara', 'Larissa', 'Laura', 'Lea', 'Lena', 'Leonie', 'Lina', 'Linda', 'Lisa', 'Liselotte', 'Livia', 'Lorena', 'Luana', 'Lucia', 'Luzia', 'Lydia',
+        'Madeleine', 'Magdalena', 'Maja', 'Manuela', 'Mara', 'Margareta', 'Margaretha', 'Margaritha', 'Margrit', 'Margrith', 'Maria', 'Marianna', 'Marianne', 'Marie', 'Marina', 'Marion', 'Marlise', 'Martha', 'Martina', 'Melanie', 'Mia', 'Michaela', 'Michelle', 'Michèle', 'Milena', 'Miriam', 'Mirjam', 'Monica', 'Monika',
+        'Nadia', 'Nadine', 'Nadja', 'Natalie', 'Nathalie', 'Nelly', 'Nicole', 'Nina', 'Noemi', 'Nora',
+        'Patricia', 'Patrizia', 'Paula', 'Petra', 'Pia', 'Priska',
+        'Rahel', 'Ramona', 'Rebecca', 'Regina', 'Regula', 'Renata', 'Renate', 'Rita', 'Rosa', 'Rosmarie', 'Ruth',
+        'Sabine', 'Sabrina', 'Sandra', 'Sara', 'Sarah', 'Selina', 'Seraina', 'Sibylle', 'Silvia', 'Simone', 'Sina', 'Sonja', 'Sophie', 'Stefanie', 'Stephanie', 'Susanna', 'Susanne', 'Sylvia',
+        'Tamara', 'Tanja', 'Therese', 'Theresia',
+        'Ursula',
+        'Valentina', 'Vanessa', 'Vera', 'Verena', 'Veronika',
+        'Yvonne',
+    );
+
+    /**
+     * @link http://blog.tagesanzeiger.ch/datenblog/index.php/6859
+     */
+    protected static $lastName = array(
+        'Achermann', 'Ackermann', 'Aeschlimann', 'Ammann', 'Arnold',
+        'Bachmann', 'Baumann', 'Baumgartner', 'Beck', 'Benz', 'Berger', 'Betschart', 'Bieri', 'Bischof', 'Blaser', 'Blum', 'Bolliger', 'Bosshard', 'Brunner', 'Bucher', 'Burri', 'Bärtschi', 'Bösch', 'Bühler', 'Bühlmann', 'Bürgi', 'Bürki',
+        'Christen',
+        'Eberle', 'Egger', 'Egli', 'Eichenberger', 'Erni', 'Eugster',
+        'Fankhauser', 'Fehr', 'Fischer', 'Flury', 'Flückiger', 'Frei', 'Frey', 'Friedli', 'Frischknecht', 'Fuchs', 'Furrer', 'Fässler',
+        'Gasser', 'Gerber', 'Giger', 'Gisler', 'Gloor', 'Graber', 'Graf', 'Grob', 'Gut',
+        'Haas', 'Haller', 'Hartmann', 'Hasler', 'Hauser', 'Heiniger', 'Herzog', 'Hess', 'Hofer', 'Hofmann', 'Hofstetter', 'Hostettler', 'Huber', 'Hug', 'Hunziker', 'Häfliger', 'Hänni', 'Hürlimann',
+        'Imhof', 'Iten',
+        'Jenni', 'Jost', 'Jäggi',
+        'Kaiser', 'Kaufmann', 'Keller', 'Kessler', 'Knecht', 'Koch', 'Kohler', 'Koller', 'Krebs', 'Kuhn', 'Kunz', 'Kuster', 'Kälin', 'Käser', 'Küng',
+        'Lang', 'Lanz', 'Lehmann', 'Leuenberger', 'Liechti', 'Locher', 'Lutz', 'Lüscher', 'Lüthi',
+        'Marti', 'Marty', 'Mathis', 'Mathys', 'Maurer', 'Meier', 'Meister', 'Merz', 'Mettler', 'Meyer', 'Michel', 'Moser', 'Mäder', 'Müller',
+        'Niederberger', 'Nussbaumer', 'Näf',
+        'Odermatt', 'Ott',
+        'Peter', 'Pfister', 'Portmann', 'Probst',
+        'Reber', 'Rohner', 'Rohrer', 'Roth', 'Röthlisberger', 'Rüegg',
+        'Schaub', 'Scheidegger', 'Schenk', 'Scherrer', 'Schmid', 'Schmidt', 'Schneider', 'Schnyder', 'Schuler', 'Schumacher', 'Schwab', 'Schwarz', 'Schweizer', 'Schär', 'Schärer', 'Schüpbach', 'Schütz', 'Seiler', 'Senn', 'Sieber', 'Siegenthaler', 'Siegrist', 'Sigrist', 'Sommer', 'Stadelmann', 'Stalder', 'Staub', 'Steffen', 'Steiger', 'Steiner', 'Steinmann', 'Stettler', 'Stocker', 'Stucki', 'Studer', 'Stutz', 'Stöckli', 'Suter', 'Sutter',
+        'Tanner', 'Tobler', 'Trachsel',
+        'Ulrich',
+        'Vogel', 'Vogt',
+        'Wagner', 'Walker', 'Walser', 'Weber', 'Wehrli', 'Weibel', 'Weiss', 'Wenger', 'Wicki', 'Widmer', 'Willi', 'Wirth', 'Wirz', 'Wittwer', 'Wolf', 'Wyss', 'Wüthrich',
+        'Zaugg', 'Zbinden', 'Zehnder', 'Ziegler', 'Zimmermann', 'Zwahlen', 'Zürcher',
+    );
 }

--- a/src/Faker/Provider/fr_CH/Person.php
+++ b/src/Faker/Provider/fr_CH/Person.php
@@ -4,5 +4,87 @@ namespace Faker\Provider\fr_CH;
 
 class Person extends \Faker\Provider\fr_FR\Person
 {
+    /**
+     * @link http://www.bfs.admin.ch/bfs/portal/de/index/themen/01/02/blank/dos/prenoms/02.html
+     */
+    protected static $firstNameMale = array(
+        'Adrian', 'Adrien', 'Alain', 'Albert', 'Alberto', 'Alessandro', 'Alex', 'Alexander', 'Alexandre', 'Alexis', 'Alfred', 'Ali', 'Andrea', 'André', 'Angelo', 'Anthony', 'Antoine', 'Antonio', 'António', 'Arnaud', 'Arthur', 'Aurélien', 'Axel',
+        'Baptiste', 'Bastien', 'Benjamin', 'Benoît', 'Bernard', 'Bertrand', 'Bruno', 'Bryan',
+        'Carlos', 'Charles', 'Christian', 'Christophe', 'Christopher', 'Claude', 'Claudio', 'Cyril', 'Cédric',
+        'Damien', 'Daniel', 'David', 'Denis', 'Didier', 'Diego', 'Diogo', 'Dominique', 'Dylan',
+        'Emmanuel', 'Enzo', 'Eric', 'Etienne',
+        'Fabien', 'Fabio', 'Fabrice', 'Fernando', 'Filipe', 'Florian', 'Francesco', 'Francis', 'Francisco', 'François', 'Frédéric',
+        'Gabriel', 'Georges', 'Gilbert', 'Gilles', 'Giovanni', 'Giuseppe', 'Gregory', 'Grégoire', 'Grégory', 'Guillaume', 'Guy', 'Gérald', 'Gérard',
+        'Hans', 'Henri', 'Hervé', 'Hugo',
+        'Jacques', 'Jean', 'Jean-Claude', 'Jean-Daniel', 'Jean-François', 'Jean-Jacques', 'Jean-Louis', 'Jean-Luc', 'Jean-Marc', 'Jean-Marie', 'Jean-Michel', 'Jean-Paul', 'Jean-Pierre', 'Joao', 'Joaquim', 'John', 'Jonas', 'Jonathan', 'Jorge', 'Jose', 'Joseph', 'José', 'João', 'Joël', 'Juan', 'Julien', 'Jérémie', 'Jérémy', 'Jérôme',
+        'Kevin',
+        'Laurent', 'Lionel', 'Loris', 'Louis', 'Loïc', 'Luc', 'Luca', 'Lucas', 'Lucien', 'Ludovic', 'Luis', 'Léo',
+        'Manuel', 'Marc', 'Marcel', 'Marco', 'Mario', 'Martin', 'Mathias', 'Mathieu', 'Matteo', 'Matthieu', 'Maurice', 'Max', 'Maxime', 'Michael', 'Michaël', 'Michel', 'Miguel', 'Mohamed',
+        'Nathan', 'Nicolas', 'Noah', 'Nolan', 'Nuno',
+        'Olivier',
+        'Pascal', 'Patrice', 'Patrick', 'Paul', 'Paulo', 'Pedro', 'Peter', 'Philippe', 'Pierre', 'Pierre-Alain', 'Pierre-André',
+        'Quentin',
+        'Rafael', 'Raphaël', 'Raymond', 'René', 'Ricardo', 'Richard', 'Robert', 'Roberto', 'Robin', 'Roger', 'Roland', 'Romain', 'Rui', 'Rémy',
+        'Sacha', 'Salvatore', 'Samuel', 'Serge', 'Sergio', 'Simon', 'Steve', 'Stéphane', 'Sylvain', 'Sébastien',
+        'Thierry', 'Thomas', 'Théo', 'Tiago',
+        'Valentin', 'Victor', 'Vincent', 'Vitor',
+        'Walter', 'William', 'Willy',
+        'Xavier',
+        'Yann', 'Yannick', 'Yvan', 'Yves',
+    );
 
+    /**
+     * @link http://www.bfs.admin.ch/bfs/portal/de/index/themen/01/02/blank/dos/prenoms/02.html
+     */
+    protected static $firstNameFemale = array(
+        'Agnès', 'Alexandra', 'Alice', 'Alicia', 'Aline', 'Amélie', 'Ana', 'Anaïs', 'Andrea', 'Andrée', 'Angela', 'Anita', 'Anna', 'Anne', 'Anne-Marie', 'Antoinette', 'Ariane', 'Arlette', 'Audrey', 'Aurélie',
+        'Barbara', 'Bernadette', 'Brigitte', 'Béatrice',
+        'Camille', 'Carine', 'Carla', 'Carmen', 'Carole', 'Caroline', 'Catherine', 'Chantal', 'Charlotte', 'Chloé', 'Christelle', 'Christiane', 'Christine', 'Cindy', 'Claire', 'Clara', 'Claudia', 'Claudine', 'Colette', 'Coralie', 'Corinne', 'Cristina', 'Cécile', 'Célia', 'Céline',
+        'Daniela', 'Danielle', 'Danièle', 'Delphine', 'Denise', 'Diana', 'Dominique',
+        'Edith', 'Elena', 'Eliane', 'Elisa', 'Elisabeth', 'Elodie', 'Elsa', 'Emilie', 'Emma', 'Erika', 'Estelle', 'Esther', 'Eva', 'Evelyne',
+        'Fabienne', 'Fanny', 'Florence', 'Francine', 'Françoise',
+        'Gabrielle', 'Geneviève', 'Georgette', 'Ginette', 'Gisèle', 'Géraldine',
+        'Huguette', 'Hélène',
+        'Inès', 'Irène', 'Isabel', 'Isabelle',
+        'Jacqueline', 'Janine', 'Jeanne', 'Jeannine', 'Jennifer', 'Jessica', 'Joana', 'Jocelyne', 'Josette', 'Josiane', 'Joëlle', 'Julia', 'Julie', 'Juliette', 'Justine',
+        'Karin', 'Karine', 'Katia',
+        'Laetitia', 'Lara', 'Laura', 'Laure', 'Laurence', 'Liliane', 'Lisa', 'Louise', 'Lucia', 'Lucie', 'Léa',
+        'Madeleine', 'Magali', 'Manon', 'Manuela', 'Marguerite', 'Maria', 'Marianne', 'Marie', 'Marie-Thérèse', 'Marina', 'Marine', 'Marion', 'Marlyse', 'Marlène', 'Martine', 'Mathilde', 'Melissa', 'Micheline', 'Michelle', 'Michèle', 'Mireille', 'Monica', 'Monique', 'Morgane', 'Muriel', 'Myriam', 'Mélanie',
+        'Nadia', 'Nadine', 'Natacha', 'Nathalie', 'Nelly', 'Nicole', 'Nina', 'Noémie',
+        'Océane', 'Olga', 'Olivia',
+        'Pascale', 'Patricia', 'Paula', 'Pauline', 'Pierrette',
+        'Rachel', 'Raymonde', 'Renée', 'Rita', 'Rosa', 'Rose', 'Rose-Marie', 'Ruth',
+        'Sabine', 'Sabrina', 'Sandra', 'Sandrine', 'Sara', 'Sarah', 'Silvia', 'Simone', 'Sofia', 'Sonia', 'Sophie', 'Stéphanie', 'Suzanne', 'Sylvia', 'Sylviane', 'Sylvie', 'Séverine',
+        'Tania', 'Tatiana', 'Teresa', 'Thérèse',
+        'Valentine', 'Valérie', 'Vanessa', 'Victoria', 'Virginie', 'Viviane', 'Véronique',
+        'Yolande', 'Yvette', 'Yvonne',
+        'Zoé',
+    );
+
+    /**
+     * @link http://blog.tagesanzeiger.ch/datenblog/index.php/6859
+     */
+    protected static $lastName = array(
+        'Aebischer', 'Aeby', 'Andrey', 'Aubert', 'Aubry',
+        'Bachmann', 'Baechler', 'Baeriswyl', 'Barbey', 'Barras', 'Baumann', 'Baumgartner', 'Berger', 'Bernard', 'Berset', 'Bersier', 'Berthoud', 'Besson', 'Blanc', 'Blaser', 'Boillat', 'Bonvin', 'Bourquin', 'Bruchez', 'Brunner', 'Brügger', 'Buchs', 'Bugnon', 'Burri', 'Bühler',
+        'Castella', 'Cattin', 'Chappuis', 'Chapuis', 'Chassot', 'Chatelain', 'Chevalley', 'Chollet', 'Christen', 'Clerc', 'Clément', 'Constantin', 'Crausaz',
+        'Da Silva', 'Darbellay', 'Demierre', 'dos Santos', 'Droz', 'Dubois', 'Dubuis', 'Duc', 'Dévaud',
+        'Egger', 'Emery',
+        'Fasel', 'Favre', 'Fellay', 'Fernandes', 'Fernandez', 'Ferreira', 'Fischer', 'Fleury', 'Flückiger', 'Fournier', 'Fragnière', 'Froidevaux',
+        'Gaillard', 'Garcia', 'Gasser', 'Gay', 'Geiser', 'Genoud', 'Gerber', 'Gilliéron', 'Girard', 'Girardin', 'Giroud', 'Glauser', 'Golay', 'Gonzalez', 'Graf', 'Grand', 'Grandjean', 'Gremaud', 'Grosjean', 'Gross', 'Guex', 'Guignard',
+        'Hofer', 'Hofmann', 'Huber', 'Huguenin', 'Héritier',
+        'Jaccard', 'Jacot', 'Jaquet', 'Jaquier', 'Jeanneret', 'Jordan', 'Jungo', 'Junod',
+        'Kaufmann', 'Keller', 'Kohler', 'Kolly', 'Kunz',
+        'Lachat', 'Lambert', 'Lehmann', 'Leuba', 'Leuenberger', 'Liechti', 'Lopez', 'Lüthi',
+        'Maeder', 'Magnin', 'Maillard', 'Maret', 'Marti', 'Martin', 'Martinez', 'Matthey', 'Maurer', 'Mauron', 'Mayor', 'Meier', 'Meyer', 'Meylan', 'Michaud', 'Michel', 'Monnet', 'Monney', 'Monnier', 'Morand', 'Morard', 'Morel', 'Moret', 'Moser', 'Muller', 'Müller',
+        'Neuhaus', 'Nguyen', 'Nicolet',
+        'Oberson',
+        'Pache', 'Pasche', 'Pasquier', 'Pereira', 'Perez', 'Perrenoud', 'Perret', 'Perrin', 'Perroud', 'Pfister', 'Piguet', 'Piller', 'Pilloud', 'Pittet', 'Pochon',
+        'Racine', 'Rey', 'Reymond', 'Richard', 'Robert', 'Rochat', 'Rodrigues', 'Rodriguez', 'Roduit', 'Rosset', 'Rossier', 'Roth', 'Rouiller', 'Roulin', 'Roy', 'Ruffieux',
+        'Savary', 'Schaller', 'Schmid', 'Schmidt', 'Schmutz', 'Schneider', 'Schwab', 'Seydoux', 'Simon', 'Stalder', 'Stauffer', 'Steiner', 'Studer', 'Suter',
+        'Tissot',
+        'Vaucher', 'Vonlanthen', 'Vuilleumier',
+        'Waeber', 'Weber', 'Wenger', 'Widmer', 'Wyss',
+        'Zbinden', 'Zimmermann',
+    );
 }

--- a/src/Faker/Provider/it_CH/Person.php
+++ b/src/Faker/Provider/it_CH/Person.php
@@ -4,5 +4,85 @@ namespace Faker\Provider\it_CH;
 
 class Person extends \Faker\Provider\it_IT\Person
 {
+    /**
+     * @link http://www.bfs.admin.ch/bfs/portal/de/index/themen/01/02/blank/dos/prenoms/02.html
+     */
+    protected static $firstNameMale = array(
+        'Aaron', 'Adriano', 'Alain', 'Alan', 'Alberto', 'Aldo', 'Alessandro', 'Alessio', 'Alex', 'Alexander', 'Alfredo', 'Andrea', 'Andreas', 'André', 'Angelo', 'Antonino', 'Antonio', 'Aris', 'Armando', 'Arturo', 'Athos', 'Attilio', 'Augusto', 'Aurelio',
+        'Boris', 'Bruno',
+        'Carlo', 'Carlos', 'Carmelo', 'Carmine', 'Cesare', 'Christian', 'Claudio', 'Corrado', 'Cristian', 'Cristiano',
+        'Damiano', 'Daniel', 'Daniele', 'Danilo', 'Dante', 'Dario', 'David', 'Davide', 'Denis', 'Diego', 'Domenico', 'Donato',
+        'Edoardo', 'Elia', 'Elio', 'Emanuele', 'Emilio', 'Enea', 'Enrico', 'Enzo', 'Eric', 'Ernesto', 'Eros', 'Ettore', 'Eugenio', 'Ezio',
+        'Fabiano', 'Fabio', 'Fabrizio', 'Fausto', 'Federico', 'Felice', 'Fernando', 'Filippo', 'Fiorenzo', 'Flavio', 'Francesco', 'Franco', 'Fulvio',
+        'Gabriel', 'Gabriele', 'Gaetano', 'Gerardo', 'Giacomo', 'Gian', 'Giancarlo', 'Gianfranco', 'Gianluca', 'Gianni', 'Gioele', 'Giona', 'Giordano', 'Giorgio', 'Giovanni', 'Giuliano', 'Giulio', 'Giuseppe', 'Graziano', 'Guido',
+        'Hans',
+        'Igor', 'Ivan', 'Ivano', 'Ivo',
+        'Jacopo', 'Jean', 'Joel', 'Jonathan', 'José',
+        'Kevin', 'Kurt',
+        'Leandro', 'Leonardo', 'Liam', 'Livio', 'Lorenzo', 'Loris', 'Luca', 'Luciano', 'Lucio', 'Luigi', 'Luis',
+        'Manuel', 'Marcello', 'Marco', 'Marino', 'Mario', 'Marko', 'Markus', 'Martin', 'Martino', 'Marzio', 'Massimiliano', 'Massimo', 'Matteo', 'Mattia', 'Maurizio', 'Mauro', 'Michael', 'Michel', 'Michele', 'Mirco', 'Mirko', 'Moreno',
+        'Nathan', 'Nicola', 'Nicolas', 'Nicolò', 'Noah',
+        'Oliver', 'Omar', 'Oscar',
+        'Paolo', 'Pasquale', 'Patrick', 'Paul', 'Pedro', 'Peter', 'Pier', 'Pierluigi', 'Piero', 'Pietro',
+        'Raffaele', 'Remo', 'Renato', 'Renzo', 'René', 'Reto', 'Riccardo', 'Robert', 'Roberto', 'Rocco', 'Roland', 'Rolf', 'Romano', 'Rosario', 'Ruben', 'Rudolf',
+        'Sacha', 'Salvatore', 'Samuel', 'Samuele', 'Sandro', 'Sebastian', 'Sebastiano', 'Sergio', 'Silvano', 'Silvio', 'Simon', 'Simone', 'Stefan', 'Stefano',
+        'Thomas', 'Tiziano', 'Tommaso',
+        'Valentino', 'Valerio', 'Vincenzo', 'Vito', 'Vittorio',
+        'Walter', 'Werner',
+    );
 
+    /**
+     * @link http://www.bfs.admin.ch/bfs/portal/de/index/themen/01/02/blank/dos/prenoms/02.html
+     */
+    protected static $firstNameFemale = array(
+        'Ada', 'Adele', 'Adriana', 'Agnese', 'Alessandra', 'Alessia', 'Alexandra', 'Alice', 'Aline', 'Ana', 'Andrea', 'Angela', 'Angelina', 'Anita', 'Anna', 'Annamaria', 'Antonella', 'Antonia', 'Antonietta', 'Arianna', 'Asia', 'Aurora',
+        'Barbara', 'Beatrice', 'Bianca', 'Brigitte', 'Bruna',
+        'Camilla', 'Carla', 'Carmela', 'Carmen', 'Carolina', 'Caterina', 'Cecilia', 'Chantal', 'Chiara', 'Christine', 'Cinzia', 'Clara', 'Claudia', 'Cristina',
+        'Daniela', 'Debora', 'Deborah', 'Denise', 'Diana', 'Dolores', 'Donatella', 'Doris',
+        'Elda', 'Elena', 'Eleonora', 'Eliana', 'Elisa', 'Elisabeth', 'Elisabetta', 'Elsa', 'Emanuela', 'Emilia', 'Emma', 'Enrica', 'Erica', 'Erika', 'Ester', 'Eva',
+        'Fabiana', 'Federica', 'Fernanda', 'Filomena', 'Flavia', 'Franca', 'Francesca',
+        'Gabriella', 'Gaia', 'Giada', 'Gianna', 'Giorgia', 'Giovanna', 'Giulia', 'Giuliana', 'Giuseppina', 'Gloria', 'Graziella', 'Greta',
+        'Ida', 'Ilaria', 'Ines', 'Irene', 'Iris', 'Isabel', 'Isabella', 'Ivana',
+        'Jacqueline', 'Jennifer', 'Jessica', 'Jolanda',
+        'Karin', 'Katia',
+        'Lara', 'Laura', 'Letizia', 'Lia', 'Lidia', 'Liliana', 'Lina', 'Linda', 'Lisa', 'Loredana', 'Lorena', 'Lorenza', 'Luana', 'Lucia', 'Luciana', 'Luisa',
+        'Manuela', 'Mara', 'Margherita', 'Margrit', 'Maria', 'Mariangela', 'Marianne', 'Marie', 'Mariella', 'Marilena', 'Marina', 'Marisa', 'Marta', 'Martina', 'Matilde', 'Maura', 'Melissa', 'Michela', 'Michelle', 'Milena', 'Mirella', 'Miriam', 'Monica', 'Monika', 'Morena', 'Myriam',
+        'Nadia', 'Nathalie', 'Nicole', 'Nicoletta', 'Nina', 'Nives', 'Noemi', 'Nora',
+        'Olga', 'Ornella',
+        'Pamela', 'Paola', 'Patricia', 'Patrizia', 'Pia', 'Pierina', 'Prisca',
+        'Raffaella', 'Renata', 'Rita', 'Roberta', 'Romina', 'Rosa', 'Rosanna', 'Rosmarie', 'Ruth',
+        'Sabina', 'Sabrina', 'Samantha', 'Sandra', 'Sara', 'Sarah', 'Serena', 'Silvana', 'Silvia', 'Simona', 'Sofia', 'Sonia', 'Sonja', 'Sophie', 'Stefania', 'Susanna', 'Susanne',
+        'Tamara', 'Tania', 'Tatiana', 'Teresa', 'Tiziana',
+        'Ursula',
+        'Valentina', 'Valeria', 'Vanessa', 'Vera', 'Verena', 'Veronica', 'Virginia', 'Vittoria', 'Viviana',
+        'Yvonne',
+    );
+
+    /**
+     * @link http://blog.tagesanzeiger.ch/datenblog/index.php/6859
+     */
+    protected static $lastName = array(
+        'Agustoni', 'Alberti', 'Albertini', 'Albisetti', 'Ambrosini', 'Antonini',
+        'Balestra', 'Balmelli', 'Bassetti', 'Bassi', 'Baumann', 'Beffa', 'Belotti', 'Beretta', 'Bernasconi', 'Berta', 'Besomi', 'Bettosini', 'Bianchi', 'Bianda', 'Bizzozero', 'Bonetti', 'Botta', 'Bottinelli', 'Brunner', 'Butti',
+        'Caccia', 'Campana', 'Camponovo', 'Candolfi', 'Canepa', 'Canonica', 'Capoferri', 'Carrara', 'Casanova', 'Cassina', 'Castelli', 'Cattaneo', 'Cavadini', 'Cavalli', 'Ceppi', 'Cereghetti', 'Cerutti', 'Chiesa', 'Colombo', 'Conti', 'Corti', 'Costa', 'Crivelli', 'Croci',
+        'Delcò', 'Delmenico', 'Donati',
+        'Esposito',
+        'Ferrari', 'Ferrazzini', 'Ferretti', 'Filippini', 'Fischer', 'Foglia', 'Foletti', 'Fontana', 'Forni', 'Frei', 'Frey', 'Frigerio', 'Fumagalli',
+        'Galfetti', 'Galli', 'Gamboni', 'Genini', 'Gerosa', 'Ghirlanda', 'Gianella', 'Gianinazzi', 'Gianini', 'Giannini', 'Gianola', 'Gilardi', 'Giovannini', 'Giudici', 'Gobbi', 'Grandi', 'Grassi', 'Grossi', 'Guerra', 'Guglielmetti', 'Guidotti',
+        'Huber',
+        'Jelmini',
+        'Keller',
+        'Lafranchi', 'Leonardi', 'Leoni', 'Lepori', 'Locatelli', 'Lombardi', 'Lombardo', 'Lorenzetti', 'Lucchini', 'Lupi', 'Lurati',
+        'Maggetti', 'Maggi', 'Maggini', 'Martinelli', 'Martini', 'Maspoli', 'Mattei', 'Medici', 'Meier', 'Meroni', 'Meyer', 'Milani', 'Minotti', 'Molinari', 'Molteni', 'Mombelli', 'Monti', 'Morandi', 'Mordasini', 'Moresi', 'Moretti', 'Morisoli', 'Moro', 'Moser', 'Müller',
+        'Nessi', 'Notari',
+        'Ortelli',
+        'Pagani', 'Pagnamenta', 'Papa', 'Pedrazzi', 'Pedrazzini', 'Pedrini', 'Pedroni', 'Peduzzi', 'Pellanda', 'Pellegrini', 'Pelloni', 'Pescia', 'Pesenti', 'Petrini', 'Piffaretti', 'Pini', 'Polli', 'Ponti', 'Ponzio', 'Poretti', 'Pozzi',
+        'Quadri',
+        'Realini', 'Regazzoni', 'Rezzonico', 'Rigamonti', 'Righetti', 'Rinaldi', 'Riva', 'Rizzi', 'Robbiani', 'Rodoni', 'Romano', 'Roncoroni', 'Rosselli', 'Rossetti', 'Rossi', 'Rossini', 'Rusca', 'Rusconi', 'Russo',
+        'Sala', 'Sargenti', 'Sartori', 'Sassi', 'Schmid', 'Schneider', 'Scolari', 'Solari', 'Solcà', 'Soldati', 'Soldini', 'Steiner', 'Storni', 'Sulmoni', 'Suter',
+        'Taddei', 'Tamagni', 'Tettamanti', 'Togni', 'Tognola',
+        'Valsangiacomo', 'Vassalli', 'Villa', 'Vitali',
+        'Weber', 'Widmer',
+        'Zanetti', 'Zanini', 'Zimmermann',
+    );
 }


### PR DESCRIPTION
Added first & last names for each Swiss region (`de_CH`, `fr_CH` and `it_CH`).