### PR TITLE
Corrected of grammar of Ukrainian middlenames and test added

### DIFF
--- a/src/Faker/Provider/uk_UA/Person.php
+++ b/src/Faker/Provider/uk_UA/Person.php
@@ -5,13 +5,13 @@ namespace Faker\Provider\uk_UA;
 class Person extends \Faker\Provider\Person
 {
     protected static $maleNameFormats = array(
-        '{{firstNameMale}} {{middleName}} {{lastName}}',
-        '{{lastName}} {{firstNameMale}} {{middleName}}',
+        '{{firstNameMale}} {{middleNameMale}} {{lastName}}',
+        '{{lastName}} {{firstNameMale}} {{middleNameMale}}',
     );
 
     protected static $femaleNameFormats = array(
-        '{{lastName}} {{firstNameFemale}} {{middleName}}',
-        '{{firstNameFemale}} {{middleName}} {{lastName}}',
+        '{{lastName}} {{firstNameFemale}} {{middleNameFemale}}',
+        '{{firstNameFemale}} {{middleNameFemale}} {{lastName}}',
     );
 
     protected static $firstNameMale = array(
@@ -29,11 +29,18 @@ class Person extends \Faker\Provider\Person
         'Юлія', 'Ярослава'
     );
 
-    protected static $middleName = array(
+    protected static $middleNameMale = array(
         'Олександрович', 'Олексійович', 'Андрійович', 'Євгенович', 'Сергійович', 'Іванович',
         'Федорович', 'Тарасович', 'Васильович', 'Романович', 'Петрович', 'Миколайович',
         'Борисович', 'Йосипович', 'Михайлович', 'Валентинович', 'Янович', 'Анатолійович',
         'Євгенійович', 'Володимирович'
+    );
+
+    protected static $middleNameFemale = array(
+        'Олександрівна', 'Олексіївна', 'Андріївна', 'Євгенівна', 'Сергіївна', 'Іванівна',
+        'Федорівна', 'Тарасівна', 'Василівна', 'Романівна', 'Петрівна', 'Миколаївна',
+        'Борисівна', 'Йосипівна', 'Михайлівна', 'Валентинівна', 'Янівна', 'Анатоліївна',
+        'Євгеніївна', 'Володимирівна'
     );
 
     protected static $lastName = array(
@@ -45,13 +52,48 @@ class Person extends \Faker\Provider\Person
     );
 
     /**
-     * Return middle name
+     * Return male middle name
+     *
      * @example 'Іванович'
      * @access public
      * @return string Middle name
      */
-    public function middleName()
+    public function middleNameMale()
     {
-        return static::randomElement(static::$middleName);
+        return static::randomElement(static::$middleNameMale);
+    }
+
+    /**
+     * Return female middle name
+     *
+     * @example 'Івановна'
+     * @access public
+     * @return string Middle name
+     */
+    public function middleNameFemale()
+    {
+        return static::randomElement(static::$middleNameFemale);
+    }
+
+    /**
+     * Return middle name for the specified gender.
+     *
+     * @access public
+     * @param string|null $gender A gender the middle name should be generated
+     *     for. If the argument is skipped a random gender will be used.
+     * @return string Middle name
+     */
+    public function middleName($gender = null)
+    {
+        if ($gender === static::GENDER_MALE) {
+            return $this->middleNameMale();
+        } elseif ($gender === static::GENDER_FEMALE) {
+            return $this->middleNameFemale();
+        }
+
+        return $this->middleName(static::randomElement(array(
+            static::GENDER_MALE,
+            static::GENDER_FEMALE,
+        )));
     }
 }

--- a/test/Faker/Provider/uk_UA/PersonTest.php
+++ b/test/Faker/Provider/uk_UA/PersonTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Faker\Test\Provider\uk_UA;
+
+use Faker\Generator;
+use Faker\Provider\uk_UA\Person;
+
+class PersonTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFirstNameMaleReturns()
+    {
+        $faker = new Generator();
+        $faker->addProvider(new Person($faker));
+        $faker->seed(1);
+
+        $this->assertEquals('Максим', $faker->firstNameMale());
+    }
+
+    public function testFirstNameFemaleReturns()
+    {
+        $faker = new Generator();
+        $faker->addProvider(new Person($faker));
+        $faker->seed(1);
+
+        $this->assertEquals('Людмила', $faker->firstNameFemale());
+    }
+
+    public function testMiddleNameMaleReturns()
+    {
+        $faker = new Generator();
+        $faker->addProvider(new Person($faker));
+        $faker->seed(1);
+
+        $this->assertEquals('Миколайович', $faker->middleNameMale());
+    }
+
+    public function testMiddleNameFemaleReturns()
+    {
+        $faker = new Generator();
+        $faker->addProvider(new Person($faker));
+        $faker->seed(1);
+
+        $this->assertEquals('Миколаївна', $faker->middleNameFemale());
+    }
+
+    public function testLastNameReturns()
+    {
+        $faker = new Generator();
+        $faker->addProvider(new Person($faker));
+        $faker->seed(1);
+
+        $this->assertEquals('Броваренко', $faker->lastName());
+    }
+
+
+}


### PR DESCRIPTION
This is my first ever pull request. 
When generating Ukrainian names, only male middle names (patronymics) were used. For female names this did not correspond to the rules of the Ukrainian language. Added female middle names and test.