### PR TITLE
fix mb_substr missing parameter error when generating japanese string with realText method

### DIFF
--- a/src/Faker/Provider/ja_JP/Text.php
+++ b/src/Faker/Provider/ja_JP/Text.php
@@ -620,7 +620,7 @@ EOT;
     {
         // extract the last char of $text
         if (function_exists('mb_substr')) {
-            $last = mb_substr($text, 0, mb_strlen($text) - 1, null, 'UTF-8');
+            $last = mb_substr($text, 0, mb_strlen($text) - 1, 'UTF-8');
         } else {
             $chars = static::split($text);
             $last = end($chars);

--- a/src/Faker/Provider/ja_JP/Text.php
+++ b/src/Faker/Provider/ja_JP/Text.php
@@ -620,7 +620,7 @@ EOT;
     {
         // extract the last char of $text
         if (function_exists('mb_substr')) {
-            $last = mb_substr($text, mb_strlen($text)-1, null, 'UTF-8');
+            $last = mb_substr($text, 0, mb_strlen($text) - 1, null, 'UTF-8');
         } else {
             $chars = static::split($text);
             $last = end($chars);
@@ -630,6 +630,6 @@ EOT;
             $text = preg_replace('/.$/u', '', $text);
         }
         // if the last char is not a valid punctuation, append a default one.
-        return in_array($last, static::$endPunct) ? $text : $text.'。';
+        return in_array($last, static::$endPunct) ? $text : $text . '。';
     }
 }


### PR DESCRIPTION
fix mb_substr missing parameter error when generating japanese string with realText method