### PR TITLE
Fixed Issue #1086

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
 composer.lock
+/nbproject/private/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 vendor
 composer.lock
-/nbproject/private/

--- a/src/Faker/Provider/en_ZA/Person.php
+++ b/src/Faker/Provider/en_ZA/Person.php
@@ -18,7 +18,7 @@ class Person extends \Faker\Provider\Person
         '{{firstNameFemale}} {{lastName}}',
         '{{firstNameFemale}} {{lastName}}',
         '{{firstNameFemale}} {{lastName}}',
-        '{{titleFemale}} {{$firstNameFemale}} {{lastName}}',
+        '{{titleFemale}} {{firstNameFemale}} {{lastName}}',
     );
 
     protected static $firstNameMale = array(


### PR DESCRIPTION
There was an extra ```$``` sign which caused the template to break. This has now been amended.  Fixes #1086.

Thank you.