### PR TITLE
Introduced the ability to specify the timezone for dateTimeThis*() methods

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -187,10 +187,10 @@ Each of the generator properties (like `name`, `address`, and `lorem`) are calle
     time($format = 'H:i:s', $max = 'now') // '20:49:42'
     dateTimeBetween($startDate = '-30 years', $endDate = 'now', $timezone = date_default_timezone_get()) // DateTime('2003-03-15 02:00:49', 'Africa/Lagos')
     dateTimeInInterval($startDate = '-30 years', $interval = '+ 5 days', $timezone = date_default_timezone_get()) // DateTime('2003-03-15 02:00:49', 'Antartica/Vostok')
-    dateTimeThisCentury($max = 'now')     // DateTime('1915-05-30 19:28:21')
-    dateTimeThisDecade($max = 'now')      // DateTime('2007-05-29 22:30:48')
-    dateTimeThisYear($max = 'now')        // DateTime('2011-02-27 20:52:14')
-    dateTimeThisMonth($max = 'now')       // DateTime('2011-10-23 13:46:23')
+    dateTimeThisCentury($max = 'now', $timezone = date_default_timezone_get())     // DateTime('1915-05-30 19:28:21', 'UTC')
+    dateTimeThisDecade($max = 'now', $timezone = date_default_timezone_get())      // DateTime('2007-05-29 22:30:48', 'Europe/Paris')
+    dateTimeThisYear($max = 'now', $timezone = date_default_timezone_get())        // DateTime('2011-02-27 20:52:14', 'Africa/Lagos')
+    dateTimeThisMonth($max = 'now', $timezone = date_default_timezone_get())       // DateTime('2011-10-23 13:46:23', 'Antarctica/Vostok')
     amPm($max = 'now')                    // 'pm'
     dayOfMonth($max = 'now')              // '04'
     dayOfWeek($max = 'now')               // 'Friday'

--- a/src/Faker/Provider/DateTime.php
+++ b/src/Faker/Provider/DateTime.php
@@ -168,42 +168,46 @@ class DateTime extends Base
 
     /**
      * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
+     * @param string $timezone time zone in which the date time should be set, default to result of `date_default_timezone_get`
      * @example DateTime('1964-04-04 11:02:02')
      * @return \DateTime
      */
-    public static function dateTimeThisCentury($max = 'now')
+    public static function dateTimeThisCentury($max = 'now', $timezone = null)
     {
-        return static::dateTimeBetween('-100 year', $max);
+        return static::dateTimeBetween('-100 year', $max, $timezone);
     }
 
     /**
      * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
+     * @param string $timezone time zone in which the date time should be set, default to result of `date_default_timezone_get`
      * @example DateTime('2010-03-10 05:18:58')
      * @return \DateTime
      */
-    public static function dateTimeThisDecade($max = 'now')
+    public static function dateTimeThisDecade($max = 'now', $timezone = null)
     {
-        return static::dateTimeBetween('-10 year', $max);
+        return static::dateTimeBetween('-10 year', $max, $timezone);
     }
 
     /**
      * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
+     * @param string $timezone time zone in which the date time should be set, default to result of `date_default_timezone_get`
      * @example DateTime('2011-09-19 09:24:37')
      * @return \DateTime
      */
-    public static function dateTimeThisYear($max = 'now')
+    public static function dateTimeThisYear($max = 'now', $timezone = null)
     {
-        return static::dateTimeBetween('-1 year', $max);
+        return static::dateTimeBetween('-1 year', $max, $timezone);
     }
 
     /**
      * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
+     * @param string $timezone time zone in which the date time should be set, default to result of `date_default_timezone_get`
      * @example DateTime('2011-10-05 12:51:46')
      * @return \DateTime
      */
