### PR TITLE
Fix CURL status code in ImageTest.php

### DIFF
--- a/test/Faker/Provider/ImageTest.php
+++ b/test/Faker/Provider/ImageTest.php
@@ -45,7 +45,7 @@ class ImageTest extends \PHPUnit_Framework_TestCase
 
     public function testDownloadWithDefaults()
     {
-        $url = "http://www.lorempixel.com/";
+        $url = "http://lorempixel.com/";
         $curlPing = curl_init($url);
         curl_setopt($curlPing, CURLOPT_TIMEOUT, 5);
         curl_setopt($curlPing, CURLOPT_CONNECTTIMEOUT, 5);


### PR DESCRIPTION
### Description
`http://lorempixel.com/` is being skipped because it responds with 301 instead of 200

### Code
`$url = "http://lorempixel.com/";   // line 48`
```
if ($httpCode < 200 | $httpCode > 300) {   // line 57
    $this->markTestSkipped("LoremPixel is offline, skipping image download");
}
```

### File
`test/Faker/Provider/ImageTest.php`