### PR TITLE
Latvia phone number format

### DIFF
--- a/src/Faker/Provider/lv_LV/PhoneNumber.php
+++ b/src/Faker/Provider/lv_LV/PhoneNumber.php
@@ -4,6 +4,9 @@ namespace Faker\Provider\lv_LV;
 
 class PhoneNumber extends \Faker\Provider\PhoneNumber
 {
+    /**
+     * {@link} https://en.wikipedia.org/wiki/Telephone_numbers_in_Latvia
+     **/
     protected static $formats = array(
         '########',
         '## ### ###',

--- a/src/Faker/Provider/lv_LV/PhoneNumber.php
+++ b/src/Faker/Provider/lv_LV/PhoneNumber.php
@@ -5,9 +5,8 @@ namespace Faker\Provider\lv_LV;
 class PhoneNumber extends \Faker\Provider\PhoneNumber
 {
     protected static $formats = array(
-        '##-###-###',
-        '##-######',
         '########',
-        '+371 #######',
+        '## ### ###',
+        '+371 ########',
     );
 }


### PR DESCRIPTION
Phone numbers length for Latvia is 8 digits plus country code. And sometimes divided with spaces.