### PR TITLE
Added Lorempixel check for ImageTest.php

### DIFF
--- a/test/Faker/Provider/ImageTest.php
+++ b/test/Faker/Provider/ImageTest.php
@@ -45,18 +45,30 @@ class ImageTest extends \PHPUnit_Framework_TestCase
 
     public function testDownloadWithDefaults()
     {
-        $file = Image::image(sys_get_temp_dir());
-        $this->assertFileExists($file);
-        if (function_exists('getimagesize')) {
-            list($width, $height, $type, $attr) = getimagesize($file);
-            $this->assertEquals(640, $width);
-            $this->assertEquals(480, $height);
-            $this->assertEquals(constant('IMAGETYPE_JPEG'), $type);
-        } else {
-            $this->assertEquals('jpg', pathinfo($file, PATHINFO_EXTENSION));
-        }
-        if (file_exists($file)) {
-            unlink($file);
+        $url = "http://www.lorempixel.com/";
+        $curlPing = curl_init($url);
+        curl_setopt($curlPing, CURLOPT_TIMEOUT, 5);
+        curl_setopt($curlPing, CURLOPT_CONNECTTIMEOUT, 5);
+        curl_setopt($curlPing, CURLOPT_RETURNTRANSFER, true);
+        $data = curl_exec($curlPing);
+        $httpCode = curl_getinfo($curlPing, CURLINFO_HTTP_CODE);
+        curl_close($curlPing);
+
+        if ($httpCode >= 200 && $httpCode < 300)
+        {
+            $file = Image::image(sys_get_temp_dir());
+            $this->assertFileExists($file);
+            if (function_exists('getimagesize')) {
+                list($width, $height, $type, $attr) = getimagesize($file);
+                $this->assertEquals(640, $width);
+                $this->assertEquals(480, $height);
+                $this->assertEquals(constant('IMAGETYPE_JPEG'), $type);
+            } else {
+                $this->assertEquals('jpg', pathinfo($file, PATHINFO_EXTENSION));
+            }
+            if (file_exists($file)) {
+                unlink($file);
+            }
         }
     }
 }

--- a/test/Faker/Provider/ImageTest.php
+++ b/test/Faker/Provider/ImageTest.php
@@ -54,11 +54,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
         $httpCode = curl_getinfo($curlPing, CURLINFO_HTTP_CODE);
         curl_close($curlPing);
 
-        /**
-         *  If HTTP response is something else than 200-299, skip the test
-         */
-        if ($httpCode < 200 | $httpCode > 300)
-        {
+        if ($httpCode < 200 | $httpCode > 300) {
             $this->markTestSkipped("LoremPixel is offline, skipping image download");
         }
 

--- a/test/Faker/Provider/ImageTest.php
+++ b/test/Faker/Provider/ImageTest.php
@@ -54,21 +54,23 @@ class ImageTest extends \PHPUnit_Framework_TestCase
         $httpCode = curl_getinfo($curlPing, CURLINFO_HTTP_CODE);
         curl_close($curlPing);
 
-        if ($httpCode >= 200 && $httpCode < 300)
+        if ($httpCode < 200 | $httpCode > 300)
         {
-            $file = Image::image(sys_get_temp_dir());
-            $this->assertFileExists($file);
-            if (function_exists('getimagesize')) {
-                list($width, $height, $type, $attr) = getimagesize($file);
-                $this->assertEquals(640, $width);
-                $this->assertEquals(480, $height);
-                $this->assertEquals(constant('IMAGETYPE_JPEG'), $type);
-            } else {
-                $this->assertEquals('jpg', pathinfo($file, PATHINFO_EXTENSION));
-            }
-            if (file_exists($file)) {
-                unlink($file);
-            }
+            $this->markTestSkipped("LoremPixel is offline, skipping image download");
+        }
+
+        $file = Image::image(sys_get_temp_dir());
+        $this->assertFileExists($file);
+        if (function_exists('getimagesize')) {
+            list($width, $height, $type, $attr) = getimagesize($file);
+            $this->assertEquals(640, $width);
+            $this->assertEquals(480, $height);
+            $this->assertEquals(constant('IMAGETYPE_JPEG'), $type);
+        } else {
+            $this->assertEquals('jpg', pathinfo($file, PATHINFO_EXTENSION));
+        }
+        if (file_exists($file)) {
+            unlink($file);
         }
     }
 }

--- a/test/Faker/Provider/ImageTest.php
+++ b/test/Faker/Provider/ImageTest.php
@@ -54,6 +54,9 @@ class ImageTest extends \PHPUnit_Framework_TestCase
         $httpCode = curl_getinfo($curlPing, CURLINFO_HTTP_CODE);
         curl_close($curlPing);
 
+        /**
+         *  If HTTP response is something else than 200-299, skip the test
+         */
         if ($httpCode < 200 | $httpCode > 300)
         {
             $this->markTestSkipped("LoremPixel is offline, skipping image download");


### PR DESCRIPTION
Added ```curl``` check to file ```test/Faker/Provider/ImageTest.php``` to test LoremPixel before conducting the unit tests. 

Basically, this check utilises ```curl``` to retrieve HTTP header. If header includes response code which is between 200 and 299, unit tests are being conducted. Otherwise, they are skipped.