### PR TITLE
Adds generators for Norwegian (nb_NO) counties and "kommune", using existing static arrays in the class

### DIFF
--- a/src/Faker/Provider/nb_NO/Address.php
+++ b/src/Faker/Provider/nb_NO/Address.php
@@ -173,6 +173,16 @@ class Address extends \Faker\Provider\Address
         return static::randomElement(static::$cityNames);
     }
 
+    public static function kommune()
+    {
+        return static::randomElement(static::$kommuneNames);
+    }
+
+    public static function county()
+    {
+        return static::randomElement(static::$countyNames);
+    }
+
     public static function streetSuffixWord()
     {
         return static::randomElement(static::$streetSuffixWord);


### PR DESCRIPTION
The static arrays for "countyNames" and "kommuneNames" were already present in the class to seed the random selection groups, there were just not accessor methods to generate a county or a "kommune". This commit just adds in these accessor methods.
