### PR TITLE
use secure https

### DIFF
--- a/src/Faker/Provider/Image.php
+++ b/src/Faker/Provider/Image.php
@@ -30,7 +30,7 @@ class Image extends Base
      */
     public static function imageUrl($width = 640, $height = 480, $category = null, $randomize = true, $word = null, $gray = false)
     {
-        $baseUrl = "http://lorempixel.com/";
+        $baseUrl = "https://lorempixel.com/";
         $url = "{$width}/{$height}/";
 
         if ($gray) {

--- a/test/Faker/Provider/ImageTest.php
+++ b/test/Faker/Provider/ImageTest.php
@@ -8,22 +8,22 @@ class ImageTest extends \PHPUnit_Framework_TestCase
 {
     public function testImageUrlUses640x680AsTheDefaultSize()
     {
-        $this->assertRegExp('#^http://lorempixel.com/640/480/#', Image::imageUrl());
+        $this->assertRegExp('#^https://lorempixel.com/640/480/#', Image::imageUrl());
     }
 
     public function testImageUrlAcceptsCustomWidthAndHeight()
     {
-        $this->assertRegExp('#^http://lorempixel.com/800/400/#', Image::imageUrl(800, 400));
+        $this->assertRegExp('#^https://lorempixel.com/800/400/#', Image::imageUrl(800, 400));
     }
 
     public function testImageUrlAcceptsCustomCategory()
     {
-        $this->assertRegExp('#^http://lorempixel.com/800/400/nature/#', Image::imageUrl(800, 400, 'nature'));
+        $this->assertRegExp('#^https://lorempixel.com/800/400/nature/#', Image::imageUrl(800, 400, 'nature'));
     }
 
     public function testImageUrlAcceptsCustomText()
     {
-        $this->assertRegExp('#^http://lorempixel.com/800/400/nature/Faker#', Image::imageUrl(800, 400, 'nature', false, 'Faker'));
+        $this->assertRegExp('#^https://lorempixel.com/800/400/nature/Faker#', Image::imageUrl(800, 400, 'nature', false, 'Faker'));
     }
 
     public function testImageUrlAddsARandomGetParameterByDefault()


### PR DESCRIPTION
Because https://lorempixel.com/ uses a valid SSL certificate, this will stop those pesky Mixed Content warnings.

In the good spirit of security, even while in development.

https://youtu.be/PdnpNJZVUE0
