### PR TITLE
[he_IL] Add Internet Provider (Ref: #1263)

### DIFF
--- a/src/Faker/Provider/he_IL/Internet.php
+++ b/src/Faker/Provider/he_IL/Internet.php
@@ -5,6 +5,7 @@ namespace Faker\Provider\he_IL;
 class Internet extends \Faker\Provider\Internet
 {
   protected static $freeEmailDomain = array('nana.co.il', 'gmail.com', 'hotmail.co.il', 'walla.co.il');
+  protected static $tld = array('com', 'net', 'org', 'co.il');
 }
 
 ?>

--- a/src/Faker/Provider/he_IL/Internet.php
+++ b/src/Faker/Provider/he_IL/Internet.php
@@ -4,8 +4,6 @@ namespace Faker\Provider\he_IL;
 
 class Internet extends \Faker\Provider\Internet
 {
-  protected static $freeEmailDomain = array('nana.co.il', 'gmail.com', 'hotmail.co.il', 'walla.co.il');
-  protected static $tld = array('com', 'net', 'org', 'co.il');
+    protected static $freeEmailDomain = array('nana.co.il', 'gmail.com', 'hotmail.co.il', 'walla.co.il');
+    protected static $tld = array('com', 'net', 'org', 'co.il');
 }
-
-?>

--- a/src/Faker/Provider/he_IL/Internet.php
+++ b/src/Faker/Provider/he_IL/Internet.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Faker\Provider\he_IL;
+
+class Internet extends \Faker\Provider\Internet
+{
+  protected static $freeEmailDomain = array('nana.co.il', 'gmail.com', 'hotmail.co.il', 'walla.co.il');
+}
+
+?>

--- a/test/Faker/Provider/fr_CH/InternetTest.php
+++ b/test/Faker/Provider/fr_CH/InternetTest.php
@@ -29,7 +29,7 @@ class InternetTest extends \PHPUnit_Framework_TestCase
      */
     public function emailIsValid()
     {
-        $email = $this->faker->unique()->safeEmail;
+        $email = $this->faker->email();
         $this->assertNotFalse(filter_var($email, FILTER_VALIDATE_EMAIL));
     }
 }

--- a/test/Faker/Provider/fr_CH/InternetTest.php
+++ b/test/Faker/Provider/fr_CH/InternetTest.php
@@ -29,7 +29,7 @@ class InternetTest extends \PHPUnit_Framework_TestCase
      */
     public function emailIsValid()
     {
-        $email = $this->faker->email();
+        $email = $this->faker->unique()->safeEmail;
         $this->assertNotFalse(filter_var($email, FILTER_VALIDATE_EMAIL));
     }
 }

--- a/test/Faker/Provider/he_IL/InternetTest.php
+++ b/test/Faker/Provider/he_IL/InternetTest.php
@@ -23,6 +23,16 @@ class InternetTest extends \PHPUnit_Framework_TestCase
      $this->faker = $faker;
    }
 
+   /**
+    * @test
+    */
+
+    public function emailIsValid()
+    {
+      $email = $this->faker->email();
+      $this->assertNotFalse(filter_var($email, FILTER_VALIDATE_EMAIL));
+    }
+
 }
 
 ?>

--- a/test/Faker/Provider/he_IL/InternetTest.php
+++ b/test/Faker/Provider/he_IL/InternetTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Faker\Test\Provider\he_IL;
+
+use Faker\Generator;
+use Faker\Provider\he_IL\Person;
+use Faker\Provider\he_IL\Internet;
+use Faker\Provider\he_IL\Company;
+
+class InternetTest extends \PHPUnit_Framework_TestCase
+{
+
+  /**
+   *  @var Faker\Generator
+   */
+
+   public function setUp()
+   {
+     $faker = new Generator();
+     $faker->addProvider(new Person($faker));
+     $faker->addProvider(new Internet($faker));
+     $faker->addProvider(new Company($faker));
+     $this->faker = $faker;
+   }
+
+}
+
+?>

--- a/test/Faker/Provider/he_IL/InternetTest.php
+++ b/test/Faker/Provider/he_IL/InternetTest.php
@@ -29,7 +29,7 @@ class InternetTest extends \PHPUnit_Framework_TestCase
 
     public function emailIsValid()
     {
-      $email = $this->faker->email();
+      $email = $this->faker->unique()->safeEmail;
       $this->assertNotFalse(filter_var($email, FILTER_VALIDATE_EMAIL));
     }
 


### PR DESCRIPTION
Hi.

As reported in #1263, Hebrew locale was generating non-unique email user names, causing errors like integrity constraint violations. 

I suspect this issue is caused by missing Internet.php provider in he_IL locale, so I decided to add it. I also added a check in unit tests to check the integrity of the e-mail address, following the same model as #1263. 

All tests ran locally and passed.

Thanks. 