### PR TITLE
[sl_SI] Created provider for Company

### DIFF
--- a/src/Faker/Provider/sl_SI/Company.php
+++ b/src/Faker/Provider/sl_SI/Company.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Faker\Provider\sl_SI;
+
+class Company extends \Faker\Provider\Company
+{
+    protected static $formats = array(
+        '{{firstName}} {{lastName}} s.p.',
+        '{{lastName}} {{companySuffix}}',
+        '{{lastName}}, {{lastName}} in {{lastName}} {{companySuffix}}',
+    );
+
+    protected static $companySuffix = array('d.o.o.', 'd.d.', 'k.d.', 'k.d.d.','d.n.o.','so.p.');
+}


### PR DESCRIPTION
Companies in Slovenija always have a suffix. Also, "and" is translated to "in".