### PR TITLE
Added a generator so its possible to get a associative out from a associative array 

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -111,6 +111,7 @@ Each of the generator properties (like `name`, `address`, and `lorem`) are calle
     // returns randomly ordered subsequence of a provided array
     randomElements($array = array ('a','b','c'), $count = 1) // array('c')
     randomElement($array = array ('a','b','c')) // 'b'
+    randomKeys($array = array('a' => 'A', 'b' => 'B', 'c' => 'C'), $count = 1) // array('b' => 'B')
     shuffle('hello, world') // 'rlo,h eoldlw'
     shuffle(array(1, 2, 3)) // array(2, 1, 3)
     numerify('Hello ###') // 'Hello 609'

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -123,6 +123,7 @@ namespace Faker;
  * @property string $randomAscii
  * @method int randomNumber($nbDigits = null, $strict = false)
  * @method int|string|null randomKey(array $array = array())
+ * @method array randomKeys(array $array = array('a' => 'A', 'b' => 'B', 'c' => 'C'), $count = 1)
  * @method int numberBetween($min = 0, $max = 2147483647)
  * @method float randomFloat($nbMaxDecimals = null, $min = 0, $max = null)
  * @method mixed randomElement(array $array = array('a', 'b', 'c'))

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -250,7 +250,7 @@ class Base
 
         $keys = array_keys($array);
         shuffle($keys);
-        $keys = array_splice( $keys, 0, $count );
+        $keys = array_splice($keys, 0, $count);
         $output = array();
         foreach ($keys as $key) {
             $output[$key] = $array[$key];

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -232,6 +232,33 @@ class Base
     }
 
     /**
+     * Returns multiple associative arrays
+     *
+     * @param array $array The array you want to get data from
+     * @param int $count How many elements do you want
+     * @return array ['b' => 'b', 'c' => 'c']
+     */
+    public static function randomKeys($array = array('a' => 'a', 'b' => 'b', 'c' => 'c'), $count = 1)
+    {
+        if (!$array) {
+            return null;
+        }
+
+        if ($count > count($array)) {
+            throw new \InvalidArgumentException('randomKeys() count must be lower or equals to the count of the array');
+        }
+
+        $keys = array_keys($array);
+        shuffle($keys);
+        $keys = array_splice( $keys, 0, $count );
+        $output = array();
+        foreach ($keys as $key) {
+            $output[$key] = $array[$key];
+        }
+        return $output;
+    }
+
+    /**
      * Returns a shuffled version of the argument.
      *
      * This function accepts either an array, or a string.

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -552,4 +552,33 @@ class BaseTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(3, $allowDuplicates);
         $this->assertContainsOnly('string', $allowDuplicates);
     }
+
+    public function testRandomKeys()
+    {
+        $this->assertNull(BaseProvider::randomKeys(array(), 'Returns null on empty array'));
+
+        $input = array('a' => 'A', 'b' => 'B', 'c' => 'C', 'd' => 'D', 'e' => 'E');
+
+        $output = BaseProvider::randomKeys($input, 2);
+        $this->assertCount(2, $output);
+        $this->assertArrayNotHasKey('f', $output);
+        $this->assertCount(2, array_intersect_assoc($input, $output));
+
+        $wholeArray = BaseProvider::randomKeys($input, 5);
+        $this->assertCount(5, $wholeArray);
+        $this->assertArrayNotHasKey('f', $wholeArray);
+        $this->assertCount(5, array_intersect_assoc($input, $wholeArray));
+    }
+
+    public function testRandomKeysCountTooHigh()
+    {
+        $this->setExpectedException(
+            \InvalidArgumentException::class,
+            'randomKeys() count must be lower or equals to the count of the array'
+        );
+
+        $input = array('a' => 'A', 'b' => 'B', 'c' => 'C', 'd' => 'D', 'e' => 'E');
+        BaseProvider::randomKeys($input, 8);
+    }
+
 }

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -573,7 +573,7 @@ class BaseTest extends \PHPUnit_Framework_TestCase
     public function testRandomKeysCountTooHigh()
     {
         $this->setExpectedException(
-            \InvalidArgumentException::class,
+            'InvalidArgumentException',
             'randomKeys() count must be lower or equals to the count of the array'
         );
 


### PR DESCRIPTION
As my model required a associative array, like this ```['a' => 'A', 'b' => 'B']``` out from a larger array, I added a generator for this.

Example

```php
$input = array('a' => 'A', 'b' => 'B', 'c' => 'C', 'd' => 'D', 'e' => 'E');
$output = $generator->randomKeys($input, 2);
```

Output is now a associative array


```
Array
(
    [b] => B
    [a] => A
)
```

I thougt about the name ```associativeElements``` instead of ```randomKeys``` but I sticked with ```randomKeys```
