### PR TITLE
Introduced the ability to specify a default timezone...

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -180,17 +180,17 @@ Each of the generator properties (like `name`, `address`, and `lorem`) are calle
 ### `Faker\Provider\DateTime`
 
     unixTime($max = 'now')                // 58781813
-    dateTime($max = 'now', $timezone = date_default_timezone_get()) // DateTime('2008-04-25 08:37:17', 'UTC')
-    dateTimeAD($max = 'now', $timezone = date_default_timezone_get()) // DateTime('1800-04-29 20:38:49', 'Europe/Paris')
+    dateTime($max = 'now', $timezone = null) // DateTime('2008-04-25 08:37:17', 'UTC')
+    dateTimeAD($max = 'now', $timezone = null) // DateTime('1800-04-29 20:38:49', 'Europe/Paris')
     iso8601($max = 'now')                 // '1978-12-09T10:10:29+0000'
     date($format = 'Y-m-d', $max = 'now') // '1979-06-09'
     time($format = 'H:i:s', $max = 'now') // '20:49:42'
-    dateTimeBetween($startDate = '-30 years', $endDate = 'now', $timezone = date_default_timezone_get()) // DateTime('2003-03-15 02:00:49', 'Africa/Lagos')
-    dateTimeInInterval($startDate = '-30 years', $interval = '+ 5 days', $timezone = date_default_timezone_get()) // DateTime('2003-03-15 02:00:49', 'Antartica/Vostok')
-    dateTimeThisCentury($max = 'now', $timezone = date_default_timezone_get())     // DateTime('1915-05-30 19:28:21', 'UTC')
-    dateTimeThisDecade($max = 'now', $timezone = date_default_timezone_get())      // DateTime('2007-05-29 22:30:48', 'Europe/Paris')
-    dateTimeThisYear($max = 'now', $timezone = date_default_timezone_get())        // DateTime('2011-02-27 20:52:14', 'Africa/Lagos')
-    dateTimeThisMonth($max = 'now', $timezone = date_default_timezone_get())       // DateTime('2011-10-23 13:46:23', 'Antarctica/Vostok')
+    dateTimeBetween($startDate = '-30 years', $endDate = 'now', $timezone = null) // DateTime('2003-03-15 02:00:49', 'Africa/Lagos')
+    dateTimeInInterval($startDate = '-30 years', $interval = '+ 5 days', $timezone = null) // DateTime('2003-03-15 02:00:49', 'Antartica/Vostok')
+    dateTimeThisCentury($max = 'now', $timezone = null)     // DateTime('1915-05-30 19:28:21', 'UTC')
+    dateTimeThisDecade($max = 'now', $timezone = null)      // DateTime('2007-05-29 22:30:48', 'Europe/Paris')
+    dateTimeThisYear($max = 'now', $timezone = null)        // DateTime('2011-02-27 20:52:14', 'Africa/Lagos')
+    dateTimeThisMonth($max = 'now', $timezone = null)       // DateTime('2011-10-23 13:46:23', 'Antarctica/Vostok')
     amPm($max = 'now')                    // 'pm'
     dayOfMonth($max = 'now')              // '04'
     dayOfWeek($max = 'now')               // 'Friday'
@@ -199,6 +199,13 @@ Each of the generator properties (like `name`, `address`, and `lorem`) are calle
     year($max = 'now')                    // '1993'
     century                               // 'VI'
     timezone                              // 'Europe/Paris'
+
+For methods that accept a `$timezone` argument, users may opt to explicitly or implicitly pass `null`.  Doing so will result in the timezone being determined by the default timezone, if set, or the "system" timezone, otherwise.
+
+The default timezone can be get and set by calling `getDefaultTimezone()` and `setDefaultTimezone(string $timezone = null)`, respectively.
+
+The "system" timezone can be get and set by calling `date_default_timezone_get()` and `date_default_timezone_set(string $timezone_identifier)`, respectively.  If no
+default timezone has been set, then Faker will call `date_default_timezone_get()` to determine the timezone to use.
 
 ### `Faker\Provider\Internet`
 

