### PR TITLE
Improved mod97 method of Iban class

### DIFF
--- a/src/Faker/Calculator/Iban.php
+++ b/src/Faker/Calculator/Iban.php
@@ -52,7 +52,8 @@ class Iban
     public static function mod97($number)
     {
         $checksum = (int)$number[0];
-        for ($i = 1, $size = strlen($number); $i < $size; $i++) {
+        $size = strlen($number);
+        for ($i = 1; $i < $size; $i++) {
             $checksum = (10 * $checksum + (int) $number[$i]) % 97;
         }
         return $checksum;


### PR DESCRIPTION
Good morning.

I moved variable ```$size``` above for loop. The reason for this is that in the previous form the method calculates ```$size``` variable on every step of the loop. I changed this to be pre-calculated, which improves the efficiency.

Thank you.