### PR TITLE
Fix FR_fr 07 prefix mobile number generation

### DIFF
--- a/src/Faker/Provider/fr_FR/PhoneNumber.php
+++ b/src/Faker/Provider/fr_FR/PhoneNumber.php
@@ -52,12 +52,14 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     // Mobile phone numbers start by 06 and 07
     // 06 is the most common prefix
     protected static $mobileFormats  = array(
+        '+33 (0)6 ## ## ## ##',
         '+33 6 ## ## ## ##',
+        '+33 (0)7 {{phoneNumber07WithSeparator}}',
         '+33 7 {{phoneNumber07WithSeparator}}',
         '06########',
-        '07########',
+        '07{{phoneNumber07}}',
         '06 ## ## ## ##',
-        '07 ## ## ## ##',
+        '07 {{phoneNumber07WithSeparator}}',
     );
 
     public function phoneNumber07()
@@ -82,8 +84,10 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     /**
      * @example '0601020304'
      */
-    public static function mobileNumber()
+    public function mobileNumber()
     {
-        return static::numerify(static::randomElement(static::$mobileFormats));
+        $format = static::randomElement(static::$mobileFormats);
+
+        return static::numerify($this->generator->parse($format));
     }
 }

--- a/test/Faker/Provider/fr_FR/PhoneNumberTest.php
+++ b/test/Faker/Provider/fr_FR/PhoneNumberTest.php
@@ -55,6 +55,7 @@ class PhoneNumberTest extends \PHPUnit_Framework_TestCase
                 $mobile = $this->faker->mobileNumber();
             } while ('+33 7' != substr($mobile, 0, 5));
             $this->assertRegExp('/^(?:(?:\+33 (?:\(0\))?)|0)7 (?:3|4|5|6|7|8|9)\d(?: \d{2}){3}$/', $mobile);
+            $i++;
         }
     }
 }

--- a/test/Faker/Provider/fr_FR/PhoneNumberTest.php
+++ b/test/Faker/Provider/fr_FR/PhoneNumberTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Faker\Test\Provider\fr_FR;
+
+use Faker\Generator;
+use Faker\Provider\fr_FR\PhoneNumber;
+
+class PhoneNumberTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Generator
+     */
+    private $faker;
+
+    public function setUp()
+    {
+        $faker = new Generator();
+        $faker->addProvider(new PhoneNumber($faker));
+        $this->faker = $faker;
+    }
+
+    public function testMobileNumber06()
+    {
+        do {
+            $mobile = $this->faker->mobileNumber();
+        } while ('06' != substr($mobile, 0, 2));
+        $this->assertRegExp('/^06(?:\d{2}){4}$/', $mobile);
+    }
+
+    public function testMobileNumber06WithSeparator()
+    {
+        $i = 0;
+        while (10 > $i) {
+            do {
+                $mobile = $this->faker->mobileNumber();
+            } while ('+33 6' != substr($mobile, 0, 5) && '06 ' != substr($mobile, 0, 3));
+            $this->assertRegExp('/^(?:(?:\+33 (?:\(0\))?)|0)6(?: \d{2}){4}$/', $mobile);
+            $i++;
+        }
+    }
+
+    public function testMobileNumber07()
+    {
+        do {
+            $mobile = $this->faker->mobileNumber();
+        } while ('07' != substr($mobile, 0, 2));
+        $this->assertRegExp('/^07(?:3|4|5|6|7|8|9)\d(?:\d{2}){3}$/', $mobile);
+    }
+
+    public function testMobileNumber07WithSeparator()
+    {
+        $i = 0;
+        while (10 > $i) {
+            do {
+                $mobile = $this->faker->mobileNumber();
+            } while ('+33 7' != substr($mobile, 0, 5));
+            $this->assertRegExp('/^(?:(?:\+33 (?:\(0\))?)|0)7 (?:3|4|5|6|7|8|9)\d(?: \d{2}){3}$/', $mobile);
+        }
+    }
+}

--- a/test/Faker/Provider/fr_FR/PhoneNumberTest.php
+++ b/test/Faker/Provider/fr_FR/PhoneNumberTest.php
@@ -23,7 +23,7 @@ class PhoneNumberTest extends \PHPUnit_Framework_TestCase
     {
         do {
             $mobile = $this->faker->mobileNumber();
-        } while ('06' != substr($mobile, 0, 2));
+        } while (' ' == $mobile[2] || '06' != substr($mobile, 0, 2));
         $this->assertRegExp('/^06(?:\d{2}){4}$/', $mobile);
     }
 
@@ -43,7 +43,7 @@ class PhoneNumberTest extends \PHPUnit_Framework_TestCase
     {
         do {
             $mobile = $this->faker->mobileNumber();
-        } while ('07' != substr($mobile, 0, 2));
+        } while (' ' == $mobile[2] || '07' != substr($mobile, 0, 2));
         $this->assertRegExp('/^07(?:3|4|5|6|7|8|9)\d(?:\d{2}){3}$/', $mobile);
     }
 


### PR DESCRIPTION
Bonjour François,

For the FR_fr provider, the `$faker->mobileNumber` does not call  the `phoneNumber07` and `phoneNumber07WithSeparator` methods because method `mobileNumber` does not invoke the generator but instead calls `static::numerify()` directly.
Also, not all of the 07xx formats have been transposed to `static::$mobileFormats`, and not all 07 formats call upon `phoneNumber07` or `phoneNumber07WithSeparator`, whereas they should.

I've shamelessly taken PR https://github.com/fzaninotto/Faker/pull/1304 from ctessier to fix the inners of the `mobileNumber()` method, and have replaced the `#` with `{{phoneNumber07[WithSeparator]}}` where approriate.
I've also added some tests (only tested the regular expressions, did not actually run the tests as I don't have PHPUnit installed).

Hoping you can merge this in soonish, our database seed fails because we use https://github.com/giggsey/libphonenumber-for-php to check phone number validity and currently part of the 07xx ones generated by Faker don't pass the isValid test.