### PR TITLE
Rewrote deprecated `each()` usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
     - 5.6
     - 7.0
     - 7.1
+    - nightly
     - hhvm
 
 sudo: false

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^5.3.3|^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0",
+        "phpunit/phpunit": "~4.0||~5.0",
         "squizlabs/php_codesniffer": "~1.5",
         "ext-intl": "*"
     },

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -276,7 +276,7 @@ class Base
         $shuffledArray = array();
         $i = 0;
         reset($array);
-        while (list($key, $value) = each($array)) {
+        foreach ($array as $key => $value) {
             if ($i == 0) {
                 $j = 0;
             } else {


### PR DESCRIPTION
See https://wiki.php.net/rfc/deprecations_php_7_2#each
Also allowed using PHPUnit version 5 because version 4
also still uses the deprecated `each()` function. This
way the project will continue to build on future PHP
versions without sacreficing backwards compatibility to
PHP 5.3-5.5 versions. (Would be needed for allowing to
install PHPunit 6).