### PR TITLE
Add personal ID, VAT for zh_TW

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1373,6 +1373,25 @@ echo $faker->personalIdentityNumber('female') // '950910-0781'
 echo $faker->bank; // '中国建设银行'
 ```
 
+### `Faker\Provider\zh_TW\Person`
+
+```php
+<?php
+
+// Generates a random personal identify number
+echo $faker->personalIdentityNumber; // A223456789
+```
+
+### `Faker\Provider\zh_TW\Company`
+
+```php
+<?php
+
+// Generates a random VAT / Company Tax number
+echo $faker->VAT; //23456789
+```
+
+
 ## Third-Party Libraries Extending/Based On Faker
 
 * Symfony2 bundles:

--- a/src/Faker/Provider/zh_TW/Company.php
+++ b/src/Faker/Provider/zh_TW/Company.php
@@ -250,4 +250,16 @@ class Company extends \Faker\Provider\Company
         }
         return $result;
     }
+
+    /**
+     * return standard VAT / Tax ID / Uniform Serial Number
+     *
+     * @example 28263822
+     *
+     * @return int
+     */
+    public function VAT()
+    {
+        return static::randomNumber(8, true);
+    }
 }

--- a/src/Faker/Provider/zh_TW/Person.php
+++ b/src/Faker/Provider/zh_TW/Person.php
@@ -4,6 +4,39 @@ namespace Faker\Provider\zh_TW;
 
 class Person extends \Faker\Provider\Person
 {
+    /**
+     * @see https://zh.wikipedia.org/wiki/%E4%B8%AD%E8%8F%AF%E6%B0%91%E5%9C%8B%E5%9C%8B%E6%B0%91%E8%BA%AB%E5%88%86%E8%AD%89
+     */
+    public static $idBirthplaceCode = array(
+        'A' => 10,
+        'B' => 11,
+        'C' => 12,
+        'D' => 13,
+        'E' => 14,
+        'F' => 15,
+        'G' => 16,
+        'H' => 17,
+        'I' => 34,
+        'J' => 18,
+        'K' => 19,
+        'M' => 21,
+        'N' => 22,
+        'O' => 35,
+        'p' => 23,
+        'Q' => 24,
+        'T' => 27,
+        'U' => 28,
+        'V' => 29,
+        'W' => 32,
+        'X' => 30,
+        'Z' => 33
+    );
+
+    /**
+     * @see https://zh.wikipedia.org/wiki/%E4%B8%AD%E8%8F%AF%E6%B0%91%E5%9C%8B%E5%9C%8B%E6%B0%91%E8%BA%AB%E5%88%86%E8%AD%89
+     */
+    public static $idDigitValidator = array(1, 9, 8, 7, 6, 5, 4, 3, 2, 1, 1);
+
     protected static $maleNameFormats = array(
         '{{lastName}}{{firstNameMale}}',
     );
@@ -128,5 +161,41 @@ class Person extends \Faker\Provider\Person
     public static function suffix()
     {
         return '';
+    }
+
+    /**
+     * @param string $gender Person::GENDER_MALE || Person::GENDER_FEMALE
+     *
+     * @see https://en.wikipedia.org/wiki/National_Identification_Card_(Republic_of_China)
+     *
+     * @return string Length 10 alphanumeric characters, begins with 1 latin character (birthplace),
+     * 1 number (gender) and then 8 numbers (the last one is check digit).
+     */
+    public function personalIdentityNumber($gender = null)
+    {
+        $birthPlace = self::randomKey(self::$idBirthplaceCode);
+        $birthPlaceCode = self::$idBirthplaceCode[$birthPlace];
+
+        $gender = ($gender != null) ? $gender : self::randomElement(array(self::GENDER_FEMALE, self::GENDER_MALE));
+        $genderCode = ($gender === self::GENDER_MALE) ? 1 : 2;
+
+        $randomNumberCode = self::randomNumber(7, true);
+
+        $codes = str_split($birthPlaceCode . $genderCode . $randomNumberCode);
+        $total = 0;
+
+        foreach ($codes as $key => $code) {
+            $total += $code * self::$idDigitValidator[$key];
+        }
+
+        $checkSumDigit = 10 - ($total % 10);
+
+        if ($checkSumDigit == 10) {
+            $checkSumDigit = 0;
+        }
+
+        $id = $birthPlace . $genderCode . $randomNumberCode . $checkSumDigit;
+
+        return $id;
     }
 }

--- a/test/Faker/Provider/zh_TW/CompanyTest.php
+++ b/test/Faker/Provider/zh_TW/CompanyTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Faker\Test\Provider\zh_TW;
+
+use Faker\Generator;
+use Faker\Provider\zh_TW\Company;
+
+class CompanyTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Generator
+     */
+    private $faker;
+
+    public function setUp()
+    {
+        $faker = new Generator();
+        $faker->addProvider(new Company($faker));
+        $this->faker = $faker;
+    }
+
+    public function testVAT()
+    {
+        $this->assertEquals(8, floor(log10($this->faker->VAT) + 1));
+    }
+}

--- a/test/Faker/Provider/zh_TW/PersonTest.php
+++ b/test/Faker/Provider/zh_TW/PersonTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Faker\Test\Provider\zh_TW;
+
+use Faker\Generator;
+use Faker\Provider\zh_TW\Person;
+
+class PersonTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Generator
+     */
+    private $faker;
+
+    public function setUp()
+    {
+        $faker = new Generator();
+        $faker->addProvider(new Person($faker));
+        $this->faker = $faker;
+    }
+
+    /**
+     * @see https://zh.wikipedia.org/wiki/%E4%B8%AD%E8%8F%AF%E6%B0%91%E5%9C%8B%E5%9C%8B%E6%B0%91%E8%BA%AB%E5%88%86%E8%AD%89
+     */
+    public function testPersonalIdentityNumber()
+    {
+        $id = $this->faker->personalIdentityNumber;
+
+        $firstChar = substr($id, 0, 1);
+        $codesString = Person::$idBirthplaceCode[$firstChar] . substr($id, 1);
+
+        // After transfer the first alphabet word into 2 digit number, there should be totally 11 numbers
+        $this->assertRegExp("/^[0-9]{11}$/", $codesString);
+
+        $total = 0;
+        $codesArray = str_split($codesString);
+        foreach ($codesArray as $key => $code) {
+            $total += $code * Person::$idDigitValidator[$key];
+        }
+
+        // Validate
+        $this->assertEquals(0, ($total % 10));
+    }
+}

--- a/test/Faker/Provider/zh_TW/TextTest.php
+++ b/test/Faker/Provider/zh_TW/TextTest.php
@@ -20,7 +20,7 @@ class TextTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    function it_should_explode_the_string_to_array()
+    function testItShouldExplodeTheStringToArray()
     {
         $this->assertSame(
             array('中', '文', '測', '試', '真', '有', '趣'),
@@ -34,7 +34,7 @@ class TextTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    function it_should_return_the_string_length()
+    function testItShouldReturnTheStringLength()
     {
         $this->assertContains(
             $this->getMethod('strlen')->invokeArgs(null, array('中文測試真有趣')),
@@ -43,7 +43,7 @@ class TextTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    function it_should_return_the_character_is_valid_start_or_not()
+    function testItShouldReturnTheCharacterIsValidStartOrNot()
     {
         $this->assertTrue($this->getMethod('validStart')->invokeArgs(null, array('中')));
 
@@ -57,7 +57,7 @@ class TextTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    function it_should_append_end_punct_to_the_end_of_string()
+    function testItShouldAppendEndPunctToTheEndOfString()
     {
         $this->assertSame(
             '中文測試真有趣。',


### PR DESCRIPTION
Hi teams, thanks for the awesome faker features.

This PR includes.

- `VAT` in `zh_TW/Company`
- `personalIdentityNumber` in `zh_TW/Person`
- Tests
- Readme update