### PR TITLE
Use PSR-1 for PHPUnit TestCase

### DIFF
--- a/test/Faker/Calculator/IbanTest.php
+++ b/test/Faker/Calculator/IbanTest.php
@@ -3,8 +3,9 @@
 namespace Faker\Test\Calculator;
 
 use Faker\Calculator\Iban;
+use PHPUnit\Framework\TestCase;
 
-class IbanTest extends \PHPUnit_Framework_TestCase
+class IbanTest extends TestCase
 {
 
     public function checksumProvider()

--- a/test/Faker/Calculator/InnTest.php
+++ b/test/Faker/Calculator/InnTest.php
@@ -3,8 +3,9 @@
 namespace Faker\Test\Calculator;
 
 use Faker\Calculator\Inn;
+use PHPUnit\Framework\TestCase;
 
-class InnTest extends \PHPUnit_Framework_TestCase
+class InnTest extends TestCase
 {
 
     public function checksumProvider()

--- a/test/Faker/Calculator/LuhnTest.php
+++ b/test/Faker/Calculator/LuhnTest.php
@@ -3,8 +3,9 @@
 namespace Faker\Test\Calculator;
 
 use Faker\Calculator\Luhn;
+use PHPUnit\Framework\TestCase;
 
-class LuhnTest extends \PHPUnit_Framework_TestCase
+class LuhnTest extends TestCase
 {
 
     public function checkDigitProvider()

--- a/test/Faker/DefaultGeneratorTest.php
+++ b/test/Faker/DefaultGeneratorTest.php
@@ -3,8 +3,9 @@
 namespace Faker\Test;
 
 use Faker\DefaultGenerator;
+use PHPUnit\Framework\TestCase;
 
-class DefaultGeneratorTest extends \PHPUnit_Framework_TestCase
+class DefaultGeneratorTest extends TestCase
 {
     public function testGeneratorReturnsNullByDefault()
     {

--- a/test/Faker/GeneratorTest.php
+++ b/test/Faker/GeneratorTest.php
@@ -3,8 +3,9 @@
 namespace Faker\Test;
 
 use Faker\Generator;
+use PHPUnit\Framework\TestCase;
 
-class GeneratorTest extends \PHPUnit_Framework_TestCase
+class GeneratorTest extends TestCase
 {
     public function testAddProviderGivesPriorityToNewlyAddedProvider()
     {

--- a/test/Faker/Provider/AddressTest.php
+++ b/test/Faker/Provider/AddressTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider;
 
 use Faker\Generator;
 use Faker\Provider\Address;
+use PHPUnit\Framework\TestCase;
 
-class AddressTest extends \PHPUnit_Framework_TestCase
+class AddressTest extends TestCase
 {
     private $faker;
 

--- a/test/Faker/Provider/BarcodeTest.php
+++ b/test/Faker/Provider/BarcodeTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider;
 
 use Faker\Generator;
 use Faker\Provider\Barcode;
+use PHPUnit\Framework\TestCase;
 
-class BarcodeTest extends \PHPUnit_Framework_TestCase
+class BarcodeTest extends TestCase
 {
     private $faker;
 

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -3,8 +3,9 @@
 namespace Faker\Test\Provider;
 
 use Faker\Provider\Base as BaseProvider;
+use PHPUnit\Framework\TestCase;
 
-class BaseTest extends \PHPUnit_Framework_TestCase
+class BaseTest extends TestCase
 {
     public function testRandomDigitReturnsInteger()
     {

--- a/test/Faker/Provider/BiasedTest.php
+++ b/test/Faker/Provider/BiasedTest.php
@@ -3,14 +3,15 @@ namespace Faker\Test\Provider;
 
 use Faker\Provider\Biased;
 use Faker\Generator;
+use PHPUnit\Framework\TestCase;
 
-class BiasedTest extends \PHPUnit_Framework_TestCase
+class BiasedTest extends TestCase
 {
     const MAX = 10;
     const NUMBERS = 25000;
     protected $generator;
     protected $results = array();
-    
+
     protected function setUp()
     {
         $this->generator = new Generator();
@@ -18,14 +19,14 @@ class BiasedTest extends \PHPUnit_Framework_TestCase
 
         $this->results = array_fill(1, self::MAX, 0);
     }
-    
+
     public function performFake($function)
     {
         for($i = 0; $i < self::NUMBERS; $i++) {
             $this->results[$this->generator->biasedNumberBetween(1, self::MAX, $function)]++;
         }
     }
-    
+
     public function testUnbiased()
     {
         $this->performFake(array('\Faker\Provider\Biased', 'unbiased'));
@@ -40,7 +41,7 @@ class BiasedTest extends \PHPUnit_Framework_TestCase
             $this->assertLessThan(self::NUMBERS * $assumed * 1.05, $amount, "Value was more than 5 percent over the expected value");
         }
     }
-    
+
     public function testLinearHigh()
     {
         $this->performFake(array('\Faker\Provider\Biased', 'linearHigh'));
@@ -54,7 +55,7 @@ class BiasedTest extends \PHPUnit_Framework_TestCase
             $this->assertLessThan(self::NUMBERS * $assumed * 1.1, $amount, "Value was more than 10 percent over the expected value");
         }
     }
-    
+
     public function testLinearLow()
     {
         $this->performFake(array('\Faker\Provider\Biased', 'linearLow'));

--- a/test/Faker/Provider/ColorTest.php
+++ b/test/Faker/Provider/ColorTest.php
@@ -3,8 +3,9 @@
 namespace Faker\Test\Provider;
 
 use Faker\Provider\Color;
+use PHPUnit\Framework\TestCase;
 
-class ColorTest extends \PHPUnit_Framework_TestCase
+class ColorTest extends TestCase
 {
 
     public function testHexColor()

--- a/test/Faker/Provider/CompanyTest.php
+++ b/test/Faker/Provider/CompanyTest.php
@@ -5,8 +5,9 @@ namespace Faker\Test\Provider;
 use Faker\Generator;
 use Faker\Provider\Company;
 use Faker\Provider\Lorem;
+use PHPUnit\Framework\TestCase;
 
-class CompanyTest extends \PHPUnit_Framework_TestCase
+class CompanyTest extends TestCase
 {
     /**
      * @var Generator

--- a/test/Faker/Provider/DateTimeTest.php
+++ b/test/Faker/Provider/DateTimeTest.php
@@ -3,8 +3,9 @@
 namespace Faker\Test\Provider;
 
 use Faker\Provider\DateTime as DateTimeProvider;
+use PHPUnit\Framework\TestCase;
 
-class DateTimeTest extends \PHPUnit_Framework_TestCase
+class DateTimeTest extends TestCase
 {
     public function setUp()
     {

--- a/test/Faker/Provider/HtmlLoremTest.php
+++ b/test/Faker/Provider/HtmlLoremTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider;
 
 use Faker\Generator;
 use Faker\Provider\HtmlLorem;
+use PHPUnit\Framework\TestCase;
 
-class HtmlLoremTest extends \PHPUnit_Framework_TestCase
+class HtmlLoremTest extends TestCase
 {
 
     public function testProvider()

--- a/test/Faker/Provider/ImageTest.php
+++ b/test/Faker/Provider/ImageTest.php
@@ -3,8 +3,9 @@
 namespace Faker\Test\Provider;
 
 use Faker\Provider\Image;
+use PHPUnit\Framework\TestCase;
 
-class ImageTest extends \PHPUnit_Framework_TestCase
+class ImageTest extends TestCase
 {
     public function testImageUrlUses640x680AsTheDefaultSize()
     {

--- a/test/Faker/Provider/InternetTest.php
+++ b/test/Faker/Provider/InternetTest.php
@@ -7,8 +7,9 @@ use Faker\Provider\Company;
 use Faker\Provider\Internet;
 use Faker\Provider\Lorem;
 use Faker\Provider\Person;
+use PHPUnit\Framework\TestCase;
 
-class InternetTest extends \PHPUnit_Framework_TestCase
+class InternetTest extends TestCase
 {
     /**
      * @var Generator

--- a/test/Faker/Provider/LocalizationTest.php
+++ b/test/Faker/Provider/LocalizationTest.php
@@ -3,8 +3,9 @@
 namespace Faker\Test\Provider;
 
 use Faker\Factory;
+use PHPUnit\Framework\TestCase;
 
-class LocalizationTest extends \PHPUnit_Framework_TestCase
+class LocalizationTest extends TestCase
 {
     public function testLocalizedNameProvidersDoNotThrowErrors()
     {

--- a/test/Faker/Provider/LoremTest.php
+++ b/test/Faker/Provider/LoremTest.php
@@ -3,8 +3,9 @@
 namespace Faker\Test\Provider;
 
 use Faker\Provider\Lorem;
+use PHPUnit\Framework\TestCase;
 
-class LoremTest extends \PHPUnit_Framework_TestCase
+class LoremTest extends TestCase
 {
     /**
      * @expectedException \InvalidArgumentException

--- a/test/Faker/Provider/MiscellaneousTest.php
+++ b/test/Faker/Provider/MiscellaneousTest.php
@@ -3,8 +3,9 @@
 namespace Faker\Test\Provider;
 
 use Faker\Provider\Miscellaneous;
+use PHPUnit\Framework\TestCase;
 
-class MiscellaneousTest extends \PHPUnit_Framework_TestCase
+class MiscellaneousTest extends TestCase
 {
     public function testBoolean()
     {

--- a/test/Faker/Provider/PaymentTest.php
+++ b/test/Faker/Provider/PaymentTest.php
@@ -9,8 +9,9 @@ use Faker\Provider\Base as BaseProvider;
 use Faker\Provider\DateTime as DateTimeProvider;
 use Faker\Provider\Payment as PaymentProvider;
 use Faker\Provider\Person as PersonProvider;
+use PHPUnit\Framework\TestCase;
 
-class PaymentTest extends \PHPUnit_Framework_TestCase
+class PaymentTest extends TestCase
 {
     private $faker;
 

--- a/test/Faker/Provider/PersonTest.php
+++ b/test/Faker/Provider/PersonTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider;
 
 use Faker\Provider\Person;
 use Faker\Generator;
+use PHPUnit\Framework\TestCase;
 
-class PersonTest extends \PHPUnit_Framework_TestCase
+class PersonTest extends TestCase
 {
     /**
      * @dataProvider firstNameProvider

--- a/test/Faker/Provider/PhoneNumberTest.php
+++ b/test/Faker/Provider/PhoneNumberTest.php
@@ -5,8 +5,9 @@ namespace Faker\Test\Provider;
 use Faker\Generator;
 use Faker\Calculator\Luhn;
 use Faker\Provider\PhoneNumber;
+use PHPUnit\Framework\TestCase;
 
-class PhoneNumberTest extends \PHPUnit_Framework_TestCase
+class PhoneNumberTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/ProviderOverrideTest.php
+++ b/test/Faker/Provider/ProviderOverrideTest.php
@@ -6,6 +6,7 @@
 namespace Faker\Test\Provider;
 
 use Faker;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ProviderOverrideTest
@@ -16,7 +17,7 @@ use Faker;
  * locale specific provider (can) has specific implementations. The goal of this test is to test the common denominator
  * and to try to catch possible invalid multi-byte sequences.
  */
-class ProviderOverrideTest extends \PHPUnit_Framework_TestCase
+class ProviderOverrideTest extends TestCase
 {
     /**
      * Constants with regular expression patterns for testing the output.

--- a/test/Faker/Provider/TextTest.php
+++ b/test/Faker/Provider/TextTest.php
@@ -3,8 +3,9 @@ namespace Faker\Test\Provider;
 
 use Faker\Provider\en_US\Text;
 use Faker\Generator;
+use PHPUnit\Framework\TestCase;
 
-class TextTest extends \PHPUnit_Framework_TestCase
+class TextTest extends TestCase
 {
     public function testTextMaxLength()
     {

--- a/test/Faker/Provider/UserAgentTest.php
+++ b/test/Faker/Provider/UserAgentTest.php
@@ -3,8 +3,9 @@
 namespace Faker\Test\Provider;
 
 use Faker\Provider\UserAgent;
+use PHPUnit\Framework\TestCase;
 
-class UserAgentTest extends \PHPUnit_Framework_TestCase
+class UserAgentTest extends TestCase
 {
     public function testRandomUserAgent()
     {

--- a/test/Faker/Provider/UuidTest.php
+++ b/test/Faker/Provider/UuidTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider;
 
 use Faker\Generator;
 use Faker\Provider\Uuid as BaseProvider;
+use PHPUnit\Framework\TestCase;
 
-class UuidTest extends \PHPUnit_Framework_TestCase
+class UuidTest extends TestCase
 {
     public function testUuidReturnsUuid()
     {

--- a/test/Faker/Provider/ar_JO/InternetTest.php
+++ b/test/Faker/Provider/ar_JO/InternetTest.php
@@ -6,8 +6,9 @@ use Faker\Generator;
 use Faker\Provider\fi_FI\Person;
 use Faker\Provider\fi_FI\Internet;
 use Faker\Provider\fi_FI\Company;
+use PHPUnit\Framework\TestCase;
 
-class InternetTest extends \PHPUnit_Framework_TestCase
+class InternetTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/ar_SA/InternetTest.php
+++ b/test/Faker/Provider/ar_SA/InternetTest.php
@@ -6,8 +6,9 @@ use Faker\Generator;
 use Faker\Provider\ar_SA\Person;
 use Faker\Provider\ar_SA\Internet;
 use Faker\Provider\ar_SA\Company;
+use PHPUnit\Framework\TestCase;
 
-class InternetTest extends \PHPUnit_Framework_TestCase
+class InternetTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/at_AT/PaymentTest.php
+++ b/test/Faker/Provider/at_AT/PaymentTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\at_AT;
 
 use Faker\Generator;
 use Faker\Provider\at_AT\Payment;
+use PHPUnit\Framework\TestCase;
 
-class PaymentTest extends \PHPUnit_Framework_TestCase
+class PaymentTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/bg_BG/PaymentTest.php
+++ b/test/Faker/Provider/bg_BG/PaymentTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\bg_BG;
 
 use Faker\Generator;
 use Faker\Provider\bg_BG\Payment;
+use PHPUnit\Framework\TestCase;
 
-class PaymentTest extends \PHPUnit_Framework_TestCase
+class PaymentTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/bn_BD/PersonTest.php
+++ b/test/Faker/Provider/bn_BD/PersonTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\bn_BD;
 
 use Faker\Generator;
 use Faker\Provider\bn_BD\Person;
+use PHPUnit\Framework\TestCase;
 
-class PersonTest extends \PHPUnit_Framework_TestCase
+class PersonTest extends TestCase
 {
     public function setUp()
     {

--- a/test/Faker/Provider/cs_CZ/PersonTest.php
+++ b/test/Faker/Provider/cs_CZ/PersonTest.php
@@ -5,8 +5,9 @@ namespace Faker\Test\Provider\cs_CZ;
 use Faker\Generator;
 use Faker\Provider\cs_CZ\Person;
 use Faker\Provider\Miscellaneous;
+use PHPUnit\Framework\TestCase;
 
-class PersonTest extends \PHPUnit_Framework_TestCase
+class PersonTest extends TestCase
 {
     public function testBirthNumber()
     {
@@ -14,7 +15,7 @@ class PersonTest extends \PHPUnit_Framework_TestCase
         $faker->addProvider(new Person($faker));
         $faker->addProvider(new Miscellaneous($faker));
 
-        for ($i = 0; $i < 1000; $i++) { 
+        for ($i = 0; $i < 1000; $i++) {
             $birthNumber = $faker->birthNumber();
             $birthNumber = str_replace('/', '', $birthNumber);
 

--- a/test/Faker/Provider/da_DK/InternetTest.php
+++ b/test/Faker/Provider/da_DK/InternetTest.php
@@ -6,8 +6,9 @@ use Faker\Generator;
 use Faker\Provider\da_DK\Person;
 use Faker\Provider\da_DK\Internet;
 use Faker\Provider\da_DK\Company;
+use PHPUnit\Framework\TestCase;
 
-class InternetTest extends \PHPUnit_Framework_TestCase
+class InternetTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/de_AT/InternetTest.php
+++ b/test/Faker/Provider/de_AT/InternetTest.php
@@ -6,8 +6,9 @@ use Faker\Generator;
 use Faker\Provider\de_AT\Person;
 use Faker\Provider\de_AT\Internet;
 use Faker\Provider\de_AT\Company;
+use PHPUnit\Framework\TestCase;
 
-class InternetTest extends \PHPUnit_Framework_TestCase
+class InternetTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/de_AT/PhoneNumberTest.php
+++ b/test/Faker/Provider/de_AT/PhoneNumberTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\de_AT;
 
 use Faker\Generator;
 use Faker\Provider\de_AT\PhoneNumber;
+use PHPUnit\Framework\TestCase;
 
-class PhoneNumberTest extends \PHPUnit_Framework_TestCase
+class PhoneNumberTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/de_CH/AddressTest.php
+++ b/test/Faker/Provider/de_CH/AddressTest.php
@@ -5,8 +5,9 @@ namespace Faker\Test\Provider\de_CH;
 use Faker\Generator;
 use Faker\Provider\de_CH\Address;
 use Faker\Provider\de_CH\Person;
+use PHPUnit\Framework\TestCase;
 
-class AddressTest extends \PHPUnit_Framework_TestCase
+class AddressTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/de_CH/InternetTest.php
+++ b/test/Faker/Provider/de_CH/InternetTest.php
@@ -6,8 +6,9 @@ use Faker\Generator;
 use Faker\Provider\de_CH\Person;
 use Faker\Provider\de_CH\Internet;
 use Faker\Provider\de_CH\Company;
+use PHPUnit\Framework\TestCase;
 
-class InternetTest extends \PHPUnit_Framework_TestCase
+class InternetTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/de_CH/PhoneNumberTest.php
+++ b/test/Faker/Provider/de_CH/PhoneNumberTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\de_CH;
 
 use Faker\Generator;
 use Faker\Provider\de_CH\PhoneNumber;
+use PHPUnit\Framework\TestCase;
 
-class PhoneNumberTest extends \PHPUnit_Framework_TestCase
+class PhoneNumberTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/de_DE/InternetTest.php
+++ b/test/Faker/Provider/de_DE/InternetTest.php
@@ -6,8 +6,9 @@ use Faker\Generator;
 use Faker\Provider\de_DE\Person;
 use Faker\Provider\de_DE\Internet;
 use Faker\Provider\de_DE\Company;
+use PHPUnit\Framework\TestCase;
 
-class InternetTest extends \PHPUnit_Framework_TestCase
+class InternetTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/en_AU/AddressTest.php
+++ b/test/Faker/Provider/en_AU/AddressTest.php
@@ -4,8 +4,9 @@ namespace Faker\Provider\en_AU;
 
 use Faker\Generator;
 use Faker\Provider\en_AU\Address;
+use PHPUnit\Framework\TestCase;
 
-class AddressTest extends \PHPUnit_Framework_TestCase
+class AddressTest extends TestCase
 {
 
   /**

--- a/test/Faker/Provider/en_CA/AddressTest.php
+++ b/test/Faker/Provider/en_CA/AddressTest.php
@@ -4,8 +4,9 @@ namespace Faker\Provider\en_CA;
 
 use Faker\Generator;
 use Faker\Provider\en_CA\Address;
+use PHPUnit\Framework\TestCase;
 
-class AddressTest extends \PHPUnit_Framework_TestCase
+class AddressTest extends TestCase
 {
 
   /**

--- a/test/Faker/Provider/en_GB/AddressTest.php
+++ b/test/Faker/Provider/en_GB/AddressTest.php
@@ -3,8 +3,9 @@
 namespace Faker\Provider\en_GB;
 
 use Faker\Generator;
+use PHPUnit\Framework\TestCase;
 
-class AddressTest extends \PHPUnit_Framework_TestCase
+class AddressTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/en_IN/AddressTest.php
+++ b/test/Faker/Provider/en_IN/AddressTest.php
@@ -4,8 +4,9 @@ namespace Faker\Provider\en_IN;
 
 use Faker\Generator;
 use Faker\Provider\en_IN\Address;
+use PHPUnit\Framework\TestCase;
 
-class AddressTest extends \PHPUnit_Framework_TestCase
+class AddressTest extends TestCase
 {
 
   /**

--- a/test/Faker/Provider/en_NG/AddressTest.php
+++ b/test/Faker/Provider/en_NG/AddressTest.php
@@ -4,8 +4,9 @@ namespace Faker\Provider\ng_NG;
 
 use Faker\Generator;
 use Faker\Provider\en_NG\Address;
+use PHPUnit\Framework\TestCase;
 
-class AddressTest extends \PHPUnit_Framework_TestCase
+class AddressTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/en_NG/InternetTest.php
+++ b/test/Faker/Provider/en_NG/InternetTest.php
@@ -5,8 +5,9 @@ namespace Faker\Test\Provider\ng_NG;
 use Faker\Generator;
 use Faker\Provider\en_NG\Person;
 use Faker\Provider\en_NG\Internet;
+use PHPUnit\Framework\TestCase;
 
-class InternetTest extends \PHPUnit_Framework_TestCase
+class InternetTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/en_NG/PersonTest.php
+++ b/test/Faker/Provider/en_NG/PersonTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\ng_NG;
 
 use Faker\Generator;
 use Faker\Provider\en_NG\Person;
+use PHPUnit\Framework\TestCase;
 
-class PersonTest extends \PHPUnit_Framework_TestCase
+class PersonTest extends TestCase
 {
      /**
      * @var Generator

--- a/test/Faker/Provider/en_NG/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_NG/PhoneNumberTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\ng_NG;
 
 use Faker\Generator;
 use Faker\Provider\en_NG\PhoneNumber;
+use PHPUnit\Framework\TestCase;
 
-class PhoneNumberTest extends \PHPUnit_Framework_TestCase
+class PhoneNumberTest extends TestCase
 {
     public function setUp()
     {

--- a/test/Faker/Provider/en_NZ/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_NZ/PhoneNumberTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\en_NZ;
 
 use Faker\Generator;
 use Faker\Provider\en_NZ\PhoneNumber;
+use PHPUnit\Framework\TestCase;
 
-class PhoneNumberTest extends \PHPUnit_Framework_TestCase
+class PhoneNumberTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/en_PH/AddressTest.php
+++ b/test/Faker/Provider/en_PH/AddressTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\en_PH;
 
 use Faker\Generator;
 use Faker\Provider\en_PH\Address;
+use PHPUnit\Framework\TestCase;
 
-class AddressTest extends \PHPUnit_Framework_TestCase
+class AddressTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/en_SG/AddressTest.php
+++ b/test/Faker/Provider/en_SG/AddressTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\en_SG;
 
 use Faker\Factory;
 use Faker\Provider\en_SG\Address;
+use PHPUnit\Framework\TestCase;
 
-class AddressTest extends \PHPUnit_Framework_TestCase
+class AddressTest extends TestCase
 {
     public function setUp()
     {

--- a/test/Faker/Provider/en_SG/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_SG/PhoneNumberTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\en_SG;
 
 use Faker\Factory;
 use Faker\Provider\en_SG\PhoneNumber;
+use PHPUnit\Framework\TestCase;
 
-class PhoneNumberTest extends \PHPUnit_Framework_TestCase
+class PhoneNumberTest extends TestCase
 {
     private $faker;
 

--- a/test/Faker/Provider/en_UG/AddressTest.php
+++ b/test/Faker/Provider/en_UG/AddressTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\en_UG;
 
 use Faker\Generator;
 use Faker\Provider\en_UG\Address;
+use PHPUnit\Framework\TestCase;
 
-class AddressTest extends \PHPUnit_Framework_TestCase
+class AddressTest extends TestCase
 {
 
 /**

--- a/test/Faker/Provider/en_US/PaymentTest.php
+++ b/test/Faker/Provider/en_US/PaymentTest.php
@@ -4,8 +4,9 @@
 namespace Faker\Provider\en_US;
 
 use Faker\Generator;
+use PHPUnit\Framework\TestCase;
 
-class PaymentTest extends \PHPUnit_Framework_TestCase
+class PaymentTest extends TestCase
 {
     /**
      * @var Generator

--- a/test/Faker/Provider/en_US/PersonTest.php
+++ b/test/Faker/Provider/en_US/PersonTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\en_US;
 
 use Faker\Provider\en_US\Person;
 use Faker\Generator;
+use PHPUnit\Framework\TestCase;
 
-class PersonTest extends \PHPUnit_Framework_TestCase
+class PersonTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/en_US/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_US/PhoneNumberTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\en_US;
 
 use Faker\Generator;
 use Faker\Provider\en_US\PhoneNumber;
+use PHPUnit\Framework\TestCase;
 
-class PhoneNumberTest extends \PHPUnit_Framework_TestCase
+class PhoneNumberTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/en_ZA/CompanyTest.php
+++ b/test/Faker/Provider/en_ZA/CompanyTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\en_ZA;
 
 use Faker\Generator;
 use Faker\Provider\en_ZA\Company;
+use PHPUnit\Framework\TestCase;
 
-class CompanyTest extends \PHPUnit_Framework_TestCase
+class CompanyTest extends TestCase
 {
     private $faker;
 

--- a/test/Faker/Provider/en_ZA/InternetTest.php
+++ b/test/Faker/Provider/en_ZA/InternetTest.php
@@ -6,8 +6,9 @@ use Faker\Generator;
 use Faker\Provider\en_ZA\Person;
 use Faker\Provider\en_ZA\Internet;
 use Faker\Provider\en_ZA\Company;
+use PHPUnit\Framework\TestCase;
 
-class InternetTest extends \PHPUnit_Framework_TestCase
+class InternetTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/en_ZA/PersonTest.php
+++ b/test/Faker/Provider/en_ZA/PersonTest.php
@@ -5,8 +5,9 @@ namespace Faker\Test\Provider\en_ZA;
 use Faker\Generator;
 use Faker\Provider\en_ZA\Person;
 use Faker\Provider\DateTime;
+use PHPUnit\Framework\TestCase;
 
-class PersonTest extends \PHPUnit_Framework_TestCase
+class PersonTest extends TestCase
 {
     private $faker;
 

--- a/test/Faker/Provider/en_ZA/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_ZA/PhoneNumberTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\en_ZA;
 
 use Faker\Generator;
 use Faker\Provider\en_ZA\PhoneNumber;
+use PHPUnit\Framework\TestCase;
 
-class PhoneNumberTest extends \PHPUnit_Framework_TestCase
+class PhoneNumberTest extends TestCase
 {
     private $faker;
 

--- a/test/Faker/Provider/es_ES/PaymentTest.php
+++ b/test/Faker/Provider/es_ES/PaymentTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\es_ES;
 
 use Faker\Generator;
 use Faker\Provider\es_ES\Payment;
+use PHPUnit\Framework\TestCase;
 
-class PaymentTest extends \PHPUnit_Framework_TestCase
+class PaymentTest extends TestCase
 {
     /**
      * @var Generator

--- a/test/Faker/Provider/es_ES/PersonTest.php
+++ b/test/Faker/Provider/es_ES/PersonTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\es_ES;
 
 use Faker\Generator;
 use Faker\Provider\es_ES\Person;
+use PHPUnit\Framework\TestCase;
 
-class PersonTest extends \PHPUnit_Framework_TestCase
+class PersonTest extends TestCase
 {
     public function setUp()
     {

--- a/test/Faker/Provider/es_ES/TextTest.php
+++ b/test/Faker/Provider/es_ES/TextTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\es_ES;
 
 use Faker\Generator;
 use Faker\Provider\es_ES\Text;
+use PHPUnit\Framework\TestCase;
 
-class TextTest extends \PHPUnit_Framework_TestCase
+class TextTest extends TestCase
 {
     /**
      * @var Generator

--- a/test/Faker/Provider/es_PE/PersonTest.php
+++ b/test/Faker/Provider/es_PE/PersonTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\es_PE;
 
 use Faker\Generator;
 use Faker\Provider\es_PE\Person;
+use PHPUnit\Framework\TestCase;
 
-class PersonTest extends \PHPUnit_Framework_TestCase
+class PersonTest extends TestCase
 {
     /**
      * @var Generator

--- a/test/Faker/Provider/es_VE/CompanyTest.php
+++ b/test/Faker/Provider/es_VE/CompanyTest.php
@@ -7,11 +7,11 @@
 
 namespace Faker\Test\Provider\es_VE;
 
-
 use Faker\Generator;
 use Faker\Provider\es_VE\Company;
+use PHPUnit\Framework\TestCase;
 
-class CompanyTest extends \PHPUnit_Framework_TestCase
+class CompanyTest extends TestCase
 {
     /**
      * @var Generator

--- a/test/Faker/Provider/es_VE/PersonTest.php
+++ b/test/Faker/Provider/es_VE/PersonTest.php
@@ -7,11 +7,11 @@
 
 namespace Faker\Test\Provider\es_VE;
 
-
 use Faker\Generator;
 use Faker\Provider\es_VE\Person;
+use PHPUnit\Framework\TestCase;
 
-class PersonTest extends \PHPUnit_Framework_TestCase
+class PersonTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/fi_FI/InternetTest.php
+++ b/test/Faker/Provider/fi_FI/InternetTest.php
@@ -6,8 +6,9 @@ use Faker\Generator;
 use Faker\Provider\fi_FI\Person;
 use Faker\Provider\fi_FI\Internet;
 use Faker\Provider\fi_FI\Company;
+use PHPUnit\Framework\TestCase;
 
-class InternetTest extends \PHPUnit_Framework_TestCase
+class InternetTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/fi_FI/PersonTest.php
+++ b/test/Faker/Provider/fi_FI/PersonTest.php
@@ -5,8 +5,9 @@ namespace Faker\Test\Provider\fi_FI;
 use Faker\Generator;
 use Faker\Provider\DateTime;
 use Faker\Provider\fi_FI\Person;
+use PHPUnit\Framework\TestCase;
 
-class PersonTest extends \PHPUnit_Framework_TestCase
+class PersonTest extends TestCase
 {
     /** @var Generator */
     protected $faker;

--- a/test/Faker/Provider/fr_BE/PaymentTest.php
+++ b/test/Faker/Provider/fr_BE/PaymentTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\fr_BE;
 
 use Faker\Generator;
 use Faker\Provider\fr_BE\Payment;
+use PHPUnit\Framework\TestCase;
 
-class PaymentTest extends \PHPUnit_Framework_TestCase
+class PaymentTest extends TestCase
 {
     /**
      * @var Generator

--- a/test/Faker/Provider/fr_CH/AddressTest.php
+++ b/test/Faker/Provider/fr_CH/AddressTest.php
@@ -5,8 +5,9 @@ namespace Faker\Test\Provider\fr_CH;
 use Faker\Generator;
 use Faker\Provider\fr_CH\Address;
 use Faker\Provider\fr_CH\Person;
+use PHPUnit\Framework\TestCase;
 
-class AddressTest extends \PHPUnit_Framework_TestCase
+class AddressTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/fr_CH/InternetTest.php
+++ b/test/Faker/Provider/fr_CH/InternetTest.php
@@ -6,8 +6,9 @@ use Faker\Generator;
 use Faker\Provider\fr_CH\Person;
 use Faker\Provider\fr_CH\Internet;
 use Faker\Provider\fr_CH\Company;
+use PHPUnit\Framework\TestCase;
 
-class InternetTest extends \PHPUnit_Framework_TestCase
+class InternetTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/fr_CH/PhoneNumberTest.php
+++ b/test/Faker/Provider/fr_CH/PhoneNumberTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\fr_CH;
 
 use Faker\Generator;
 use Faker\Provider\fr_CH\PhoneNumber;
+use PHPUnit\Framework\TestCase;
 
-class PhoneNumberTest extends \PHPUnit_Framework_TestCase
+class PhoneNumberTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/fr_FR/CompanyTest.php
+++ b/test/Faker/Provider/fr_FR/CompanyTest.php
@@ -5,8 +5,9 @@ namespace Faker\Test\Provider\fr_FR;
 use Faker\Calculator\Luhn;
 use Faker\Generator;
 use Faker\Provider\fr_FR\Company;
+use PHPUnit\Framework\TestCase;
 
-class CompanyTest extends \PHPUnit_Framework_TestCase
+class CompanyTest extends TestCase
 {
     private $faker;
 

--- a/test/Faker/Provider/fr_FR/PersonTest.php
+++ b/test/Faker/Provider/fr_FR/PersonTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\fr_FR;
 
 use Faker\Generator;
 use Faker\Provider\fr_FR\Person;
+use PHPUnit\Framework\TestCase;
 
-class PersonTest extends \PHPUnit_Framework_TestCase
+class PersonTest extends TestCase
 {
     private $faker;
 
@@ -21,13 +22,13 @@ class PersonTest extends \PHPUnit_Framework_TestCase
 		$nir = $this->faker->nir(\Faker\Provider\Person::GENDER_MALE);
 		$this->assertStringStartsWith('1', $nir);
     }
-	
+
 	public function testNIRReturnsTheRightPattern()
     {
 		$nir = $this->faker->nir;
 		$this->assertRegExp("/^[12]\d{5}[0-9A-B]\d{8}$/", $nir);
 	}
-	
+
 	public function testNIRFormattedReturnsTheRightPattern()
     {
 		$nir = $this->faker->nir(null, true);

--- a/test/Faker/Provider/id_ID/PersonTest.php
+++ b/test/Faker/Provider/id_ID/PersonTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\id_ID;
 
 use Faker\Generator;
 use Faker\Provider\id_ID\Person;
+use PHPUnit\Framework\TestCase;
 
-class PersonTest extends \PHPUnit_Framework_TestCase
+class PersonTest extends TestCase
 {
     public function setUp()
     {

--- a/test/Faker/Provider/it_CH/AddressTest.php
+++ b/test/Faker/Provider/it_CH/AddressTest.php
@@ -5,8 +5,9 @@ namespace Faker\Test\Provider\it_CH;
 use Faker\Generator;
 use Faker\Provider\it_CH\Address;
 use Faker\Provider\it_CH\Person;
+use PHPUnit\Framework\TestCase;
 
-class AddressTest extends \PHPUnit_Framework_TestCase
+class AddressTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/it_CH/InternetTest.php
+++ b/test/Faker/Provider/it_CH/InternetTest.php
@@ -6,8 +6,9 @@ use Faker\Generator;
 use Faker\Provider\it_CH\Person;
 use Faker\Provider\it_CH\Internet;
 use Faker\Provider\it_CH\Company;
+use PHPUnit\Framework\TestCase;
 
-class InternetTest extends \PHPUnit_Framework_TestCase
+class InternetTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/it_CH/PhoneNumberTest.php
+++ b/test/Faker/Provider/it_CH/PhoneNumberTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\it_CH;
 
 use Faker\Generator;
 use Faker\Provider\it_CH\PhoneNumber;
+use PHPUnit\Framework\TestCase;
 
-class PhoneNumberTest extends \PHPUnit_Framework_TestCase
+class PhoneNumberTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/it_IT/CompanyTest.php
+++ b/test/Faker/Provider/it_IT/CompanyTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\it_IT;
 
 use Faker\Generator;
 use Faker\Provider\it_IT\Company;
+use PHPUnit\Framework\TestCase;
 
-class CompanyTest extends \PHPUnit_Framework_TestCase
+class CompanyTest extends TestCase
 {
     public function setUp()
     {
@@ -19,5 +20,5 @@ class CompanyTest extends \PHPUnit_Framework_TestCase
         $vatId = $this->faker->vatId();
         $this->assertRegExp('/^IT[0-9]{11}$/', $vatId);
     }
-    
+
 }

--- a/test/Faker/Provider/it_IT/PersonTest.php
+++ b/test/Faker/Provider/it_IT/PersonTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\it_IT;
 
 use Faker\Generator;
 use Faker\Provider\it_IT\Person;
+use PHPUnit\Framework\TestCase;
 
-class PersonTest extends \PHPUnit_Framework_TestCase
+class PersonTest extends TestCase
 {
     public function setUp()
     {
@@ -19,5 +20,5 @@ class PersonTest extends \PHPUnit_Framework_TestCase
         $taxId = $this->faker->taxId();
         $this->assertRegExp('/^[a-zA-Z]{6}[0-9]{2}[a-zA-Z][0-9]{2}[a-zA-Z][0-9]{3}[a-zA-Z]$/', $taxId);
     }
-    
+
 }

--- a/test/Faker/Provider/ja_JP/InternetTest.php
+++ b/test/Faker/Provider/ja_JP/InternetTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\ja_JP;
 
 use Faker\Generator;
 use Faker\Provider\ja_JP\Internet;
+use PHPUnit\Framework\TestCase;
 
-class InternetTest extends \PHPUnit_Framework_TestCase
+class InternetTest extends TestCase
 {
     public function testUserName()
     {

--- a/test/Faker/Provider/ja_JP/PersonTest.php
+++ b/test/Faker/Provider/ja_JP/PersonTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\ja_JP;
 
 use Faker\Generator;
 use Faker\Provider\ja_JP\Person;
+use PHPUnit\Framework\TestCase;
 
-class PersonTest extends \PHPUnit_Framework_TestCase
+class PersonTest extends TestCase
 {
     public function testKanaNameMaleReturns()
     {

--- a/test/Faker/Provider/ja_JP/PhoneNumberTest.php
+++ b/test/Faker/Provider/ja_JP/PhoneNumberTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\ja_JP;
 
 use Faker\Generator;
 use Faker\Provider\ja_JP\PhoneNumber;
+use PHPUnit\Framework\TestCase;
 
-class PhoneNumberTest extends \PHPUnit_Framework_TestCase
+class PhoneNumberTest extends TestCase
 {
     public function testPhoneNumber()
     {

--- a/test/Faker/Provider/kk_KZ/CompanyTest.php
+++ b/test/Faker/Provider/kk_KZ/CompanyTest.php
@@ -3,8 +3,9 @@ namespace Faker\Test\Provider\kk_KZ;
 
 use Faker\Generator;
 use Faker\Provider\kk_KZ\Company;
+use PHPUnit\Framework\TestCase;
 
-class CompanyTest extends \PHPUnit_Framework_TestCase
+class CompanyTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/kk_KZ/PersonTest.php
+++ b/test/Faker/Provider/kk_KZ/PersonTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\kk_KZ;
 use Faker\Generator;
 use Faker\Provider\DateTime;
 use Faker\Provider\kk_KZ\Person;
+use PHPUnit\Framework\TestCase;
 
-class PersonTest extends \PHPUnit_Framework_TestCase
+class PersonTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/mn_MN/PersonTest.php
+++ b/test/Faker/Provider/mn_MN/PersonTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\mn_MN;
 
 use Faker\Generator;
 use Faker\Provider\mn_MN\Person;
+use PHPUnit\Framework\TestCase;
 
-class PersonTest extends \PHPUnit_Framework_TestCase
+class PersonTest extends TestCase
 {
     public function testName()
     {

--- a/test/Faker/Provider/nl_BE/PaymentTest.php
+++ b/test/Faker/Provider/nl_BE/PaymentTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\nl_BE;
 
 use Faker\Generator;
 use Faker\Provider\nl_BE\Payment;
+use PHPUnit\Framework\TestCase;
 
-class PaymentTest extends \PHPUnit_Framework_TestCase
+class PaymentTest extends TestCase
 {
     /**
      * @var Generator

--- a/test/Faker/Provider/nl_NL/CompanyTest.php
+++ b/test/Faker/Provider/nl_NL/CompanyTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\nl_NL;
 
 use Faker\Generator;
 use Faker\Provider\nl_NL\Company;
+use PHPUnit\Framework\TestCase;
 
-class CompanyTest extends \PHPUnit_Framework_TestCase
+class CompanyTest extends TestCase
 {
     private $faker;
 

--- a/test/Faker/Provider/nl_NL/PersonTest.php
+++ b/test/Faker/Provider/nl_NL/PersonTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\nl_NL;
 
 use Faker\Generator;
 use Faker\Provider\nl_NL\Person;
+use PHPUnit\Framework\TestCase;
 
-class PersonTest extends \PHPUnit_Framework_TestCase
+class PersonTest extends TestCase
 {
     private $faker;
 

--- a/test/Faker/Provider/pl_PL/AddressTest.php
+++ b/test/Faker/Provider/pl_PL/AddressTest.php
@@ -3,8 +3,9 @@
 namespace Faker\Provider\pl_PL;
 
 use Faker\Generator;
+use PHPUnit\Framework\TestCase;
 
-class AddressTest extends \PHPUnit_Framework_TestCase
+class AddressTest extends TestCase
 {
     /**
      * @var Generator

--- a/test/Faker/Provider/pt_BR/CompanyTest.php
+++ b/test/Faker/Provider/pt_BR/CompanyTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\pt_BR;
 
 use Faker\Generator;
 use Faker\Provider\pt_BR\Company;
+use PHPUnit\Framework\TestCase;
 
-class CompanyTest extends \PHPUnit_Framework_TestCase
+class CompanyTest extends TestCase
 {
 
     public function setUp()

--- a/test/Faker/Provider/pt_BR/PersonTest.php
+++ b/test/Faker/Provider/pt_BR/PersonTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\pt_BR;
 
 use Faker\Generator;
 use Faker\Provider\pt_BR\Person;
+use PHPUnit\Framework\TestCase;
 
-class PersonTest extends \PHPUnit_Framework_TestCase
+class PersonTest extends TestCase
 {
 
     public function setUp()

--- a/test/Faker/Provider/pt_PT/AddressTest.php
+++ b/test/Faker/Provider/pt_PT/AddressTest.php
@@ -5,8 +5,9 @@ namespace Faker\Test\Provider\pt_PT;
 use Faker\Generator;
 use Faker\Provider\pt_PT\Address;
 use Faker\Provider\pt_PT\Person;
+use PHPUnit\Framework\TestCase;
 
-class AddressTest extends \PHPUnit_Framework_TestCase
+class AddressTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/pt_PT/PersonTest.php
+++ b/test/Faker/Provider/pt_PT/PersonTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\pt_PT;
 
 use Faker\Generator;
 use Faker\Provider\pt_PT\Person;
+use PHPUnit\Framework\TestCase;
 
-class PersonTest extends \PHPUnit_Framework_TestCase
+class PersonTest extends TestCase
 {
 
     public function setUp()

--- a/test/Faker/Provider/pt_PT/PhoneNumberTest.php
+++ b/test/Faker/Provider/pt_PT/PhoneNumberTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\pt_PT;
 
 use Faker\Generator;
 use Faker\Provider\pt_PT\PhoneNumber;
+use PHPUnit\Framework\TestCase;
 
-class PhoneNumberTest extends \PHPUnit_Framework_TestCase
+class PhoneNumberTest extends TestCase
 {
     public function setUp()
     {

--- a/test/Faker/Provider/ro_RO/PersonTest.php
+++ b/test/Faker/Provider/ro_RO/PersonTest.php
@@ -5,8 +5,9 @@ namespace Faker\Test\Provider\ro_RO;
 use Faker\Generator;
 use Faker\Provider\DateTime;
 use Faker\Provider\ro_RO\Person;
+use PHPUnit\Framework\TestCase;
 
-class PersonTest extends \PHPUnit_Framework_TestCase
+class PersonTest extends TestCase
 {
     const TEST_CNP_REGEX = '/^[1-9][0-9]{2}(?:0[1-9]|1[012])(?:0[1-9]|[12][0-9]|3[01])(?:0[1-9]|[123][0-9]|4[0-6]|5[12])[0-9]{3}[0-9]$/';
 

--- a/test/Faker/Provider/ro_RO/PhoneNumberTest.php
+++ b/test/Faker/Provider/ro_RO/PhoneNumberTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\ro_RO;
 
 use Faker\Generator;
 use Faker\Provider\ro_RO\PhoneNumber;
+use PHPUnit\Framework\TestCase;
 
-class PhoneNumberTest extends \PHPUnit_Framework_TestCase
+class PhoneNumberTest extends TestCase
 {
     public function setUp()
     {

--- a/test/Faker/Provider/ru_RU/CompanyTest.php
+++ b/test/Faker/Provider/ru_RU/CompanyTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\ru_RU;
 
 use Faker\Generator;
 use Faker\Provider\ru_RU\Company;
+use PHPUnit\Framework\TestCase;
 
-class CompanyTest extends \PHPUnit_Framework_TestCase
+class CompanyTest extends TestCase
 {
     /**
      * @var Generator

--- a/test/Faker/Provider/sv_SE/PersonTest.php
+++ b/test/Faker/Provider/sv_SE/PersonTest.php
@@ -5,8 +5,9 @@ namespace Faker\Test\Provider\sv_SE;
 use Faker\Calculator\Luhn;
 use Faker\Generator;
 use Faker\Provider\sv_SE\Person;
+use PHPUnit\Framework\TestCase;
 
-class PersonTest extends \PHPUnit_Framework_TestCase
+class PersonTest extends TestCase
 {
     /** @var Generator */
     protected $faker;

--- a/test/Faker/Provider/uk_UA/AddressTest.php
+++ b/test/Faker/Provider/uk_UA/AddressTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\uk_UA;
 
 use Faker\Generator;
 use Faker\Provider\uk_UA\Address;
+use PHPUnit\Framework\TestCase;
 
-class AddressTest extends \PHPUnit_Framework_TestCase
+class AddressTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/uk_UA/PersonTest.php
+++ b/test/Faker/Provider/uk_UA/PersonTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\uk_UA;
 
 use Faker\Generator;
 use Faker\Provider\uk_UA\Person;
+use PHPUnit\Framework\TestCase;
 
-class PersonTest extends \PHPUnit_Framework_TestCase
+class PersonTest extends TestCase
 {
     public function testFirstNameMaleReturns()
     {

--- a/test/Faker/Provider/uk_UA/PhoneNumberTest.php
+++ b/test/Faker/Provider/uk_UA/PhoneNumberTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\uk_UA;
 
 use Faker\Generator;
 use Faker\Provider\uk_UA\PhoneNumber;
+use PHPUnit\Framework\TestCase;
 
-class PhoneNumberTest extends \PHPUnit_Framework_TestCase
+class PhoneNumberTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/zh_TW/CompanyTest.php
+++ b/test/Faker/Provider/zh_TW/CompanyTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\zh_TW;
 
 use Faker\Generator;
 use Faker\Provider\zh_TW\Company;
+use PHPUnit\Framework\TestCase;
 
-class CompanyTest extends \PHPUnit_Framework_TestCase
+class CompanyTest extends TestCase
 {
     /**
      * @var Generator

--- a/test/Faker/Provider/zh_TW/PersonTest.php
+++ b/test/Faker/Provider/zh_TW/PersonTest.php
@@ -4,8 +4,9 @@ namespace Faker\Test\Provider\zh_TW;
 
 use Faker\Generator;
 use Faker\Provider\zh_TW\Person;
+use PHPUnit\Framework\TestCase;
 
-class PersonTest extends \PHPUnit_Framework_TestCase
+class PersonTest extends TestCase
 {
     /**
      * @var Generator

--- a/test/Faker/Provider/zh_TW/TextTest.php
+++ b/test/Faker/Provider/zh_TW/TextTest.php
@@ -2,7 +2,9 @@
 
 namespace Faker\Test\Provider\zh_TW;
 
-class TextTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class TextTest extends TestCase
 {
     private $textClass;
 


### PR DESCRIPTION
Use [PSR-1](http://www.php-fig.org/psr/psr-1/#namespace-and-class-names) while extending PHPUnit TestCase class. This will help us when to migrate to PHPUnit 6, that [no longer support snake case namespaces](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#600---2017-02-03).