### PR TITLE
Added strict comparison to birthNumber method

### DIFF
--- a/src/Faker/Provider/cs_CZ/Person.php
+++ b/src/Faker/Provider/cs_CZ/Person.php
@@ -434,7 +434,7 @@ class Person extends \Faker\Provider\Person
 
     public function birthNumber($gender = null, $minAge = 0, $maxAge = 100, $slashProbability = 50)
     {
-        if ($gender == null) {
+        if ($gender === null) {
             $gender = $this->generator->boolean() ? static::GENDER_MALE : static::GENDER_FEMALE;
         }
 


### PR DESCRIPTION
Hello.

I added strict comparison to variable $gender in birthNumber method. This lowers bug risks and improves performance because in strict comparison the two pieces of data are being compared to have not only the same value, but the same type as well. This eliminates possible type-related bugs.