### PR TITLE
Remove jobTitle from readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -170,7 +170,6 @@ Each of the generator properties (like `name`, `address`, and `lorem`) are calle
     bs                      // 'e-enable robust architectures'
     company                 // 'Bogan-Treutel'
     companySuffix           // 'and Sons'
-    jobTitle                // 'Cashier'
 
 ### `Faker\Provider\en_US\Text`
 


### PR DESCRIPTION
Unknown formatter "jobTitle"
README remains the 'jobTitle' property which is already removed from company provider.