### PR TITLE
Add generation for free dynamic emails

### DIFF
--- a/src/Faker/Provider/Internet.php
+++ b/src/Faker/Provider/Internet.php
@@ -6,6 +6,7 @@ class Internet extends \Faker\Provider\Base
 {
     protected static $freeEmailDomain = array('gmail.com', 'yahoo.com', 'hotmail.com');
     protected static $tld = array('com', 'com', 'com', 'com', 'com', 'com', 'biz', 'info', 'net', 'org');
+    protected static $dynamicEmailDomain = array('maildrop.cc', 'yopmail.com', 'mailinator.com');
 
     protected static $userNameFormats = array(
         '{{lastName}}.{{firstName}}',
@@ -57,6 +58,14 @@ class Internet extends \Faker\Provider\Base
     }
 
     /**
+     * @example 'jdoe@gmail.com'
+     */
+    public function dynamicEmail()
+    {
+        return preg_replace('/\s/u', '', $this->userName() . '@' . static::dynamicEmailDomain());
+    }
+
+    /**
      * @example 'jdoe@dawson.com'
      */
     public function companyEmail()
@@ -70,6 +79,14 @@ class Internet extends \Faker\Provider\Base
     public static function freeEmailDomain()
     {
         return static::randomElement(static::$freeEmailDomain);
+    }
+
+    /**
+     * @example 'maildrop.cc'
+     */
+    public static function dynamicEmailDomain()
+    {
+        return static::randomElement(static::$dynamicEmailDomain);
     }
 
     /**


### PR DESCRIPTION
Add generation for dynamic and free emails on: [maildrop.cc](maildrop.cc), [yopmail.com](yopmail.com), [mailinator.com](mailinator.com).
Will allow emails sent for created inboxes can be read facilitating testing and preventing spam.

Generated emails has no signups, no passwords, is designed for no security, is designed for little to no privacy, to offers the ability to give out a quick e-mail address to your site or app, helps to stop your inbox from getting flooded with tests from that one time you are testing your application. 

You can read emails accessing these links:
```
https://maildrop.cc/inbox/<generated_email>
http://www.yopmail.com/<generated_email>
https://www.mailinator.com/inbox2.jsp?public_to=<generated_email>

PS: generated email without [@...]
```

@fzaninotto, what do you think about?