-    public static function dateTimeThisMonth($max = 'now')
+    public static function dateTimeThisMonth($max = 'now', $timezone = null)
     {
-        return static::dateTimeBetween('-1 month', $max);
+        return static::dateTimeBetween('-1 month', $max, $timezone);
     }
 
     /**

--- a/test/Faker/Provider/DateTimeTest.php
+++ b/test/Faker/Provider/DateTimeTest.php
@@ -50,6 +50,66 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(new \DateTimeZone($this->defaultTz), $date->getTimezone());
     }
 
+    public function testDateTimeThisCentury()
+    {
+        $date = DateTimeProvider::dateTimeThisCentury();
+        $this->assertInstanceOf('\DateTime', $date);
+        $this->assertGreaterThanOrEqual(new \DateTime('-100 year'), $date);
+        $this->assertLessThanOrEqual(new \DateTime(), $date);
+        $this->assertEquals(new \DateTimeZone($this->defaultTz), $date->getTimezone());
+    }
+
+    public function testDateTimeThisDecade()
+    {
+        $date = DateTimeProvider::dateTimeThisDecade();
+        $this->assertInstanceOf('\DateTime', $date);
+        $this->assertGreaterThanOrEqual(new \DateTime('-10 year'), $date);
+        $this->assertLessThanOrEqual(new \DateTime(), $date);
+        $this->assertEquals(new \DateTimeZone($this->defaultTz), $date->getTimezone());
+    }
+
+    public function testDateTimeThisYear()
+    {
+        $date = DateTimeProvider::dateTimeThisYear();
+        $this->assertInstanceOf('\DateTime', $date);
+        $this->assertGreaterThanOrEqual(new \DateTime('-1 year'), $date);
+        $this->assertLessThanOrEqual(new \DateTime(), $date);
+        $this->assertEquals(new \DateTimeZone($this->defaultTz), $date->getTimezone());
+    }
+
+    public function testDateTimeThisMonth()
+    {
+        $date = DateTimeProvider::dateTimeThisMonth();
+        $this->assertInstanceOf('\DateTime', $date);
+        $this->assertGreaterThanOrEqual(new \DateTime('-1 month'), $date);
+        $this->assertLessThanOrEqual(new \DateTime(), $date);
+        $this->assertEquals(new \DateTimeZone($this->defaultTz), $date->getTimezone());
+    }
+
+    public function testDateTimeThisCenturyWithTimezone()
+    {
+        $date = DateTimeProvider::dateTimeThisCentury('now', 'America/New_York');
+        $this->assertEquals($date->getTimezone(), new \DateTimeZone('America/New_York'));
+    }
+
+    public function testDateTimeThisDecadeWithTimezone()
+    {
+        $date = DateTimeProvider::dateTimeThisDecade('now', 'America/New_York');
+        $this->assertEquals($date->getTimezone(), new \DateTimeZone('America/New_York'));
+    }
+
+    public function testDateTimeThisYearWithTimezone()
+    {
+        $date = DateTimeProvider::dateTimeThisYear('now', 'America/New_York');
+        $this->assertEquals($date->getTimezone(), new \DateTimeZone('America/New_York'));
+    }
+
+    public function testDateTimeThisMonthWithTimezone()
+    {
+        $date = DateTimeProvider::dateTimeThisMonth('now', 'America/New_York');
+        $this->assertEquals($date->getTimezone(), new \DateTimeZone('America/New_York'));
+    }
+
     public function testIso8601()
     {
         $date = DateTimeProvider::iso8601();
@@ -103,7 +163,7 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
     {
         $date = DateTimeProvider::dateTimeInInterval($start, $interval);
         $this->assertInstanceOf('\DateTime', $date);
-        
+
         $_interval = \DateInterval::createFromDateString($interval);
         $_start = new \DateTime($start);
         if ($isInFuture) {


### PR DESCRIPTION
Introduced the ability to specify the timezone for the following methods:
* dateTimeThisCentury(),
* dateTimeThisDecade(),
* dateTimeThisYear(), and
* dateTimeThisMonth().

Updated readme and introduced new unit tests.