### PR TITLE
Removed dead code from Luhn.php

### DIFF
--- a/src/Faker/Calculator/Luhn.php
+++ b/src/Faker/Calculator/Luhn.php
@@ -2,7 +2,6 @@
 
 namespace Faker\Calculator;
 
-use Faker\Provider\Base as BaseProvider;
 use InvalidArgumentException;
 
 /**


### PR DESCRIPTION
Hi.

Looks like class ```Faker\Provider\Base``` was declared in ```src/Faker/Calculator/Luhn.php``` but never used. Removed this dead code.

PHPUnit run before and after -- both passed. 

Thank you.
