### PR TITLE
Fixed type-o in readme under section about Language specific formatters

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1302,7 +1302,7 @@ echo $faker->btw; // "NL123456789B01" - Dutch Value Added Tax number (alias)
 echo $faker->idNumber; // "111222333" - Dutch Personal identification number (BSN)
 ```
 
-### `Faker\Provider\no_NO\Payment`
+### `Faker\Provider\nb_NO\Payment`
 
 ```php
 <?php


### PR DESCRIPTION
Fixed type-o in readme under section about Language specific formatters where it listed a language as no_NO not nb_NO.