--- a/readme.md
+++ b/readme.md
@@ -200,12 +200,7 @@ Each of the generator properties (like `name`, `address`, and `lorem`) are calle
     century                               // 'VI'
     timezone                              // 'Europe/Paris'
 
-For methods that accept a `$timezone` argument, users may opt to explicitly or implicitly pass `null`.  Doing so will result in the timezone being determined by the default timezone, if set, or the "system" timezone, otherwise.
-
-The default timezone can be get and set by calling `getDefaultTimezone()` and `setDefaultTimezone(string $timezone = null)`, respectively.
-
-The "system" timezone can be get and set by calling `date_default_timezone_get()` and `date_default_timezone_set(string $timezone_identifier)`, respectively.  If no
-default timezone has been set, then Faker will call `date_default_timezone_get()` to determine the timezone to use.
+Methods accepting a `$timezone` argument default to `date_default_timezone_get()`. You can pass a custom timezone string to each method, or define a custom timezone for all time methods at once using `$faker::setDefaultTimezone($timezone)`.
 
 ### `Faker\Provider\Internet`
 

--- a/src/Faker/Provider/DateTime.php
+++ b/src/Faker/Provider/DateTime.php
@@ -6,6 +6,8 @@ class DateTime extends Base
 {
     protected static $century = array('I','II','III','IV','V','VI','VII','VIII','IX','X','XI','XII','XIII','XIV','XV','XVI','XVII','XVIII','XIX','XX','XXI');
 
+    protected static $defaultTimezone = null;
+
     protected static function getMaxTimestamp($max = 'now')
     {
         if (is_numeric($max)) {
@@ -36,7 +38,7 @@ class DateTime extends Base
      * Get a datetime object for a date between January 1, 1970 and now
      *
      * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
-     * @param string $timezone time zone in which the date time should be set, default to result of `date_default_timezone_get`
+     * @param string $timezone time zone in which the date time should be set, default to DateTime::$defaultTimezone, if set, otherwise the result of `date_default_timezone_get`
      * @example DateTime('2005-08-16 20:39:21')
      * @return \DateTime
      * @see http://php.net/manual/en/timezones.php
@@ -46,7 +48,7 @@ class DateTime extends Base
     {
         return static::setTimezone(
             new \DateTime('@' . static::unixTime($max)),
-            (null === $timezone ? date_default_timezone_get() : $timezone)
+            $timezone
         );
     }
 
@@ -54,7 +56,7 @@ class DateTime extends Base
      * Get a datetime object for a date between January 1, 001 and now
      *
      * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
-     * @param string $timezone time zone in which the date time should be set, default to result of `date_default_timezone_get`
+     * @param string $timezone time zone in which the date time should be set, default to DateTime::$defaultTimezone, if set, otherwise the result of `date_default_timezone_get`
      * @example DateTime('1265-03-22 21:15:52')
      * @return \DateTime
      * @see http://php.net/manual/en/timezones.php
@@ -65,7 +67,7 @@ class DateTime extends Base
         $min = (PHP_INT_SIZE>4 ? -62135597361 : -PHP_INT_MAX);
         return static::setTimezone(
             new \DateTime('@' . mt_rand($min, static::getMaxTimestamp($max))),
-            (null === $timezone ? date_default_timezone_get() : $timezone)
+            $timezone
         );
     }
 
@@ -113,7 +115,7 @@ class DateTime extends Base
      *
      * @param \DateTime|string $startDate Defaults to 30 years ago
      * @param \DateTime|string $endDate   Defaults to "now"
-     * @param string $timezone time zone in which the date time should be set, default to result of `date_default_timezone_get`
+     * @param string $timezone time zone in which the date time should be set, default to DateTime::$defaultTimezone, if set, otherwise the result of `date_default_timezone_get`
      * @example DateTime('1999-02-02 11:42:52')
      * @return \DateTime
      * @see http://php.net/manual/en/timezones.php
@@ -132,7 +134,7 @@ class DateTime extends Base
 
         return static::setTimezone(
             new \DateTime('@' . $timestamp),
-            (null === $timezone ? date_default_timezone_get() : $timezone)
+            $timezone
         );
     }
 
@@ -143,7 +145,7 @@ class DateTime extends Base
      *
      * @param string $date      Defaults to 30 years ago
      * @param string $interval  Defaults to 5 days after
-     * @param string $timezone time zone in which the date time should be set, default to result of `date_default_timezone_get`
+     * @param string $timezone time zone in which the date time should be set, default to DateTime::$defaultTimezone, if set, otherwise the result of `date_default_timezone_get`
      * @example dateTimeInInterval('1999-02-02 11:42:52', '+ 5 days')
      * @return \DateTime
      * @see http://php.net/manual/en/timezones.php
@@ -162,13 +164,13 @@ class DateTime extends Base
         return static::dateTimeBetween(
             $begin,
             $end,
-            (null === $timezone ? date_default_timezone_get() : $timezone)
+            $timezone
         );
     }
 
     /**
      * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
-     * @param string $timezone time zone in which the date time should be set, default to result of `date_default_timezone_get`
+     * @param string $timezone time zone in which the date time should be set, default to DateTime::$defaultTimezone, if set, otherwise the result of `date_default_timezone_get`
      * @example DateTime('1964-04-04 11:02:02')
      * @return \DateTime
      */
