### PR TITLE
Made unformatted and international formats configurable

### DIFF
--- a/src/Faker/Provider/en_ZA/PhoneNumber.php
+++ b/src/Faker/Provider/en_ZA/PhoneNumber.php
@@ -5,15 +5,13 @@ namespace Faker\Provider\en_ZA;
 class PhoneNumber extends \Faker\Provider\PhoneNumber
 {
     protected static $formats = array(
-        '+27({{areaCode}})#######',
-        '+27{{areaCode}}#######',
+        '0({{areaCode}})#######',
         '0{{areaCode}}#######',
         '0{{areaCode}} ### ####',
         '0{{areaCode}}-###-####',
     );
 
     protected static $cellphoneFormats = array(
-        '+27{{cellphoneCode}}#######',
         '0{{cellphoneCode}}#######',
         '0{{cellphoneCode}} ### ####',
         '0{{cellphoneCode}}-###-####',
@@ -27,7 +25,10 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     );
 
     protected static $tollFreeAreaCodes = array(
-        '0800', '0860', '0861', '0862',
+        '0800',
+        '0860',
+        '0861',
+        '0862',
     );
 
     /**
@@ -60,6 +61,32 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
         return implode('', $digits);
     }
 
+    /**
+     * @param bool $formatted
+     * @param bool $international
+     *
+     * @return string
+     */
+    public function phoneNumber($formatted = true, $international = false)
+    {
+        $format = static::randomElement(static::$formats);
+
+        $number = self::numerify($this->generator->parse($format));
+
+        if (!$formatted) {
+            $number = trim(str_replace(array('(', ')', '-', ' '), '', $number));
+        }
+
+        if ($international) {
+            $number = preg_replace('/(^[0])/', '+27', $number);
+        }
+
+        return $number;
+    }
+
+    /**
+     * @return string
+     */
     public static function cellphoneCode()
     {
         $digits[] = self::numberBetween(6, 8);
@@ -79,22 +106,52 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
         return implode('', $digits);
     }
 
+    /**
+     * @return string
+     */
     public static function specialCode()
     {
         return static::randomElement(static::$tollFreeAreaCodes);
     }
 
-    public function mobileNumber()
+    /**
+     * @param bool $formatted
+     * @param bool $international
+     *
+     * @return string
+     */
+    public function mobileNumber($formatted = true, $international = false)
     {
         $format = static::randomElement(static::$cellphoneFormats);
 
-        return self::numerify($this->generator->parse($format));
+        $number = self::numerify($this->generator->parse($format));
+
+        if (!$formatted) {
+            $number = trim(str_replace(array('(', ')', '-', ' '), '', $number));
+        }
+
+        if ($international) {
+            $number = preg_replace('/(^[0])/', '+27', $number);
+        }
+
+        return $number;
     }
 
-    public function tollFreeNumber()
+    /**
+     * @param bool $formatted
+     *
+     * @return string
+     */
+    public function tollFreeNumber($formatted = true)
     {
         $format = static::randomElement(static::$specialFormats);
 
-        return self::numerify($this->generator->parse($format));
+        $number = self::numerify($this->generator->parse($format));
+
+        if (!$formatted) {
+            $number = trim(str_replace(array('(', ')', '-', ' '), '', $number));
+        }
+
+        return $number;
     }
 }

