### PR TITLE
Semantic Versioning (semVer) provider

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -293,6 +293,7 @@ Each of the generator properties (like `name`, `address`, and `lorem`) are calle
     languageCode  // en
     currencyCode  // EUR
     emoji         // 😁
+    semVer        // 7.1.14
 
 ### `Faker\Provider\Biased`
 

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -130,6 +130,7 @@ namespace Faker;
  * @property string $currencyCode
  * @property boolean $boolean
  * @method boolean boolean($chanceOfGettingTrue = 50)
+ * @property string $semVer
  *
  * @property int    $randomDigit
  * @property int    $randomDigitNotNull

--- a/src/Faker/Provider/Miscellaneous.php
+++ b/src/Faker/Provider/Miscellaneous.php
@@ -316,4 +316,16 @@ class Miscellaneous extends Base
     {
         return json_decode('"' . static::randomElement(static::$emoji) . '"');
     }
+
+    /**
+     * Returns a semantic version number.
+     *
+     * @example '7.1.14'
+     *
+     * @link http://semver.org/
+     */
+    public static function semVer()
+    {
+        return sprintf('%d.%d.%d', mt_rand(1, 50), mt_rand(1, 50), mt_rand(1, 999));
+    }
 }

--- a/src/Faker/Provider/Miscellaneous.php
+++ b/src/Faker/Provider/Miscellaneous.php
@@ -326,6 +326,6 @@ class Miscellaneous extends Base
      */
     public static function semVer()
     {
-        return sprintf('%d.%d.%d', mt_rand(1, 50), mt_rand(1, 50), mt_rand(1, 999));
+        return sprintf('%d.%d.%d', mt_rand(1, 50), mt_rand(0, 50), mt_rand(0, 999));
     }
 }

--- a/test/Faker/Provider/MiscellaneousTest.php
+++ b/test/Faker/Provider/MiscellaneousTest.php
@@ -55,4 +55,9 @@ class MiscellaneousTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertRegExp('/^[\x{1F600}-\x{1F637}]$/u', Miscellaneous::emoji());
     }
+
+    public function testSemVer()
+    {
+        $this->assertRegExp('/^\d+\.\d+\.\d+$/', Miscellaneous::semVer());
+    }
 }


### PR DESCRIPTION
This PR adds a Provider for software versions that follow [Semantic Versioning](http://semver.org/) (that is, the form of `MAJOR.MINOR.PATCH`).

The ranges used are 1-50, 0-50, and 0-999 for the major, minor, and patch releases, respectively.

Example output can include:

```
1.0.0
14.6.232
48.0.82
```