### PR TITLE
Implement singleton for Faker\Factory class

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -95,6 +95,16 @@ for ($i=0; $i < 10; $i++) {
 
 **Tip**: For a quick generation of fake data, you can also use Faker as a command line tool thanks to [faker-cli](https://github.com/bit3/faker-cli).
 
+### As Singleton
+
+You may also reuse the same instance for each locale. Useful if you're running into memory issues due to many instances of Faker being created.
+
+```php
+// Loads a previously created instance for the given locale
+// If none exists, a new one is created through Faker\Factory::create()
+$faker = Faker\Factory::load();
+```
+
 ## Formatters
 
 Each of the generator properties (like `name`, `address`, and `lorem`) are called "formatters". A faker generator has many of them, packaged in "providers". Here is a list of the bundled formatters in the default locale.

--- a/src/Faker/Factory.php
+++ b/src/Faker/Factory.php
@@ -8,6 +8,22 @@ class Factory
 
     protected static $defaultProviders = array('Address', 'Barcode', 'Biased', 'Color', 'Company', 'DateTime', 'File', 'Image', 'Internet', 'Lorem', 'Miscellaneous', 'Payment', 'Person', 'PhoneNumber', 'Text', 'UserAgent', 'Uuid');
 
+    private static $instances = [];
+
+    /**
+     * Singleton
+     *
+     * @param string $locale
+     * @return Generator
+     */
+    public static function load($locale = self::DEFAULT_LOCALE)
+    {
+        if (!isset(self::$instances[$locale])) {
+            self::$instances[$locale] = self::create($locale);
+        }
+        return self::$instances[$locale];
+    }
+
     /**
      * Create a new generator
      * 

--- a/src/Faker/Factory.php
+++ b/src/Faker/Factory.php
@@ -8,7 +8,7 @@ class Factory
 
     protected static $defaultProviders = array('Address', 'Barcode', 'Biased', 'Color', 'Company', 'DateTime', 'File', 'Image', 'Internet', 'Lorem', 'Miscellaneous', 'Payment', 'Person', 'PhoneNumber', 'Text', 'UserAgent', 'Uuid');
 
-    private static $instances = [];
+    private static $instances;
 
     /**
      * Singleton
@@ -18,6 +18,9 @@ class Factory
      */
     public static function load($locale = self::DEFAULT_LOCALE)
     {
+        if (self::$instances === null) {
+            self::$instances = array();
+        }
         if (!isset(self::$instances[$locale])) {
             self::$instances[$locale] = self::create($locale);
         }


### PR DESCRIPTION
Ran into memory issues when seeding the project database. Several instances of Faker were being created in different loops for different locales, and turns out that `realText()` loads up a huge text chunk to the memory *per instance*. 

Therefore implemented a simple singleton solution to make it possible reuse previously created instances of Faker. A simple test shows the huge difference between reusing instances or not:

```php
// New instances, NO singleton
for ($i = 0; $i < 20; $i++) {
    $faker = Faker\Factory::create();
    $faker->realText(30, 5); // Memory eater
    $mem = memory_get_peak_usage(true) / 1024 / 1024;
    echo "Loop: {$i} - Mem: {$mem}Mb\n";
}
```

> Loop: 0 - Mem: 24Mb
Loop: 1 - Mem: 38Mb
Loop: 2 - Mem: 50Mb
Loop: 3 - Mem: 64Mb
Loop: 4 - Mem: 78Mb
Loop: 5 - Mem: 92Mb
Loop: 6 - Mem: 106Mb
Loop: 7 - Mem: 120Mb
PHP Fatal error:  Allowed memory size of 134217728 bytes exhausted (tried to allocate 4096 bytes) in /Users/mathielo/projects/marketplace-api/vendor/fzaninotto/faker/src/Faker/Provider/Text.php on line 121

Now reusing instances:

```php
for ($i = 0; $i < 20; $i++) {
//    $faker = Faker\Factory::create();
    $faker = Faker\Factory::load();
    $faker->realText(30, 5); // Memory eater
    $mem = memory_get_peak_usage(true) / 1024 / 1024;
    echo "Loop: {$i} - Mem: {$mem}Mb\n";
}
```

> Loop: 0 - Mem: 24Mb
Loop: 1 - Mem: 24Mb
Loop: 2 - Mem: 24Mb
Loop: 3 - Mem: 24Mb
Loop: 4 - Mem: 24Mb
Loop: 5 - Mem: 24Mb
Loop: 6 - Mem: 24Mb
Loop: 7 - Mem: 24Mb
Loop: 8 - Mem: 24Mb
Loop: 9 - Mem: 24Mb
Loop: 10 - Mem: 24Mb
Loop: 11 - Mem: 24Mb
Loop: 12 - Mem: 24Mb
Loop: 13 - Mem: 24Mb
Loop: 14 - Mem: 24Mb
Loop: 15 - Mem: 24Mb
Loop: 16 - Mem: 24Mb
Loop: 17 - Mem: 24Mb
Loop: 18 - Mem: 24Mb
Loop: 19 - Mem: 24Mb

Ideally I'd have the singleton as default behaviour for `Factory::create()` but not sure if it'd break backwards compatibility or if a **new** instance is **needed** by default. 

Also thought of having something like `Factory::create($locale = self::DEFAULT_LOCALE, $newInstance = true){}` but seems dirty. Feel free to suggest any changes.

No tests were written as there were no changes to Generator / Providers.