### PR TITLE
Added Dutch BTW (vat) Number

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1039,6 +1039,14 @@ echo $faker->district;
 echo $faker->cityName;
 ```
 
+### `Faker\Provider\nl_NL\Company`
+
+```php
+<?php
+echo $faker->vat; // "NL123456789B01" - Dutch Value Added Tax number
+echo $faker->btw; // "NL123456789B01" - Dutch Value Added Tax number (alias)
+```
+
 ### `Faker\Provider\no_NO\Payment`
 
 ```php

--- a/src/Faker/Provider/nl_NL/Company.php
+++ b/src/Faker/Provider/nl_NL/Company.php
@@ -25,7 +25,7 @@ class Company extends \Faker\Provider\Company
      */
     public static function vat()
     {
-        return sprintf("%s%d%s%d", 'NL', self::randomNumber(9, true),'B', self::randomNumber(2, true));
+        return sprintf("%s%d%s%d", 'NL', self::randomNumber(9, true), 'B', self::randomNumber(2, true));
 
     }
 

--- a/src/Faker/Provider/nl_NL/Company.php
+++ b/src/Faker/Provider/nl_NL/Company.php
@@ -12,4 +12,28 @@ class Company extends \Faker\Provider\Company
     );
 
     protected static $companySuffix = array('VOF', 'CV', 'LLP', 'BV', 'NV', 'IBC', 'CSL', 'EESV', 'SE', 'CV', 'Stichting', '& Zonen', '& Zn');
+
+    /**
+     * Belasting Toegevoegde Waarde (BTW) = VAT
+     *
+     * @example 'NL123456789B01'
+     *
+     * @see (dutch) http://www.belastingdienst.nl/wps/wcm/connect/bldcontentnl/belastingdienst/zakelijk/btw/administratie_bijhouden/btw_nummers_controleren/uw_btw_nummer
+     *
+     *
+     * @return string VAT Number
+     */
+    public static function vat()
+    {
+        return sprintf("%s%d%s%d", 'NL', self::randomNumber(9, true),'B', self::randomNumber(2, true));
+
+    }
+
+    /**
+     * Alias dutch vat number format
+     */
+    public static function btw()
+    {
+        return self::vat();
+    }
 }

--- a/test/Faker/Provider/nl_NL/CompanyTest.php
+++ b/test/Faker/Provider/nl_NL/CompanyTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Faker\Test\Provider\nl_NL;
+
+use Faker\Generator;
+use Faker\Provider\nl_NL\Company;
+
+class CompanyTest extends \PHPUnit_Framework_TestCase
+{
+    private $faker;
+
+    public function setUp()
+    {
+        $faker = new Generator();
+        $faker->addProvider(new Company($faker));
+        $this->faker = $faker;
+    }
+
+    public function testGenerateValidVatNumber()
+    {
+        $vatNo = $this->faker->vat();
+
+        $this->assertEquals(14, strlen($vatNo));
+        $this->assertRegExp('/^NL[0-9]{9}B[0-9]{2}$/', $vatNo);
+    }
+
+    public function testGenerateValidBtwNumberAlias()
+    {
+        $btwNo = $this->faker->btw();
+
+        $this->assertEquals(14, strlen($btwNo));
+        $this->assertRegExp('/^NL[0-9]{9}B[0-9]{2}$/', $btwNo);
+    }
+}


### PR DESCRIPTION
The Dutch BTW number has the following:

- Countrycode **NL**
- 9 digit number 
- 3 character suffix (B01 to B99)

see [link (dutch)](http://www.belastingdienst.nl/wps/wcm/connect/bldcontentnl/belastingdienst/zakelijk/btw/administratie_bijhouden/btw_nummers_controleren/uw_btw_nummer) for more details