### PR TITLE
Replaces main image funcationality with Unsplash.it to support SSL.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -258,16 +258,14 @@ Each of the generator properties (like `name`, `address`, and `lorem`) are calle
 
 ### `Faker\Provider\Image`
 
-    // Image generation provided by LoremPixel (http://lorempixel.com/)
-    imageUrl($width = 640, $height = 480) // 'http://lorempixel.com/640/480/'
-    imageUrl($width, $height, 'cats')     // 'http://lorempixel.com/800/600/cats/'
-    imageUrl($width, $height, 'cats', true, 'Faker') // 'http://lorempixel.com/800/400/cats/Faker'
-    imageUrl($width, $height, 'cats', true, 'Faker', true) // 'http://lorempixel.com/grey/800/400/cats/Faker/' Monochrome image
+    // Image generation provided by UnpslashIt (https://unsplash.it/)
+    imageUrl($width = 640, $height = 480) // 'https://unsplash.it/640/480/'
+	// Category-Based images provided by LoremPixel
+	imageUrl($width, $height, 'cats')     // 'https://lorempixel.com/800/600/cats/'
+    imageUrl($width, $height, 'cats', true, 'Faker') // 'https://lorempixel.com/800/400/cats/Faker'
     image($dir = '/tmp', $width = 640, $height = 480) // '/tmp/13b73edae8443990be1aa8f1a483bc27.jpg'
     image($dir, $width, $height, 'cats')  // 'tmp/13b73edae8443990be1aa8f1a483bc27.jpg' it's a cat!
-    image($dir, $width, $height, 'cats', false) // '13b73edae8443990be1aa8f1a483bc27.jpg' it's a filename without path
-    image($dir, $width, $height, 'cats', true, false) // it's a no randomize images (default: `true`)
-    image($dir, $width, $height, 'cats', true, true, 'Faker') // 'tmp/13b73edae8443990be1aa8f1a483bc27.jpg' it's a cat with 'Faker' text. Default, `null`.
+    image($dir, $width, $height, 'cats', true, 'Faker') // 'tmp/13b73edae8443990be1aa8f1a483bc27.jpg' it's a cat with Faker text
 
 ### `Faker\Provider\Uuid`
 

--- a/src/Faker/Provider/Image.php
+++ b/src/Faker/Provider/Image.php
@@ -3,32 +3,35 @@
 namespace Faker\Provider;
 
 /**
- * Depends on image generation from http://lorempixel.com/
+ * Depends on image generation from https://unsplash.it/.
  */
 class Image extends Base
 {
     protected static $categories = array(
         'abstract', 'animals', 'business', 'cats', 'city', 'food', 'nightlife',
-        'fashion', 'people', 'nature', 'sports', 'technics', 'transport'
+        'fashion', 'people', 'nature', 'sports', 'technics', 'transport',
     );
 
     /**
-     * Generate the URL that will return a random image
+     * Generate the URL that will return a random image.
      *
      * Set randomize to false to remove the random GET parameter at the end of the url.
      *
-     * @example 'http://lorempixel.com/640/480/?12345'
+     * @example 'https://unsplash.it/640/480/?12345'
      */
-    public static function imageUrl($width = 640, $height = 480, $category = null, $randomize = true, $word = null, $gray = false)
+    public static function imageUrl($width = 640, $height = 480, $category = null, $randomize = true, $word = null, $gray = false, $blur = false, $gravity = null)
     {
-        $baseUrl = "http://lorempixel.com/";
+        $baseUrl = 'https://unsplash.it/';
         $url = "{$width}/{$height}/";
-        
+        $query_params = [];
+
         if ($gray) {
-            $url = "gray/" . $url;
+            $url = 'g/'.$url;
         }
-        
+
         if ($category) {
+            // only support categories for lorempixel
+            $baseUrl = 'http://lorempixel.com/';
             if (!in_array($category, static::$categories)) {
                 throw new \InvalidArgumentException(sprintf('Unknown image category "%s"', $category));
             }
@@ -39,14 +42,25 @@ class Image extends Base
         }
 
         if ($randomize) {
-            $url .= '?' . static::randomNumber(5, true);
+            $rand_string = ($category) ? static::randomNumber(5, true) : 'random';
+            array_push($query_params, $rand_string);
         }
 
-        return $baseUrl . $url;
+        if ($blur) {
+            array_push($query_params, 'blur');
+        }
+
+        if ($gravity) {
+            array_push($query_params, 'gravity');
+        }
+
+        $append = (count($query_params)) ? '?'.implode('&', $query_params) : '';
+
+        return $baseUrl.$url.$append;
     }
 
     /**
-     * Download a remote random image to disk and return its location
+     * Download a remote random image to disk and return its location.
      *
      * Requires curl, or allow_url_fopen to be on in php.ini.
      *

--- a/test/Faker/Provider/ImageTest.php
+++ b/test/Faker/Provider/ImageTest.php
@@ -8,12 +8,12 @@ class ImageTest extends \PHPUnit_Framework_TestCase
 {
     public function testImageUrlUses640x680AsTheDefaultSize()
     {
-        $this->assertRegExp('#^http://lorempixel.com/640/480/#', Image::imageUrl());
+        $this->assertRegExp('#^https://unsplash.it/640/480/#', Image::imageUrl());
     }
 
     public function testImageUrlAcceptsCustomWidthAndHeight()
     {
-        $this->assertRegExp('#^http://lorempixel.com/800/400/#', Image::imageUrl(800, 400));
+        $this->assertRegExp('#^https://unsplash.it/800/400/#', Image::imageUrl(800, 400));
     }
 
     public function testImageUrlAcceptsCustomCategory()
@@ -45,7 +45,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
 
     public function testDownloadWithDefaults()
     {
-        $url = "http://www.lorempixel.com/";
+        $url = 'http://www.lorempixel.com/';
         $curlPing = curl_init($url);
         curl_setopt($curlPing, CURLOPT_TIMEOUT, 5);
         curl_setopt($curlPing, CURLOPT_CONNECTTIMEOUT, 5);
@@ -55,7 +55,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
         curl_close($curlPing);
 
         if ($httpCode < 200 | $httpCode > 300) {
-            $this->markTestSkipped("LoremPixel is offline, skipping image download");
+            $this->markTestSkipped('LoremPixel is offline, skipping image download');
         }
 
         $file = Image::image(sys_get_temp_dir());


### PR DESCRIPTION
Ran into an issue with consuming an API via iOS and learned that [iOS9 will enforce ATS])(http://www.techrepublic.com/article/wwdc-2016-apple-to-require-https-encryption-on-all-ios-apps-by-2017/), as such non-SSL images will not display. 

Since Lorempixel does not support SSL, switching provider to Unsplash.it, while not allowing categories (built-in fallback support for categories to rely on LoremPixel), UnSpash does offer some other features, such as directional cropping and blurring, both of which I've added to the functionality by appending parameters to the imageURL function. 

This fix may better be supported by waiting until new version and dropping LoremPixel (i.e. category support) altogether or choosing another SSL-enabled vendor that provides categories.

Just my $0.02! 