### PR TITLE
fix 32bits issue

### DIFF
--- a/src/Faker/Provider/DateTime.php
+++ b/src/Faker/Provider/DateTime.php
@@ -62,8 +62,9 @@ class DateTime extends Base
      */
     public static function dateTimeAD($max = 'now', $timezone = null)
     {
+        $min = (PHP_INT_SIZE>4 ? -62135597361 : -PHP_INT_MAX);
         return static::setTimezone(
-            new \DateTime('@' . mt_rand(-62135597361, static::getMaxTimestamp($max))),
+            new \DateTime('@' . mt_rand($min, static::getMaxTimestamp($max))),
             (null === $timezone ? date_default_timezone_get() : $timezone)
         );
     }

--- a/src/Faker/Provider/Internet.php
+++ b/src/Faker/Provider/Internet.php
@@ -185,10 +185,10 @@ class Internet extends \Faker\Provider\Base
     {
         if (static::numberBetween(0, 1) === 0) {
             // 10.x.x.x range
-            $ip = long2ip(static::numberBetween(167772160, 184549375));
+            $ip = long2ip(static::numberBetween(ip2long("10.0.0.0"), ip2long("10.255.255.255")));
         } else {
             // 192.168.x.x range
-            $ip = long2ip(static::numberBetween(3232235520, 3232301055));
+            $ip = long2ip(static::numberBetween(ip2long("192.168.0.0"), ip2long("192.168.255.255")));
         }
 
         return $ip;


### PR DESCRIPTION
From Fedora QA, on 32bits
```
There were 2 errors:
1) Faker\Test\Provider\DateTimeTest::testDateTimeAD
mt_rand() expects parameter 1 to be integer, float given
/builddir/build/BUILDROOT/php-Faker-1.5.0-5.fc25.noarch/usr/share/php/Faker/Provider/DateTime.php:56
/builddir/build/BUILD/Faker-d0190b156bcca848d401fb80f31f504f37141c8d/test/Faker/Provider/DateTimeTest.php:27
2) Faker\Test\Provider\DateTimeTest::testFixedSeedWithMaximumTimestamp
mt_rand() expects parameter 1 to be integer, float given
/builddir/build/BUILDROOT/php-Faker-1.5.0-5.fc25.noarch/usr/share/php/Faker/Provider/DateTime.php:56
/builddir/build/BUILD/Faker-d0190b156bcca848d401fb80f31f504f37141c8d/test/Faker/Provider/DateTimeTest.php:83

```