### PR TITLE
Hotfix/failing unit tests

### DIFF
--- a/test/Faker/Provider/InternetTest.php
+++ b/test/Faker/Provider/InternetTest.php
@@ -14,7 +14,7 @@ class InternetTest extends \PHPUnit_Framework_TestCase
      * @var Generator
      */
     private $faker;
-    
+
     public function setUp()
     {
         $faker = new Generator();
@@ -53,7 +53,7 @@ class InternetTest extends \PHPUnit_Framework_TestCase
         $emailAddress = $this->faker->email();
         $this->assertRegExp($pattern, $emailAddress);
     }
-    
+
     /**
      * @dataProvider localeDataProvider
      */
@@ -146,7 +146,7 @@ class InternetTest extends \PHPUnit_Framework_TestCase
 
     public function testIpv4NotLocalNetwork()
     {
-        $this->assertNotRegExp('/\A1\./', $this->faker->ipv4());
+        $this->assertNotRegExp('/\A0\./', $this->faker->ipv4());
     }
 
     public function testIpv4NotBroadcast()

--- a/test/Faker/Provider/MiscellaneousTest.php
+++ b/test/Faker/Provider/MiscellaneousTest.php
@@ -53,6 +53,6 @@ class MiscellaneousTest extends \PHPUnit_Framework_TestCase
 
     public function testEmoji()
     {
-        $this->assertRegExp('/^[\x{1F600}-\x{1F636}]$/u', Miscellaneous::emoji());
+        $this->assertRegExp('/^[\x{1F600}-\x{1F637}]$/u', Miscellaneous::emoji());
     }
 }


### PR DESCRIPTION
This PR fixes two failing unit tests from the most recent `master` build.

1. The `emoji()` generator includes the `U+1F600` to `U+1F637` range, however the test only checked the `U+1F600` to `U+1F636` range. This test has been fixed to include the missing 😷 emoji.
2. The `ipv4()` generator generates IPs in the range `1.0.0.0` to `255.255.255.254`, and specifically excludes any IPs in the `0.0.0.0` to `0.255.255.255` range (I confirmed this via the wording of the original pull request), however the `testIpv4NotLocalNetwork()` test validated that a generated IP doesn't start with `1.`. The test has been updated to reflect the original intention of the `ipv4()` generator and verify that a generated IP doesn't start with `0.`