### PR TITLE
Bump PHPUnit version for namespace compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^5.3.3 || ^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.0 || ^5.0",
+        "phpunit/phpunit": "^4.8.35 || ^5.7",
         "squizlabs/php_codesniffer": "^1.5",
         "ext-intl": "*"
     },


### PR DESCRIPTION
As suggest in #1344 by @MarioBlazek, I  bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06) and [`^5.7`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-5.7.md#570---2016-12-02), that support that namespace.