### PR TITLE
Added unit testing for en_CA provider

### DIFF
--- a/test/Faker/Provider/en_CA/AddressTest.php
+++ b/test/Faker/Provider/en_CA/AddressTest.php
@@ -20,6 +20,9 @@ class AddressTest extends \PHPUnit_Framework_TestCase
     $this->faker = $faker;
   }
 
+  /**
+   * Test the validity of province
+   */
   public function testProvince()
   {
     $province = $this->faker->province();
@@ -28,6 +31,9 @@ class AddressTest extends \PHPUnit_Framework_TestCase
     $this->assertRegExp('/[A-Z][a-z]+/', $province);
   }
 
+  /**
+   * Test the validity of province abbreviation
+   */
   public function testProvinceAbbr()
   {
     $provinceAbbr = $this->faker->provinceAbbr();
@@ -36,6 +42,9 @@ class AddressTest extends \PHPUnit_Framework_TestCase
     $this->assertRegExp('/^[A-Z]{2}$/', $provinceAbbr);
   }
 
+  /**
+   * Test the validity of postcode letter
+   */
   public function testPostcodeLetter()
   {
     $postcodeLetter = $this->faker->randomPostcodeLetter();
@@ -44,6 +53,9 @@ class AddressTest extends \PHPUnit_Framework_TestCase
     $this->assertRegExp('/^[A-Z]{1}$/', $postcodeLetter);
   }
 
+  /**
+   * Test the validity of Canadian postcode
+   */
   public function testPostcode()
   {
     $postcode = $this->faker->postcode();

--- a/test/Faker/Provider/en_CA/AddressTest.php
+++ b/test/Faker/Provider/en_CA/AddressTest.php
@@ -43,6 +43,14 @@ class AddressTest extends \PHPUnit_Framework_TestCase
     $this->assertInternalType('string', $postcodeLetter);
     $this->assertRegExp('/^[A-Z]{1}$/', $postcodeLetter);
   }
+
+  public function testPostcode()
+  {
+    $postcode = $this->faker->postcode();
+    $this->assertNotEmpty($postcode);
+    $this->assertInternalType('string', $postcode);
+    $this->assertRegExp('/^[A-Za-z]\d[A-Za-z][ -]?\d[A-Za-z]\d$/', $postcode);
+  }
 }
 
 ?>

--- a/test/Faker/Provider/en_CA/AddressTest.php
+++ b/test/Faker/Provider/en_CA/AddressTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Faker\Provider\en_CA;
+
+use Faker\Generator;
+use Faker\Provider\en_CA\Address;
+
+class AddressTest extends \PHPUnit_Framework_TestCase
+{
+
+  /**
+   * @var Faker\Generator
+   */
+  private $faker;
+
+  public function setUp()
+  {
+    $faker = new Generator();
+    $faker->addProvider(new Address($faker));
+    $this->faker = $faker;
+  }
+
+  public function testProvince()
+  {
+    $province = $this->faker->province();
+    $this->assertNotEmpty($province);
+    $this->assertInternalType('string', $province);
+    $this->assertRegExp('/[A-Z][a-z]+/', $province);
+  }
+
+  public function testProvinceAbbr()
+  {
+    $provinceAbbr = $this->faker->provinceAbbr();
+    $this->assertNotEmpty($provinceAbbr);
+    $this->assertInternalType('string', $provinceAbbr);
+    $this->assertRegExp('/^[A-Z]{2}$/', $provinceAbbr);
+  }
+
+  public function testPostcodeLetter()
+  {
+    $postcodeLetter = $this->faker->randomPostcodeLetter();
+    $this->assertNotEmpty($postcodeLetter);
+    $this->assertInternalType('string', $postcodeLetter);
+    $this->assertRegExp('/^[A-Z]{1}$/', $postcodeLetter);
+  }
+}
+
+?>


### PR DESCRIPTION
Added ```test/Faker/Provider/en_CA/AddressTest.php``` unit test class to test ```en_CA``` provider. Unit test class tests province, province abbreviation and post code letters in three assertions: 

1) Variable is not empty
2) Variable type is a string 
3) Variable matches required RegEx pattern

Thank you.