### PR TITLE
uk_UA & ru_RU: Removed @license from Text.php

### DIFF
--- a/src/Faker/Provider/ru_RU/Text.php
+++ b/src/Faker/Provider/ru_RU/Text.php
@@ -21,7 +21,6 @@ class Text extends \Faker\Provider\Text
      *
      * Language: Russian
      *
-     * @licence Creative Commons Attribution-ShareAlike https://creativecommons.org/licenses/by-sa/3.0/deed.ru
      * @see     https://wikimediafoundation.org/wiki/Terms_of_Use/
      * @link    http://ru.wikisource.org/wiki/%D0%9C%D1%91%D1%80%D1%82%D0%B2%D1%8B%D0%B5_%D0%B4%D1%83%D1%88%D0%B8_(%D0%93%D0%BE%D0%B3%D0%BE%D0%BB%D1%8C)/%D0%A2%D0%BE%D0%BC_I/%D0%93%D0%BB%D0%B0%D0%B2%D0%B0_I
      * @var string

--- a/src/Faker/Provider/uk_UA/Text.php
+++ b/src/Faker/Provider/uk_UA/Text.php
@@ -21,7 +21,6 @@ class Text extends \Faker\Provider\Text
      *
      * Language: Ukrainian
      *
-     * @licence Creative Commons Attribution-ShareAlike https://creativecommons.org/licenses/by-sa/3.0/deed.ru
      * @see     https://wikimediafoundation.org/wiki/Terms_of_Use/
      * @link    http://uk.wikisource.org/wiki/%D0%97%D0%B0%D1%85%D0%B0%D1%80_%D0%91%D0%B5%D1%80%D0%BA%D1%83%D1%82
      * @var string


### PR DESCRIPTION
Removed ```@license``` from Text.php in both ```uk_UA``` and ```ru_RU``` locales. Since the texts are in public domain no license notice is required. 

This should be the last part of solution to ticket #881.