@@ -179,7 +181,7 @@ class DateTime extends Base
 
     /**
      * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
-     * @param string $timezone time zone in which the date time should be set, default to result of `date_default_timezone_get`
+     * @param string $timezone time zone in which the date time should be set, default to DateTime::$defaultTimezone, if set, otherwise the result of `date_default_timezone_get`
      * @example DateTime('2010-03-10 05:18:58')
      * @return \DateTime
      */
@@ -190,7 +192,7 @@ class DateTime extends Base
 
     /**
      * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
-     * @param string $timezone time zone in which the date time should be set, default to result of `date_default_timezone_get`
+     * @param string $timezone time zone in which the date time should be set, default to DateTime::$defaultTimezone, if set, otherwise the result of `date_default_timezone_get`
      * @example DateTime('2011-09-19 09:24:37')
      * @return \DateTime
      */
@@ -201,7 +203,7 @@ class DateTime extends Base
 
     /**
      * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
-     * @param string $timezone time zone in which the date time should be set, default to result of `date_default_timezone_get`
+     * @param string $timezone time zone in which the date time should be set, default to DateTime::$defaultTimezone, if set, otherwise the result of `date_default_timezone_get`
      * @example DateTime('2011-10-05 12:51:46')
      * @return \DateTime
      */
@@ -298,6 +300,33 @@ class DateTime extends Base
      */
     private static function setTimezone(\DateTime $dt, $timezone)
     {
-        return $dt->setTimezone(new \DateTimeZone($timezone));
+        return $dt->setTimezone(new \DateTimeZone(static::resolveTimezone($timezone)));
+    }
+
+    /**
+     * Sets default time zone.
+     *
+     * @param string $timezone
+     *
+     * @return void
+     */
+    public static function setDefaultTimezone($timezone = null)
+    {
+        static::$defaultTimezone = $timezone;
+    }
+
+    /**
+     * Gets default time zone.
+     *
+     * @return string
+     */
+    public static function getDefaultTimezone()
+    {
+        return static::$defaultTimezone;
+    }
+
+    private static function resolveTimezone($timezone)
+    {
+        return ((null === $timezone) ? ((null === static::$defaultTimezone) ? date_default_timezone_get() : static::$defaultTimezone) : $timezone);
     }
 }

--- a/test/Faker/Provider/DateTimeTest.php
+++ b/test/Faker/Provider/DateTimeTest.php
@@ -8,14 +8,63 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        $this->originalTz = date_default_timezone_get();
         $this->defaultTz = 'UTC';
