### PR TITLE
Added missing grayscale option/flag to Image provider

### DIFF
--- a/src/Faker/Provider/Image.php
+++ b/src/Faker/Provider/Image.php
@@ -52,7 +52,7 @@ class Image extends Base
      *
      * @example '/path/to/dir/13b73edae8443990be1aa8f1a483bc27.jpg'
      */
-    public static function image($dir = null, $width = 640, $height = 480, $category = null, $fullPath = true, $randomize = true, $word = null)
+    public static function image($dir = null, $width = 640, $height = 480, $category = null, $fullPath = true, $randomize = true, $word = null, $gray = false)
     {
         $dir = is_null($dir) ? sys_get_temp_dir() : $dir; // GNU/Linux / OS X / Windows compatible
         // Validate directory path
@@ -66,7 +66,7 @@ class Image extends Base
         $filename = $name .'.jpg';
         $filepath = $dir . DIRECTORY_SEPARATOR . $filename;
 
-        $url = static::imageUrl($width, $height, $category, $randomize, $word);
+        $url = static::imageUrl($width, $height, $category, $randomize, $word, $gray);
 
         // save file
         if (function_exists('curl_exec')) {


### PR DESCRIPTION
LoremPixel offers a grayscale option which was already available in the `imageUrl` method in the Image provider; however, this option was missing in the`image` method.
