### PR TITLE
Added en_IN unit test for Address.php

### DIFF
--- a/test/Faker/Provider/en_IN/AddressTest.php
+++ b/test/Faker/Provider/en_IN/AddressTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Faker\Provider\en_IN;
+
+use Faker\Generator;
+use Faker\Provider\en_IN\Address;
+
+class AddressTest extends \PHPUnit_Framework_TestCase
+{
+
+  /**
+   * @var Faker\Generator
+   */
+  private $faker;
+
+  public function setUp()
+  {
+    $faker = new Generator();
+    $faker->addProvider(new Address($faker));
+    $this->faker = $faker;
+  }
+
+  public function testCity()
+  {
+    $city = $this->faker->city();
+    $this->assertNotEmpty($city);
+    $this->assertInternalType('string', $city);
+    $this->assertRegExp('/[A-Z][a-z]+/', $city);
+  }
+
+  public function testCountry()
+  {
+    $country = $this->faker->country();
+    $this->assertNotEmpty($country);
+    $this->assertInternalType('string', $country);
+    $this->assertRegExp('/[A-Z][a-z]+/', $country);
+  }
+
+  public function testLocalityName()
+  {
+    $localityName = $this->faker->localityName();
+    $this->assertNotEmpty($localityName);
+    $this->assertInternalType('string', $localityName);
+    $this->assertRegExp('/[A-Z][a-z]+/', $localityName);
+  }
+
+  public function testAreaSuffix()
+  {
+    $areaSuffix = $this->faker->areaSuffix();
+    $this->assertNotEmpty($areaSuffix);
+    $this->assertInternalType('string', $areaSuffix);
+    $this->assertRegExp('/[A-Z][a-z]+/', $areaSuffix);
+  }
+}
+
+?>


### PR DESCRIPTION
Added unit test kit for file ```Address.php``` in ```en_IN``` provider.

The unit testing process goes as follows: 
1) Test that the variable is not empty
2) Test that internal type is string
3) Test that the string starts with upper-case letter (RegEx match)

Thank you.