### PR TITLE
Fix typo

### DIFF
--- a/src/Faker/Provider/de_AT/Person.php
+++ b/src/Faker/Provider/de_AT/Person.php
@@ -59,7 +59,7 @@ class Person extends \Faker\Provider\Person
         'Alexandra', 'Alexandrea', 'Algelika', 'Alina', 'Amelie', 'Andrea', 'Angelina', 'Anita', 'Anja', 'Anna', 'Anna-Lena', 'Annika', 'Astrid',
         'Barbara', 'Bettina', 'Bianca', 'Birgit',
         'Carina', 'Caroline', 'Celina', 'Chiara', 'Christina', 'Christine', 'Clara', 'Claudia', 'Cornelia',
-        'Daniela', 'Denise', 'Dorins',
+        'Daniela', 'Denise', 'Doris',
         'Elena', 'Elisa', 'Elisabeth', 'Ella', 'Emely', 'Emilia', 'Emily', 'Emma', 'Eva', 'Eva-Maria',
         'Franziska',
         'Hanna', 'Hannah', 'Helena',


### PR DESCRIPTION
Dorins is most likely a typo. While Doris is a common name in Austria, Dorins isn't :smile: