### PR TITLE
Add fix for default time zone

### DIFF
--- a/src/Faker/Provider/DateTime.php
+++ b/src/Faker/Provider/DateTime.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Faker\Provider;
+date_default_timezone_set('UTC');
 
 class DateTime extends Base
 {


### PR DESCRIPTION
There is a PHP error we see that indicates problems when no default time zone is specified. This adds UTC as the default. This may well address a number of dateTime related issues like #945 #1165 #1078 and possibly others.