### PR TITLE
Link Eloquent Populator

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1393,6 +1393,7 @@ echo $faker->bank; // '中国建设银行'
 * [CakePHP 2.x Fake Seeder Plugin](https://github.com/ravage84/cakephp-fake-seeder) A CakePHP 2.x shell to seed your database with fake and/or fixed data.
 * [images-generator](https://github.com/bruceheller/images-generator): An image generator provider using GD for placeholder type pictures
 * [pattern-lab/plugin-php-faker](https://github.com/pattern-lab/plugin-php-faker): Pattern Lab is a Styleguide, Component Library, and Prototyping tool. This creates unique content each time Pattern Lab is generated.
+* [guidocella/eloquent-populator](https://github.com/guidocella/eloquent-populator): Adapter for Laravel's Eloquent ORM.
 
 ## License
 


### PR DESCRIPTION
Hi. I created an adapter/Populator for Laravel's Eloquent ORM, but I released it as a [separate package](https://github.com/guidocella/eloquent-populator) because I ended up adding lots of stuff. So I added a link to it in the readme if it's ok. I don't know if I should add Eloquent to the list of supported ORMs.