### PR TITLE
update operators' phone number prefix.

### DIFF
--- a/src/Faker/Provider/zh_CN/PhoneNumber.php
+++ b/src/Faker/Provider/zh_CN/PhoneNumber.php
@@ -5,9 +5,10 @@ namespace Faker\Provider\zh_CN;
 class PhoneNumber extends \Faker\Provider\PhoneNumber
 {
     protected static $operators = array(
-        134, 135, 136, 137, 138, 139, 147, 150, 151, 152, 157, 158, 159, 182, 187, 188, // china mobile
-        130, 131, 132, 145, 155, 156, 185, 186, 145, // china unicom
-        133 , 153 , 180 , 181 , 189, // chinatelecom
+        134, 135, 136, 137, 138, 139, 147, 150, 151, 152, 157, 158, 159, 178, 182, 183, 184, 187, 188, // china mobile
+        130, 131, 132, 145, 155, 156, 175, 176, 185, 186, // china unicom
+        133, 149, 153, 177, 180, 181, 189, // chinatelecom
+        170, 171, // virtual operators
     );
 
     protected static $formats = array('########');


### PR DESCRIPTION
- add: 178, 182, 183, 184 for china mobile;
- add: 175, 176 for china unicom;
- chg: remove redundant 145;
- add: 149, 177 for china telecom;
- add: 170, 171 for virtual operators.