### PR TITLE
Fix: Do not pick a random float less than minimum

### DIFF
--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -110,6 +110,9 @@ class Base
 
         if (null === $max) {
             $max = static::randomNumber();
+            if ($min > $max) {
+                $max = $min;
+            }
         }
 
         if ($min > $max) {


### PR DESCRIPTION
This PR

* [x] fixes an issue where a value generated by `randomFloat($nbMaxDecimals, $min)` can actually be less than `$min`