### PR TITLE
Adding in Master of Divinity Suffix

### DIFF
--- a/src/Faker/Provider/en_US/Person.php
+++ b/src/Faker/Provider/en_US/Person.php
@@ -107,7 +107,7 @@ class Person extends \Faker\Provider\Person
         'Zboncak', 'Zemlak', 'Ziemann', 'Zieme', 'Zulauf'
     );
 
-    private static $suffix = array('Jr.', 'Sr.', 'I', 'II', 'III', 'IV', 'V', 'MD', 'DDS', 'PhD', 'DVM');
+    private static $suffix = array('Jr.', 'Sr.', 'I', 'II', 'III', 'IV', 'V', 'MD', 'DDS', 'PhD', 'DVM', 'MDiv');
 
     /**
      * @example 'PhD'


### PR DESCRIPTION
This is important because it is four characters long.
