### PR TITLE
Ensure unique IDs in randomHtml

### DIFF
--- a/src/Faker/Provider/HtmlLorem.php
+++ b/src/Faker/Provider/HtmlLorem.php
@@ -3,6 +3,7 @@
 namespace Faker\Provider;
 
 use Faker\Generator;
+use Faker\UniqueGenerator;
 
 class HtmlLorem extends Base
 {
@@ -30,6 +31,8 @@ class HtmlLorem extends Base
     const INPUT_TAG = "input";
     const LABEL_TAG = "label";
 
+    private $idGenerator;
+
     public function __construct(Generator $generator)
     {
         parent::__construct($generator);
@@ -43,6 +46,7 @@ class HtmlLorem extends Base
     public function randomHtml($maxDepth = 4, $maxWidth = 4)
     {
         $document = new \DOMDocument();
+        $this->idGenerator = new UniqueGenerator($this->generator, 10000);
 
         $head = $document->createElement("head");
         $this->addRandomTitle($head);
@@ -122,7 +126,7 @@ class HtmlLorem extends Base
                 $node->setAttribute("class", $this->generator->word);
                 break;
             case 2:
-                $node->setAttribute("id", (string)$this->generator->randomNumber(5));
+                $node->setAttribute("id", (string)$this->idGenerator->randomNumber(5));
                 break;
         }
     }

--- a/src/Faker/Provider/HtmlLorem.php
+++ b/src/Faker/Provider/HtmlLorem.php
@@ -46,7 +46,7 @@ class HtmlLorem extends Base
     public function randomHtml($maxDepth = 4, $maxWidth = 4)
     {
         $document = new \DOMDocument();
-        $this->idGenerator = new UniqueGenerator($this->generator, 10000);
+        $this->idGenerator = new UniqueGenerator($this->generator);
 
         $head = $document->createElement("head");
         $this->addRandomTitle($head);

--- a/src/Faker/UniqueGenerator.php
+++ b/src/Faker/UniqueGenerator.php
@@ -16,7 +16,7 @@ class UniqueGenerator
      * @param Generator $generator
      * @param $maxRetries
      */
-    public function __construct(Generator $generator, $maxRetries)
+    public function __construct(Generator $generator, $maxRetries = 10000)
     {
         $this->generator = $generator;
         $this->maxRetries = $maxRetries;


### PR DESCRIPTION
In case of duplicate IDs the method fails.
Considering the small 5-digit-max range [0,99999] that's quite probable, and I [encountered it](https://travis-ci.org/fzaninotto/Faker/jobs/169501052#L282).
I did not increase the number of digits to be safe concerning BC.

A few notes about why I did the implementation as so:
* Doing `$this->unique()` or `$this->generator->unique()` would "pollute" (or be polluted by) the unique pool for `randomNumber` in other parts of the application.
* We want a fresh unique pool for each call to `randomHtml()`.

<br>ping @rudkjobing :)