### PR TITLE
fix [zh_CN]PhoneNumber illegal operator prefix

### DIFF
--- a/src/Faker/Provider/zh_CN/PhoneNumber.php
+++ b/src/Faker/Provider/zh_CN/PhoneNumber.php
@@ -5,11 +5,10 @@ namespace Faker\Provider\zh_CN;
 class PhoneNumber extends \Faker\Provider\PhoneNumber
 {
     protected static $operators = array(
-        1340, 1341, 1342, 1343, 1344, 1345, 1346, 1347, 1348, 135, 136, 137, 138, 139, 147, 150, 151, 152, 157, 158, 159, 1705, 178, 182, 183, 184, 187, 188, // China Mobile
+        134, 135, 136, 137, 138, 139, 147, 150, 151, 152, 157, 158, 159, 1705, 178, 182, 183, 184, 187, 188, // China Mobile
         130, 131, 132, 145, 155, 156, 1707, 1708, 1709, 1718, 1719, 176, 185, 186, // China Unicom
-        133, 149, 153, 1700, 1701, 177, 180, 181, 189, // China Telecom
+        133, 153, 1700, 1701, 177, 180, 181, 189, // China Telecom
         170, 171, // virtual operators
-        1349, // ChinaSat
     );
 
     protected static $formats = array('###########');

--- a/src/Faker/Provider/zh_CN/PhoneNumber.php
+++ b/src/Faker/Provider/zh_CN/PhoneNumber.php
@@ -5,18 +5,20 @@ namespace Faker\Provider\zh_CN;
 class PhoneNumber extends \Faker\Provider\PhoneNumber
 {
     protected static $operators = array(
-        134, 135, 136, 137, 138, 139, 147, 150, 151, 152, 157, 158, 159, 178, 182, 183, 184, 187, 188, // china mobile
-        130, 131, 132, 145, 155, 156, 175, 176, 185, 186, // china unicom
-        133, 149, 153, 177, 180, 181, 189, // chinatelecom
+        1340, 1341, 1342, 1343, 1344, 1345, 1346, 1347, 1348, 135, 136, 137, 138, 139, 147, 150, 151, 152, 157, 158, 159, 1705, 178, 182, 183, 184, 187, 188, // China Mobile
+        130, 131, 132, 145, 155, 156, 1707, 1708, 1709, 1718, 1719, 176, 185, 186, // China Unicom
+        133, 149, 153, 1700, 1701, 177, 180, 181, 189, // China Telecom
         170, 171, // virtual operators
+        1349, // ChinaSat
     );
 
-    protected static $formats = array('########');
+    protected static $formats = array('###########');
 
     public function phoneNumber()
     {
-        $operators = static::randomElement(static::$operators);
+        $operator = static::randomElement(static::$operators);
+        $format = static::randomElement(static::$formats);
 
-        return $operators . static::numerify(static::randomElement(static::$formats));
+        return $operator . static::numerify(substr($format, 0, strlen($format) - strlen($operator)));
     }
 }


### PR DESCRIPTION
- remove 175 (illegal)
- according to https://en.wikipedia.org/wiki/Telephone_numbers_in_China