### PR TITLE
Allow children classes to access self::$suffix

### DIFF
--- a/src/Faker/Provider/en_US/Person.php
+++ b/src/Faker/Provider/en_US/Person.php
@@ -107,7 +107,7 @@ class Person extends \Faker\Provider\Person
         'Zboncak', 'Zemlak', 'Ziemann', 'Zieme', 'Zulauf'
     );
 
-    private static $suffix = array('Jr.', 'Sr.', 'I', 'II', 'III', 'IV', 'V', 'MD', 'DDS', 'PhD', 'DVM');
+    protected static $suffix = array('Jr.', 'Sr.', 'I', 'II', 'III', 'IV', 'V', 'MD', 'DDS', 'PhD', 'DVM');
 
     /**
      * @example 'PhD'


### PR DESCRIPTION
suffix() uses late static binding, and no longer works when called from
an extending class. Another solution would be to use self instead of
static, but other properties in that class are protected too, so this
should make it look more consistent.