### PR TITLE
Fix "Resource temporarily unavailable"

### DIFF
--- a/src/Faker/Provider/Image.php
+++ b/src/Faker/Provider/Image.php
@@ -86,10 +86,10 @@ class Image extends Base
             $success = curl_exec($ch) && curl_getinfo($ch, CURLINFO_HTTP_CODE) === 200;
             fclose($fp);
             curl_close($ch);
-            
-            if (!$success) {            
+
+            if (!$success) {
                 unlink($filepath);
-                
+
                 // could not contact the distant URL or HTTP error - fail silently.
                 return false;
             }

--- a/src/Faker/Provider/Image.php
+++ b/src/Faker/Provider/Image.php
@@ -84,24 +84,20 @@ class Image extends Base
             $ch = curl_init($url);
             curl_setopt($ch, CURLOPT_FILE, $fp);
             $success = curl_exec($ch) && curl_getinfo($ch, CURLINFO_HTTP_CODE) === 200;
-
-            if ($success) {
-                fclose($fp);
-            } else {
-                unlink($filepath);
-            }
-
+            fclose($fp);
             curl_close($ch);
+            
+            if (!$success) {            
+                unlink($filepath);
+                
+                // could not contact the distant URL or HTTP error - fail silently.
+                return false;
+            }
         } elseif (ini_get('allow_url_fopen')) {
             // use remote fopen() via copy()
             $success = copy($url, $filepath);
         } else {
             return new \RuntimeException('The image formatter downloads an image from a remote HTTP server. Therefore, it requires that PHP can request remote hosts, either via cURL or fopen()');
-        }
-
-        if (!$success) {
-            // could not contact the distant URL or HTTP error - fail silently.
-            return false;
         }
 
         return $fullPath ? $filepath : $filename;


### PR DESCRIPTION
When trying to unlink the file after unsuccessful download, a warning is thrown because file is still open