### PR TITLE
Change symbol 'minus' with code 226 to 'minus' with code 45

### DIFF
--- a/src/Faker/Provider/Text.php
+++ b/src/Faker/Provider/Text.php
@@ -136,6 +136,6 @@ abstract class Text extends Base
 
     protected static function appendEnd($text)
     {
-        return rtrim($text, ',— ').'.';
+        return rtrim($text, ',- ').'.';
     }
 }


### PR DESCRIPTION
With utf-8 charset call trim with symbol "- (code 226)" work uncorrect.

Example with Russian string
```
$s = 'Пример';
$res = trim($s, '—');
var_dump($res);

// result: string(11) "Приме�"
```