### PR TITLE
Fix: Prefer dependencies installed from dist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 vendor/autoload.php:
-	composer install --no-interaction --prefer-source
+	composer install --no-interaction --prefer-dist
 
 .PHONY: sniff
 sniff: vendor/autoload.php


### PR DESCRIPTION
This PR

* [x] uses the `--prefer-dist` option when installing dependencies in `Makefile` target

💁 It's faster, and it's also more in line with `.travis.yml`