### PR TITLE
Fix EAN8 checkSum generator

### DIFF
--- a/src/Faker/Provider/Barcode.php
+++ b/src/Faker/Provider/Barcode.php
@@ -20,7 +20,7 @@ class Barcode extends Base
      */
     protected static function eanChecksum($input)
     {
-        $sequence = (strlen($input) - 1) === 8 ? array(3, 1) : array(1, 3);
+        $sequence = (strlen($input) + 1) === 8 ? array(3, 1) : array(1, 3);
         $sums = 0;
         foreach (str_split($input) as $n => $digit) {
             $sums += $digit * $sequence[$n % 2];


### PR DESCRIPTION
Fix eanChecksum function who check bad length for input. Correct sequence for ean8 checkSum is 3, 1 and not 1, 3. [See on Wikipedia](https://fr.wikipedia.org/wiki/EAN_8).
@fzaninotto Sorry for #950, it was a PR demo for web training session :smiley: