### PR TITLE
en_US locale provider for jobTitle added.

### DIFF
--- a/src/Faker/Provider/en_US/Company.php
+++ b/src/Faker/Provider/en_US/Company.php
@@ -90,4 +90,12 @@ class Company extends \Faker\Provider\Company
 
         return join($result, ' ');
     }
+
+    /**
+     * @example 'Hand Trimmer'
+     */
+    public function jobTitle()
+    {
+        return static::randomElement(static::$jobTitle);
+    }
 }


### PR DESCRIPTION
Added a method to the en_US/Company provider to give access to the job title array instead instead of a "lorem" word. 