### PR TITLE
Change postal code format for ko_KR

### DIFF
--- a/src/Faker/Provider/ko_KR/Address.php
+++ b/src/Faker/Provider/ko_KR/Address.php
@@ -4,7 +4,7 @@ namespace Faker\Provider\ko_KR;
 
 class Address extends \Faker\Provider\Address
 {
-    protected static $postcode = array('###-###');
+    protected static $postcode = array('#####');
     protected static $buildingNumber = array('####', '###');
     protected static $metropolitanCity = array(
         '서울특별시', '부산광역시', '대구광역시', '인천광역시', '광주광역시', '대전광역시', '울산광역시',


### PR DESCRIPTION
Korean postal codes have been changed from the old xxx-xxx format to xxxxx on August 1, 2015