### PR TITLE
Lock Travis-CI environment to Ubuntu Precise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: precise
+
 php:
     - 5.3
     - 5.4


### PR DESCRIPTION
Travis-CI is moving towards Ubuntu Trusty for their default build environment, which doesn't support PHP 5.3 (so all PHP 5.3 builds fail for new contributors - see attached screenshot).

Since Faker requires PHP >= 5.3.3 – and thus should be tested on all PHP versions >= 5.3 – this PR locks the Travis-CI environment to Ubuntu Precise, which _does_ support PHP 5.3.

![screenshot_61](https://user-images.githubusercontent.com/920019/29127728-2242b262-7cdf-11e7-9602-4873f5ace156.png)