--- a/test/Faker/Provider/en_ZA/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_ZA/PhoneNumberTest.php
@@ -18,48 +18,92 @@ class PhoneNumberTest extends \PHPUnit_Framework_TestCase
 
     public function testPhoneNumber()
     {
-        for ($i = 0; $i < 10; $i++) {
+        for ($i = 0; $i < 5; $i++) {
             $number = $this->faker->phoneNumber;
 
             $digits = array_values(array_filter(str_split($number), 'ctype_digit'));
 
-            // 10 digits
-            if($digits[0] = 2 && $digits[1] == 7) {
-                $this->assertLessThanOrEqual(11, count($digits));
-            } else {
-                $this->assertGreaterThanOrEqual(10, count($digits));
-            }
+            $this->assertEquals(10, count($digits));
+            $this->assertEquals('0', $digits[0]);
         }
     }
 
     public function testTollFreePhoneNumber()
     {
-        for ($i = 0; $i < 10; $i++) {
+        for ($i = 0; $i < 5; $i++) {
             $number = $this->faker->tollFreeNumber;
             $digits = array_values(array_filter(str_split($number), 'ctype_digit'));
 
-            if (count($digits) === 11) {
-                $this->assertEquals('0', $digits[0]);
-            }
-
             $areaCode = $digits[0] . $digits[1] . $digits[2] . $digits[3];
+
+            $this->assertEquals('0', $digits[0]);
             $this->assertContains($areaCode, array('0800', '0860', '0861', '0862'));
         }
     }
 
     public function testCellPhoneNumber()
     {
-        for ($i = 0; $i < 10; $i++) {
+        for ($i = 0; $i < 5; $i++) {
             $number = $this->faker->mobileNumber;
             $digits = array_values(array_filter(str_split($number), 'ctype_digit'));
 
-            if($digits[0] = 2 && $digits[1] == 7) {
-                $this->assertLessThanOrEqual(11, count($digits));
-            } else {
-                $this->assertGreaterThanOrEqual(10, count($digits));
-            }
-
+            $this->assertEquals(10, count($digits));
             $this->assertRegExp('/^(\+27|27)?(\()?0?([6][0-4]|[7][1-9]|[8][1-9])(\))?( |-|\.|_)?(\d{3})( |-|\.|_)?(\d{4})/', $number);
+        }
+    }
+
+    public function testUnformattedPhoneNumber()
+    {
+        for ($i = 0; $i < 5; $i++) {
+            $number = $this->faker->phoneNumber(false);
+
+            $digits = array_values(array_filter(str_split($number), 'ctype_digit'));
+
+            $this->assertEquals(10, count($digits));
+        }
+    }
+
+    public function testInternationalPhoneNumber()
+    {
+        for ($i = 0; $i < 5; $i++) {
+            $number = $this->faker->phoneNumber(false, true);
+
+            $digits = array_values(array_filter(str_split($number), 'ctype_digit'));
+
+            $this->assertEquals(11, count($digits));
+            $this->assertEquals('+27', substr($number, 0, 3));
+        }
+    }
+
+    public function testUnformattedTollFreeNumber() {
+        for ($i = 0; $i < 5; $i++) {
+            $number = $this->faker->tollFreeNumber(false);
+            $digits = array_values(array_filter(str_split($number), 'ctype_digit'));
+
+            $areaCode = $digits[0] . $digits[1] . $digits[2] . $digits[3];
+            $this->assertContains($areaCode, array('0800', '0860', '0861', '0862'));
+            $this->assertEquals(0, preg_match('/[-()\s]/', $number));
+        }
+    }
+
+    public function testUnformattedCellPhoneNumber() {
+        for ($i = 0; $i < 5; $i++) {
+            $number = $this->faker->mobileNumber(false);
+            $digits = array_values(array_filter(str_split($number), 'ctype_digit'));
+
+            $this->assertEquals(10, count($digits));
+            $this->assertEquals(0, preg_match('/[-()\s]/', $number));
+        }
+    }
+
+    public function testInternationalCellPhoneNumber() {
+        for ($i = 0; $i < 5; $i++) {
+            $number = $this->faker->mobileNumber(false, true);
+            $digits = array_values(array_filter(str_split($number), 'ctype_digit'));
+
+            $this->assertEquals(11, count($digits));
+            $this->assertEquals('+27', substr($number, 0, 3));
+            $this->assertEquals(0, preg_match('/[-()\s]/', $number));
         }
     }
 }


### PR DESCRIPTION
Added ability to choose whether one wants a formatted or unformatted phone numbers, which can now also optionally be returned in international format.
- Formatted numbers could contain brackets, dashes and spaces, where unformatted numbers wont have any of those.
  - International format numbers will always start with '+27' instead of '0'
- Added unit tests to test new functionality
