### PR TITLE
Added a Document Number for Dutch citizens

### DIFF
--- a/src/Faker/Provider/nl_NL/Person.php
+++ b/src/Faker/Provider/nl_NL/Person.php
@@ -278,6 +278,8 @@ class Person extends \Faker\Provider\Person
         return $lastName;
     }
 
+
+
     public function title($gender = null)
     {
         return static::randomElement(static::$title);
@@ -314,7 +316,34 @@ class Person extends \Faker\Provider\Person
     {
         return static::randomElement(static::$prefix);
     }
-    
+
+    private static function randomCappedLetterNotO()
+    {
+        $char = chr(mt_rand(65, 90));
+        return ($char !== 'O') ? $char : static::randomCappedLetterNotO();
+    }
+
+    /**
+     * For more information see link, bulletpoint 3.
+     * @link https://nl.wikipedia.org/wiki/Paspoort#Algemeen
+     *
+     * @return string
+     */
+    public static function documentNumber()
+    {
+        return implode([
+            static::randomCappedLetterNotO(),
+            static::randomCappedLetterNotO(),
+            static::randomElement([static::randomCappedLetterNotO(), static::randomDigit()]),
+            static::randomElement([static::randomCappedLetterNotO(), static::randomDigit()]),
+            static::randomElement([static::randomCappedLetterNotO(), static::randomDigit()]),
+            static::randomElement([static::randomCappedLetterNotO(), static::randomDigit()]),
+            static::randomElement([static::randomCappedLetterNotO(), static::randomDigit()]),
+            static::randomElement([static::randomCappedLetterNotO(), static::randomDigit()]),
+            static::randomDigit(),
+        ]);
+    }
+
     /**
      * @link https://nl.wikipedia.org/wiki/Burgerservicenummer#11-proef
      *

--- a/src/Faker/Provider/nl_NL/Person.php
+++ b/src/Faker/Provider/nl_NL/Person.php
@@ -329,17 +329,17 @@ class Person extends \Faker\Provider\Person
      */
     public static function documentNumber()
     {
-        return implode([
+        return implode(array(
             static::randomCappedLetterNotO(),
             static::randomCappedLetterNotO(),
-            static::randomElement([static::randomCappedLetterNotO(), static::randomDigit()]),
-            static::randomElement([static::randomCappedLetterNotO(), static::randomDigit()]),
-            static::randomElement([static::randomCappedLetterNotO(), static::randomDigit()]),
-            static::randomElement([static::randomCappedLetterNotO(), static::randomDigit()]),
-            static::randomElement([static::randomCappedLetterNotO(), static::randomDigit()]),
-            static::randomElement([static::randomCappedLetterNotO(), static::randomDigit()]),
+            static::randomElement(array(static::randomCappedLetterNotO(), static::randomDigit())),
+            static::randomElement(array(static::randomCappedLetterNotO(), static::randomDigit())),
+            static::randomElement(array(static::randomCappedLetterNotO(), static::randomDigit())),
+            static::randomElement(array(static::randomCappedLetterNotO(), static::randomDigit())),
+            static::randomElement(array(static::randomCappedLetterNotO(), static::randomDigit())),
+            static::randomElement(array(static::randomCappedLetterNotO(), static::randomDigit())),
             static::randomDigit(),
-        ]);
+        ));
     }
 
     /**

--- a/src/Faker/Provider/nl_NL/Person.php
+++ b/src/Faker/Provider/nl_NL/Person.php
@@ -278,8 +278,6 @@ class Person extends \Faker\Provider\Person
         return $lastName;
     }
 
-
-
     public function title($gender = null)
     {
         return static::randomElement(static::$title);

--- a/test/Faker/Provider/nl_NL/PersonTest.php
+++ b/test/Faker/Provider/nl_NL/PersonTest.php
@@ -29,4 +29,10 @@ class PersonTest extends \PHPUnit_Framework_TestCase
         }
         $this->assertTrue($sum != 0 && $sum % 11 == 0);
     }
+
+    public function testGenerateValidDocumentNumber()
+    {
+        $documentNumber = $this->faker->documentNumber();
+        $this->assertRegExp('/^[A-NP-Z]{2}[A-NP-Z0-9]{6}[0-9]$/', $documentNumber);
+    }
 }


### PR DESCRIPTION
This adds the possibility to generate a valid Dutch Document number, which is placed in dutch passports. Reason for adding it was the recently added BSN number, to which the document number is related. 

Currently the function uses a private function randomCappedLetterNotO within the Dutch person, I would like to be advised on where to place the this function since it is a more general function, yet it might have only the current use case (Dutch Document numbers may not contain O's so that may not be confused with the number zero). 