### PR TITLE
Language provider

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,7 @@ Faker requires PHP >= 5.3.3.
 	- [Phone Number](#fakerprovideren_usphonenumber)
 	- [Company](#fakerprovideren_uscompany)
 	- [Real Text](#fakerprovideren_ustext)
+    - [Language](#fakerprovideren_uslanguage)
 	- [Date and Time](#fakerproviderdatetime)
 	- [Internet](#fakerproviderinternet)
 	- [User Agent](#fakerprovideruseragent)

--- a/readme.md
+++ b/readme.md
@@ -177,6 +177,10 @@ Each of the generator properties (like `name`, `address`, and `lorem`) are calle
 
     realText($maxNbChars = 200, $indexSize = 2) // "And yet I wish you could manage it?) 'And what are they made of?' Alice asked in a shrill, passionate voice. 'Would YOU like cats if you were never even spoke to Time!' 'Perhaps not,' Alice replied."
 
+### `Faker\Provider\en_US\Language`
+
+    language                // 'Afrikaans'
+
 ### `Faker\Provider\DateTime`
 
     unixTime($max = 'now')                // 58781813

--- a/src/Faker/Factory.php
+++ b/src/Faker/Factory.php
@@ -6,7 +6,7 @@ class Factory
 {
     const DEFAULT_LOCALE = 'en_US';
 
-    protected static $defaultProviders = array('Address', 'Barcode', 'Biased', 'Color', 'Company', 'DateTime', 'File', 'HtmlLorem', 'Image', 'Internet', 'Lorem', 'Miscellaneous', 'Payment', 'Person', 'PhoneNumber', 'Text', 'UserAgent', 'Uuid');
+    protected static $defaultProviders = array('Address', 'Barcode', 'Biased', 'Color', 'Company', 'DateTime', 'File', 'HtmlLorem', 'Image', 'Internet', 'Lorem', 'Miscellaneous', 'Payment', 'Person', 'PhoneNumber', 'Text', 'UserAgent', 'Uuid', 'Language');
 
     /**
      * Create a new generator

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -188,6 +188,8 @@ namespace Faker;
  *
  * @method string randomHtml($maxDepth = 4, $maxWidth = 4)
  *
+ * @property string $language
+ *
  */
 class Generator
 {

--- a/src/Faker/Provider/Language.php
+++ b/src/Faker/Provider/Language.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Faker\Provider;
+
+class Language extends Base
+{
+    /**
+     * See Locales for longer languages lists
+     **/
+    protected static $language = array(
+        'Afrikaans', 'English', 'Norwegian',
+    );
+
+    /**
+     * @example 'Afrikaans'
+     */
+    public static function language()
+    {
+        return static::randomElement(static::$language);
+    }
+}

--- a/src/Faker/Provider/en_US/Language.php
+++ b/src/Faker/Provider/en_US/Language.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Faker\Provider\en_US;
+
+class Language extends \Faker\Provider\Language
+{
+    /**
+     * {@link} https://en.wikipedia.org/wiki/List_of_official_languages
+     **/
+    protected static $language = array(
+      //A
+      'Afar', 'Afrikaans', 'Aja-Gbe', 'Akan (Akuapem Twi, Ashante Twi, Fante)',
+      'Albanian', 'Amazigh', 'Amharic', 'Anii', 'Arabic', 'Armenian', 'Assamese',
+      'Aymara', 'Azerbaijani',
+      //B
+      'Balanta', 'Bambara', 'Bariba', 'Bassari', 'Bedik', 'Belarusian', 'Bengali',
+      'Berber', 'Biali', 'Bislama', 'Boko', 'Bomu', 'Bosnian', 'Bozo', 'Buduma',
+      'Bulgarian', 'Burmese',
+      //C
+      'Cantonese', 'Catalan', 'Chinese, Mandarin', 'Chichewa', 'Chirbawe (Sena)',
+      'Comorian', 'Croatian', 'Czech',
+      //D
+      'Dagaare', 'Dagbani', 'Dangme', 'Danish', 'Dari', 'Dendi', 'Dhivehi',
+      'Dioula', 'Dogon', 'Dutch', 'Dzongkha',
+      //E
+      'English', 'Estonian', 'Ewe-Gbe',
+      //F
+      'Fijian', 'Filipino', 'Finnish', 'Fon-Gbe', 'Foodo', 'French', 'Fula',
+      //G
+      'Ga', 'Gàidhlig', 'Gbe', 'Gen-Gbe', 'Georgian', 'German', 'Gonja',
+      'Gourmanché', 'Greek', 'Guaraní', 'Gujarati',
+      //H
+      'Haitian Creole', 'Hassaniya', 'Hausa', 'Hebrew', 'Hindi', 'Hiri Motu',
+      'Hungarian',
+      //I
+      'Igbo', 'Icelandic', 'Indonesian', 'Irish', 'Italian',
+      //J
+      'Japanese', 'Jola',
+      //K
+      'Kabye', 'Kalanga', 'Kanuri', 'Kasem', 'Kazakh', 'Khmer', 'Kinyarwanda',
+      'Kirundi', 'Kissi', 'Khoisan', 'Korean', 'Kpelle', 'Kurdish', 'Kyrgyz',
+      //L
+      'Lao', 'Latin', 'Latvian', 'Lithuanian', 'Lukpa', 'Luxembourgish',
+      //M
+      'Macedonian', 'Malagasy', 'Malay', 'Malinke', 'Maltese', 'Mamara',
+      'Manding (Mandinka, Malinke)', 'Mandinka', 'Mandjak', 'Mankanya',
+      'Manx Gaelic', 'Māori', 'Marshallese', 'Mbelime', 'Moldovan', 'Mongolian',
+      'Montenegrin', 'Mossi',
+      //N
+      'Nambya', 'Nateni', 'Nauruan', 'Ndau', 'Ndebele (Northern)',
+      'Ndebele (Southern)', 'Nepali', /* 'New Zealand Sign Language', */
+      'Noon', 'North Korean', 'Northern Sotho', 'Norwegian', 'Nzema',
+      //O
+      'Oniyan', 'Ossetian',
+      //P
+      'Palauan', 'Papiamento', 'Pashto', 'Persian', 'Polish', 'Portuguese',
+      //Q
+      'Quechua',
+      //R
+      'Romanian', 'Romansh', 'Russian',
+      //S
+      'Safen', 'Samoa', 'Sango', 'Sena', 'Serbian', 'Serer', 'Seychellois Creole',
+      'Shona', 'Sinhala', 'Slovak', 'Slovene', 'Somali', 'Songhay-Zarma',
+      'Soninke', 'Sotho', 'Spanish', 'Susu', 'Swahili', 'Swati', 'Swedish',
+      'Syenara',
+      //T
+      'Tajik', 'Tagalog', 'Tamasheq', 'Tamil', 'Tammari', 'Tasawaq', 'Tebu',
+      'Telugu', 'Tetum', 'Thai', 'Tigrinya', 'Tok Pisin', 'Toma', 'Tonga',
+      'Tongan', 'Tsonga', 'Tswana', 'Turkish', 'Turkmen', 'Tuvaluan',
+      //U
+      'Ukrainian', 'Urdu', 'Uzbek',
+      //V
+      'Venda', 'Vietnamese',
+      //W
+      'Waama', 'Waci-Gbe', 'Wamey', 'Welsh', 'Wolof',
+      //X
+      'Xhosa', 'Xwela-Gbe',
+      //Y
+      'Yobe', 'Yom', 'Yoruba',
+      //Z
+      /* 'Zimbabwean sign language', */ 'Zulu',
+    );
+}

--- a/src/Faker/Provider/en_US/Language.php
+++ b/src/Faker/Provider/en_US/Language.php
@@ -5,7 +5,7 @@ namespace Faker\Provider\en_US;
 class Language extends \Faker\Provider\Language
 {
     /**
-     * {@link} https://en.wikipedia.org/wiki/List_of_official_languages
+     * @link https://en.wikipedia.org/wiki/List_of_official_languages
      **/
     protected static $language = array(
       //A

--- a/src/Faker/Provider/nb_NO/Language.php
+++ b/src/Faker/Provider/nb_NO/Language.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Faker\Provider\nb_NO;
+
+class Language extends \Faker\Provider\Language
+{
+    /**
+     * {@link} https://no.wikipedia.org/wiki/Liste_over_offisielle_språk
+     **/
+    protected static $language = array(
+      //=== A ===
+      'Afrikaans', 'Amharisk', 'Albansk', 'Arabisk', 'Armensk', 'Assamesisk',
+      'Aymara', 'Aserbajdsjansk',
+      //=== B ===
+      'Bengali', 'Bislama', 'Bosnisk', 'Bulgarsk', 'Burmesisk',
+      //=== D ===
+      'Dansk', 'Dari', 'Dhivehi', 'Dzongkha',
+      //=== E ===
+      'Engelsk', 'Estisk',
+      //=== F ===
+      'Fijiansk', 'Fijiansk hindi', 'Filippinsk', 'Finsk', 'Fransk', 'Frisisk',
+      //=== G ===
+      'Georgisk', 'Gresk', 'Guaraní', 'Gujarati',
+      //=== H ===
+      'Haitisk', 'Hebraisk', 'Hindi', 'Hiri motu', 'Hviterussisk',
+      //=== I ===
+      'Islandsk', 'Indonesisk', 'Irsk gælisk', 'Italiensk',
+      //=== J ===
+      'Japansk',
+      //=== K ===
+      'Kannada', 'Kasjmirsk', 'Kasakhisk', 'Katalansk', 'Khmer', 'Kinesisk',
+      'Kirgisisk', 'Komorisk', 'Koreansk', 'Kroatisk', 'Kurdisk',
+      //=== L ===
+      'Laotisk', 'Latin', 'Latvisk', 'Litauisk', 'Luxembourgsk',
+      //=== M ===
+      'Makedonsk', 'Malayisk', 'Malayalam', 'Maltesisk', 'Maorisk', 'Marathi',
+      'Moldovsk', 'Mongolsk',
+      //=== N ===
+      'Naurisk', 'Ndebele', 'Nederlandsk', 'Nepalsk', 'Nordlig sotho', 'Norsk',
+      /* 'Nyzealandsk tegnspråk', */
+      //=== O ===
+      'Oriya',
+      //=== P ===
+      'Pashto', 'Persisk', 'Polsk', 'Portugisisk', 'Punjabi',
+      //=== Q ===
+      'Quechua',
+      //=== R ===
+      'Retoromansk', 'Rumensk', 'Russisk',
+      //=== S ===
+      'Sanskrit', 'Serbisk', 'Shona', 'Sindhi', 'Singalesisk', 'Slovakisk', 'Slovensk',
+      'Somali', 'Sotho', 'Spansk', 'Svensk', 'Swahili', 'Swazi',
+      //=== T ===
+      'Tadsjikisk', 'Tamilsk', 'Telugu', 'Tetum', 'Thai', 'Tok pisin', 'Tsjekkisk',
+      'Tsonga', 'Tswana', 'Turkmensk', 'Tyrkisk', 'Tysk',
+      //=== U ===
+      'Ukrainsk', 'Ungarsk', 'Urdu', 'Usbekisk',
+      //=== V ===
+      'Venda (Tshivenda)', 'Vietnamesisk',
+      //=== W ===
+      'Walisisk',
+      //=== X ===
+      'Xhosa',
+      //=== Z ===
+      'Zulu',
+    );
+}

--- a/src/Faker/Provider/nb_NO/Language.php
+++ b/src/Faker/Provider/nb_NO/Language.php
@@ -5,7 +5,7 @@ namespace Faker\Provider\nb_NO;
 class Language extends \Faker\Provider\Language
 {
     /**
-     * {@link} https://no.wikipedia.org/wiki/Liste_over_offisielle_språk
+     * @link https://no.wikipedia.org/wiki/Liste_over_offisielle_språk
      **/
     protected static $language = array(
       //=== A ===

--- a/test/Faker/Provider/LanguageTest.php
+++ b/test/Faker/Provider/LanguageTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Faker\Test\Provider;
+
+use Faker\Generator;
+use Faker\Factory;
+use Faker\Provider\en_US\Language;
+
+class LanguageTest extends \PHPUnit_Framework_TestCase
+{
+    private $faker;
+    private $faker_factory;
+
+    public function setUp()
+    {
+        //Create generator
+        $faker = new Generator();
+        $faker->addProvider(new Language($faker));
+        $this->faker = $faker;
+        
+        //Create factory    
+        $this->faker_factory = Factory::create();
+    }
+
+    public function testLanguageString()
+    {
+        $language = $this->faker->language;
+        $this->assertNotEmpty($language);
+    }
+    
+    public function testFactoryIncludesLanguage()
+    {
+        $language = $this->faker_factory->language;
+        $this->assertNotEmpty($language);
+    }
+}


### PR DESCRIPTION
This PR adds a Provider for languages. It has en_US and nb_NO language names, both taken from a list on wikipedia.

Example output can include:

> Afrikaans
> English
> Norwegian
