### PR TITLE
Code adjustments in unique() generator

### DIFF
--- a/src/Faker/UniqueGenerator.php
+++ b/src/Faker/UniqueGenerator.php
@@ -37,9 +37,6 @@ class UniqueGenerator
      */
     public function __call($name, $arguments)
     {
-        if (!isset($this->uniques[$name])) {
-            $this->uniques[$name] = array();
-        }
         $i = 0;
         do {
             $i++;
@@ -48,9 +45,9 @@ class UniqueGenerator
             }
             $res = call_user_func_array(array($this->generator, $name), $arguments);
             $serialized = serialize($res);
-        } while (array_key_exists($serialized, $this->uniques[$name]));
+        } while (isset($this->uniques[$name][$serialized]));
 
-        $this->uniques[$name][$serialized]= null;
+        $this->uniques[$name][$serialized] = true;
 
         return $res;
     }

--- a/src/Faker/UniqueGenerator.php
+++ b/src/Faker/UniqueGenerator.php
@@ -47,9 +47,10 @@ class UniqueGenerator
                 throw new \OverflowException(sprintf('Maximum retries of %d reached without finding a unique value', $this->maxRetries));
             }
             $res = call_user_func_array(array($this->generator, $name), $arguments);
-        } while (array_key_exists(serialize($res), $this->uniques[$name]));
+            $serialized = serialize($res);
+        } while (array_key_exists($serialized, $this->uniques[$name]));
 
-        $this->uniques[$name][serialize($res)]= null;
+        $this->uniques[$name][$serialized]= null;
 
         return $res;
     }

--- a/src/Faker/UniqueGenerator.php
+++ b/src/Faker/UniqueGenerator.php
@@ -42,12 +42,13 @@ class UniqueGenerator
         }
         $i = 0;
         do {
-            $res = call_user_func_array(array($this->generator, $name), $arguments);
             $i++;
             if ($i > $this->maxRetries) {
                 throw new \OverflowException(sprintf('Maximum retries of %d reached without finding a unique value', $this->maxRetries));
             }
+            $res = call_user_func_array(array($this->generator, $name), $arguments);
         } while (array_key_exists(serialize($res), $this->uniques[$name]));
+
         $this->uniques[$name][serialize($res)]= null;
 
         return $res;


### PR DESCRIPTION
Highlights:

* When unique value found, serialize once instead of twice. If unique values are likely to be found on first try, this results in twice less serialize calls. Refs #749.
* Use `isset()` instead of `array_key_exists()`, the former being a language construct and not a function, it is significantly faster. This change also allows code simplification by removing the "intermediary index creation" step at beginning of method. Refs #491.