-        date_default_timezone_set($this->defaultTz);
+        DateTimeProvider::setDefaultTimezone($this->defaultTz);
     }
 
     public function tearDown()
     {
-        date_default_timezone_set($this->originalTz);
+        DateTimeProvider::setDefaultTimezone();
+    }
+
+    public function testPreferDefaultTimezoneOverSystemTimezone()
+    {
+        /**
+         * Set the system timezone to something *other* than the timezone used
+         * in setUp().
+         */
+        $originalSystemTimezone = date_default_timezone_get();
+        $systemTimezone = 'Antarctica/Vostok';
+        date_default_timezone_set($systemTimezone);
+
+        /**
+         * Get a new date/time value and assert that it prefers the default
+         * timezone over the system timezone.
+         */
+        $date = DateTimeProvider::dateTime();
+        $this->assertNotSame($systemTimezone, $date->getTimezone()->getName());
+        $this->assertSame($this->defaultTz, $date->getTimezone()->getName());
+
+        /**
+         * Restore the system timezone.
+         */
+        date_default_timezone_set($originalSystemTimezone);
+    }
+
+    public function testUseSystemTimezoneWhenDefaultTimezoneIsNotSet()
+    {
+        /**
+         * Set the system timezone to something *other* than the timezone used
+         * in setUp() *and* reset the default timezone.
+         */
+        $originalSystemTimezone = date_default_timezone_get();
+        $originalDefaultTimezone = DateTimeProvider::getDefaultTimezone();
+        $systemTimezone = 'Antarctica/Vostok';
+        date_default_timezone_set($systemTimezone);
+        DateTimeProvider::setDefaultTimezone();
+
+        /**
+         * Get a new date/time value and assert that it uses the system timezone
+         * and not the system timezone.
+         */
+        $date = DateTimeProvider::dateTime();
+        $this->assertSame($systemTimezone, $date->getTimezone()->getName());
+        $this->assertNotSame($this->defaultTz, $date->getTimezone()->getName());
+
+        /**
+         * Restore the system timezone.
+         */
+        date_default_timezone_set($originalSystemTimezone);
     }
 
     public function testUnixTime()

--- a/test/Faker/Provider/ro_RO/PersonTest.php
+++ b/test/Faker/Provider/ro_RO/PersonTest.php
@@ -15,22 +15,19 @@ class PersonTest extends \PHPUnit_Framework_TestCase
      *
      */
     protected $faker;
-    protected $originalTz;
 
     public function setUp()
     {
-        $this->originalTz = @date_default_timezone_get();
-        date_default_timezone_set('Europe/Bucharest');
-
         $faker = new Generator();
         $faker->addProvider(new DateTime($faker));
         $faker->addProvider(new Person($faker));
+        $faker->setDefaultTimezone('Europe/Bucharest');
         $this->faker = $faker;
     }
 
     public function tearDown()
     {
-        date_default_timezone_set($this->originalTz);
+        $this->faker->setDefaultTimezone();
     }
 
     public function invalidGenderProvider()


### PR DESCRIPTION
Inspiration: @curry684 

This PR introduces the ability to set a default timezone that will be used when no timezone is provided by a caller.

It does *not* break existing code, to the best of my knowledge, because the default value is `null` and when it's set to `null`, then it gets the timezone from `date_default_timezone_get()`.  (One of the new unit tests covers this scenario.)

Users can set the default timezone via `$faker->setDefaultTimezone('Europe/Copenhagen')` and can see its current value via `$faker->getDefaultTimezone()`.

If `$faker->setDefaultTimezone()` is called, then it effectively "resets" the default timezone value to `null`, which means that timezones will again be determined by `date_default_timezone_get()` when the caller does not provide a timezone.

A little refactoring was done in the `DateTime` provider, moving the timezone resolution logic into one place instead of having it spread out.

The `DateTime` provider test class was updated a bit, making use of the new functionality in the `setUp()` and `tearDown()` methods.  Additionally, two new tests were added to test some of this new functionality.

The documentation was updated a bit to provide a little explanation on how the timezones would be determined an how users could get and set the timezones using both the new and old functionality.

Finally, the Romanian `Person` test class was also updated a bit, also making use of the new functionality.  It was unclear to me, however, that the timezone changing in that class had any impact.