### PR TITLE
Improve Internet::transliterate performance

### DIFF
--- a/src/Faker/Provider/Internet.php
+++ b/src/Faker/Provider/Internet.php
@@ -209,6 +209,10 @@ class Internet extends \Faker\Provider\Base
 
     protected static function transliterate($string)
     {
+        if (0 === preg_match('/[^A-Za-z0-9_.]/', $string)) {
+            return $string;
+        }
+
         $transId = 'Any-Latin; Latin-ASCII; NFD; [:Nonspacing Mark:] Remove; NFC;';
         if (function_exists('transliterator_transliterate') && $transliterator = \Transliterator::create($transId)) {
             $transString = $transliterator->transliterate($string);


### PR DESCRIPTION
This patch improves the performance of the `Internet::transliterate` method by not using the transliterator if the current string is already in ASCII.

It improves the speed of Alice's benchmark of 37%.

/cc @theofidry 