### PR TITLE
en_za id number outdated 

### DIFF
--- a/src/Faker/Provider/en_ZA/Person.php
+++ b/src/Faker/Provider/en_ZA/Person.php
@@ -159,7 +159,7 @@ class Person extends \Faker\Provider\Person
         }
         $sequenceDigits = str_pad(self::randomNumber(3), 3, 0, STR_PAD_BOTH);
         $citizenDigit = ($citizen === true) ? '0' : '1';
-        $raceDigit = self::randomNumber(1);
+        $raceDigit = self:numberBetween(8,9);//self::randomNumber(1);
 
         $partialIdNumber = $birthDateString . $genderDigit . $sequenceDigits . $citizenDigit . $raceDigit;
 


### PR DESCRIPTION
we no longer use race digit and its normally just 8/9 no one knows why it just is 