### PR TITLE
Add prefixes for nl_NL

### DIFF
--- a/src/Faker/Provider/nl_NL/Person.php
+++ b/src/Faker/Provider/nl_NL/Person.php
@@ -30,6 +30,22 @@ class Person extends \Faker\Provider\Person
         'BA', 'Bsc', 'LLB', 'LLM', 'MA', 'Msc', 'MPhil', 'D', 'PhD', 'AD', 'B', 'M'
     );
 
+    protected static $prefix = array("'s", "'t", 'a', 'aan', "aan 't", 'aan de', 'aan den', 'aan der', 'aan het',
+        "aan t", 'af', 'al', 'am', 'am de', 'auf', 'auf dem', 'auf den', 'auf der', 'auf ter', 'aus', "aus 'm",
+        'aus dem', 'aus den', 'aus der', 'aus m', 'ben', 'bij', "bij 't", 'bij de', 'bij den', 'bij het', 'bij t',
+        'bin', 'boven d', "boven d'", 'd', "d'", 'da', 'dal', 'dal’', 'dalla', 'das', 'de', 'de die', 'de die le',
+        'de l', 'de l’', 'de la', 'de las', 'de le', 'de van der', 'deca', 'degli', 'dei', 'del', 'della', 'den',
+        'der', 'des', 'di', 'die le', 'do', 'don', 'dos', 'du', 'el', 'het', 'i', 'im', 'in', "in 't", 'in de', 'in den',
+        'in der', 'in het', 'in t', 'l', 'l’', 'la', 'las', 'le', 'les', 'lo', 'los', 'of', 'onder', "onder 't",
+        'onder de', 'onder den', 'onder het', 'onder t', 'op', "op 't", 'op de', 'op den', 'op der', 'op gen', 'op het',
+        'op t', 'op ten', 'over', "over 't", 'over de', 'over den', 'over het', 'over t', 's', "s'", 't', 'te', 'ten',
+        'ter', 'tho', 'thoe', 'thor', 'to', 'toe', 'tot', 'uijt', "uijt 't", 'uijt de', 'uijt den', 'uijt te de',
+        'uijt ten', 'uit', "uit 't", 'uit de', 'uit den', 'uit het', 'uit t', 'uit te de', 'uit ten', 'unter', 'van',
+        "van 't", 'van De', 'van de', 'van de l', "van de l'", 'van den', 'van der', 'van gen', 'van het', 'van la',
+        'van t', 'van ter', 'van van de', 'ver', 'vom', 'von', "von 't", 'von dem', 'von den', 'von der', 'von t', 'voor',
+        "voor 't", 'voor de', 'voor den', "voor in 't", 'voor in t', 'vor', 'vor der', 'zu', 'zum', 'zur'
+    );
+
     protected static $commonDutchLastNames = array(
         'de Jong', 'Jansen', 'de Vries', 'van de Berg', 'van den Berg', 'van der Berg', 'van Dijk', 'Bakker', 'Janssen',
         'Visser', 'Smit', 'Meijer', 'Meyer', 'de Boer', 'Mulder', 'de Groot', 'Bos', 'Vos', 'Peters', 'Hendriks',
@@ -92,11 +108,11 @@ class Person extends \Faker\Provider\Person
         'Haselaar', 'van Haspengouw', 'Hazenveld', 'de Heer', 'Heere', 'Heerkens',
         'Heerschop', 'Hehl', 'van der Heiden', 'van der Heijden', 'Heijman', 'Heijmans', 'Heijmen', 'Heinrichs',
         'Hekker', 'Hellevoort', 'Helmerhorst', 'van Hemert', 'Hemma', 'Hendricks', 'Hendriks',
-        'Hendrikse', 'van Henegouwen',  'van den Henst', 'Heribert van Laon', 'd\' Heripon',
+        'Hendrikse', 'van Henegouwen',  'van den Henst', 'Heribert van Laon', "d' Heripon",
         'Hermans', 'van Herstal', 'van Heusden', 'Hexspoor', 'Heymans', 'Heyne', 'Hoedemakers', 'van den Hoek', 'Hoeks',
         'Hoelen', 'Hoes', 'van Hoevel en van Zwindrecht', 'van der Hoeven', 'van Holland', 'Hollander', 'Holthuis',
         'Hondeveld', 'Honing', 'de Hoog', 'Hoogers', 'de Hoogh', 'Hoppenbrouwer', 'Horrocks', 'van der Horst',
-        'van Hostaden', 'Houdijk', 'van \'t Houteveen', 'Huberts', 'Huel', 'Huijben', 'Huijbrechts', 'Huijs',
+        'van Hostaden', 'Houdijk', "van 't Houteveen", 'Huberts', 'Huel', 'Huijben', 'Huijbrechts', 'Huijs',
         'Huijzing', 'Huisman', 'Huls', 'Hulshouts', 'Hulskes', 'Hulst', 'van Hulten', 'Huurdeman', 'van het Heerenveen',
         'Jaceps', 'Jacobi', 'Jacobs', 'Jacquot', 'de Jager', 'Jans', 'Jansdr', 'Janse', 'Jansen', 'Jansen', 'Jansse',
         'Janssen', 'Janssens', 'Jasper dr', 'Jdotte', 'Jeggij', 'Jekel', 'Jerusalem', 'Jochems',
@@ -135,7 +151,7 @@ class Person extends \Faker\Provider\Person
         'van de Plas', 'van der Plas', 'van der Ploeg', 'van der Pluijm', 'Poncelet', 'Ponci', 'Pons', 'van Poppel',
         'Post', 'Potters', 'van der Pouw', 'van Praagh', 'Pratt', 'Prinsen', 'Puig', 'Rackham', 'Rademaker', 'Ramaker',
         'Recer', 'Recers', 'de Reede', 'Rehorst', 'Reijers', 'Reimes', 'Rek', 'Remmers', 'van Rheineck', 'Ridder',
-        'Riem', 'van Riet', 'van \'t Riet', 'Rietveld', 'Rijcken', 'Rijks', 'Rijn', 'van Rijnsbergen', 'Rijntjes',
+        'Riem', 'van Riet', "van 't Riet", 'Rietveld', 'Rijcken', 'Rijks', 'Rijn', 'van Rijnsbergen', 'Rijntjes',
         'van Rijthoven', 'Rippey', 'Risma', 'Robbrechts Bruijne', 'Roessink', 'van Roijen', 'Romijn', 'de Roo',
         'Roodesteijn', 'van Rooij', 'Room', 'de Roos', 'Roose', 'Roosenboom', 'van Rossum', 'Rotteveel', 'Roukes',
         'Rousselet', 'Rouwenhorst', 'Rouwhorst', 'Rubben', 'Ruijs', 'Rutten', 'van Saksen', 'Salet', 'van Salm',
@@ -161,7 +177,7 @@ class Person extends \Faker\Provider\Person
         'Vierdag', 'Vignon', 'van Vlaanderen', 'Volcke', 'van Voorhout', 'van Voorst', 'Voortman', 'Vos', 'Vrancken',
         'de Vries', 'de Vroege', 'de Vrome', 'ter Waarbeek', 'Waardeloo', 'van Waas', 'Wagenvoort', 'van Wallaert',
         'Walsteijn', 'Walter', 'van Wassenaar', 'van de Water', 'Weeldenburg', 'Weerdenburg',
-        'Weijland', 'Weijters', 'van Wel', 'van \'t Wel', 'Welf', 'Wendt', 'Wensen', 'de Werd', 'Werdes',
+        'Weijland', 'Weijters', 'van Wel', "van 't Wel", 'Welf', 'Wendt', 'Wensen', 'de Werd', 'Werdes',
         'van Wessex', 'Westerbeek', 'Westerburg', 'Westermann',
         'van Westfalen', 'van de Weterink', 'Wever', 'Weyland', 'Weylant', 'van Wickerode', 'van de Wiel', 'Wigman',
         'Wijland', 'van Wijland', 'Wilcken', 'Wildschut', 'Willems', 'Willems van Lier', 'Willemsen', 'Wilmont',
@@ -289,5 +305,13 @@ class Person extends \Faker\Provider\Person
     public static function suffix()
     {
         return static::randomElement(static::$suffix);
+    }
+
+    /*
+     * @example 'van der'
+     */
+    public static function prefix()
+    {
+        return static::randomElement(static::$prefix);
     }
 }


### PR DESCRIPTION
Based on: https://www.vernoeming.nl/alle-333-voorvoegsels-tussenvoegsels-in-nederlandse-achternamen

Fixed a few consistency issues along the way with handling single quotes.

Added the `prefix` method.

Due to the nature `$commonDutchLastNames` and `$dutchLastNames` are set up (already including the prefixes) I did not want to interfere with the current formats, but simply add additional functionality.