### PR TITLE
Use static instead of self

### DIFF
--- a/src/Faker/Provider/Text.php
+++ b/src/Faker/Provider/Text.php
@@ -128,7 +128,7 @@ abstract class Text extends Base
     protected static function validStart($word)
     {
         $isValid = true;
-        if (self::$textStartsWithUppercase) {
+        if (static::$textStartsWithUppercase) {
             $isValid = preg_match('/^\p{Lu}/u', $word);
         }
         return $isValid;


### PR DESCRIPTION
Because `$textStartsWithUppercase` was always set to false no matter what you had set in localized class.