### PR TITLE
Add --dev flag to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@ Faker requires PHP >= 5.3.3.
 ## Installation
 
 ```sh
-composer require fzaninotto/faker
+composer require --dev fzaninotto/faker
 ```
 
 ## Basic Usage


### PR DESCRIPTION
There are almost no circumstances where `faker` should be a requirement for a production environment. Instructions on installation tweaked to add the `--dev` flag to the `composer require` instruction to aid copy-paste.