### PR TITLE
Add a building number with letter to German speaking locales.

### DIFF
--- a/src/Faker/Provider/de_AT/Address.php
+++ b/src/Faker/Provider/de_AT/Address.php
@@ -4,7 +4,7 @@ namespace Faker\Provider\de_AT;
 
 class Address extends \Faker\Provider\Address
 {
-    protected static $buildingNumber = array('###', '##', '#');
+    protected static $buildingNumber = array('###', '##', '#', '##[abc]', '#[abc]');
 
     protected static $streetSuffixLong = array(
         'Gasse', 'Platz', 'Ring', 'Straße', 'Weg',
@@ -107,5 +107,10 @@ class Address extends \Faker\Provider\Address
     public static function state()
     {
         return static::randomElement(static::$state);
+    }
+
+    public static function buildingNumber()
+    {
+        return static::regexify(self::numerify(static::randomElement(static::$buildingNumber)));
     }
 }

--- a/src/Faker/Provider/de_CH/Address.php
+++ b/src/Faker/Provider/de_CH/Address.php
@@ -4,7 +4,7 @@ namespace Faker\Provider\de_CH;
 
 class Address extends \Faker\Provider\Address
 {
-    protected static $buildingNumber = array('###', '##', '#', '#a', '#b', '#c');
+    protected static $buildingNumber = array('###', '##', '#', '##[abc]', '#[abc]');
 
     protected static $streetSuffixLong = array(
         'Gasse', 'Platz', 'Ring', 'Strasse', 'Weg', 'Allee'
@@ -176,5 +176,10 @@ class Address extends \Faker\Provider\Address
     {
         $canton = static::canton();
         return current($canton);
+    }
+
+    public static function buildingNumber()
+    {
+        return static::regexify(self::numerify(static::randomElement(static::$buildingNumber)));
     }
 }

--- a/src/Faker/Provider/de_DE/Address.php
+++ b/src/Faker/Provider/de_DE/Address.php
@@ -4,7 +4,7 @@ namespace Faker\Provider\de_DE;
 
 class Address extends \Faker\Provider\Address
 {
-    protected static $buildingNumber = array('###', '##', '#', '#/#');
+    protected static $buildingNumber = array('###', '##', '#', '#/#', '##[abc]', '#[abc]');
 
     protected static $streetSuffixLong = array(
         'Gasse', 'Platz', 'Ring', 'Straße', 'Weg', 'Allee'
@@ -86,5 +86,10 @@ class Address extends \Faker\Provider\Address
     public static function state()
     {
         return static::randomElement(static::$state);
+    }
+
+    public static function buildingNumber()
+    {
+        return static::regexify(self::numerify(static::randomElement(static::$buildingNumber)));
     }
 }

--- a/test/Faker/Provider/en_SG/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_SG/PhoneNumberTest.php
@@ -7,11 +7,13 @@ use Faker\Provider\en_SG\PhoneNumber;
 
 class PhoneNumberTest extends \PHPUnit_Framework_TestCase
 {
+    private $faker;
+
     public function setUp()
     {
-        $faker = Factory::create('en_SG');
-        $faker->addProvider(new PhoneNumber($faker));
-        $this->faker = $faker;
+        $this->faker = Factory::create('en_SG');
+        $this->faker->seed(1);
+        $this->faker->addProvider(new PhoneNumber($this->faker));
     }
 
     // http://en.wikipedia.org/wiki/Telephone_numbers_in_Singapore#Numbering_plan


### PR DESCRIPTION
In Austria, Germany, and Switzerland a building number can have a letter as a suffix. Example: `Hauptstraße 23a`.