### PR TITLE
Fix: fix invalid parameter of mb_substr()

### DIFF
--- a/src/Faker/Provider/ja_JP/Text.php
+++ b/src/Faker/Provider/ja_JP/Text.php
@@ -620,7 +620,7 @@ EOT;
     {
         // extract the last char of $text
         if (function_exists('mb_substr')) {
-            $last = mb_substr($text, mb_strlen($text)-1, 'UTF-8');
+            $last = mb_substr($text, mb_strlen($text)-1, null, 'UTF-8');
         } else {
             $chars = static::split($text);
             $last = end($chars);


### PR DESCRIPTION
In this PR, fix bug which call mb_substr() with invalid parameter in ja_JP Text.

error message when call $faker->realText:
`
mb_substr() expects parameter 3 to be integer, string given
`
