### PR TITLE
Get currency codes from library to stay up to date

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         }
     ],
     "require": {
-        "php": "^5.3.3 || ^7.0"
+        "php": "^5.3.3 || ^7.0",
+        "alcohol/iso4217": "^3.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.35 || ^5.7",

--- a/src/Faker/Provider/Miscellaneous.php
+++ b/src/Faker/Provider/Miscellaneous.php
@@ -2,6 +2,8 @@
 
 namespace Faker\Provider;
 
+use Alcohol\ISO4217;
+
 class Miscellaneous extends Base
 {
     /**
@@ -201,27 +203,12 @@ class Miscellaneous extends Base
     );
 
     /**
-     * @link https://en.wikipedia.org/wiki/ISO_4217
-     * On date of 2017-07-07
+     * @return array of valid ISO 4217 currency codes
      */
-    protected static $currencyCode = array(
-        'AED', 'AFN', 'ALL', 'AMD', 'ANG', 'AOA', 'ARS', 'AUD', 'AWG', 'AZN',
-        'BAM', 'BBD', 'BDT', 'BGN', 'BHD', 'BIF', 'BMD', 'BND', 'BOB', 'BRL',
-        'BSD', 'BTN', 'BWP', 'BYN', 'BZD', 'CAD', 'CDF', 'CHF', 'CLP', 'CNY',
-        'COP', 'CRC', 'CUC', 'CUP', 'CVE', 'CZK', 'DJF', 'DKK', 'DOP', 'DZD',
-        'EGP', 'ERN', 'ETB', 'EUR', 'FJD', 'FKP', 'GBP', 'GEL', 'GHS', 'GIP',
-        'GMD', 'GNF', 'GTQ', 'GYD', 'HKD', 'HNL', 'HRK', 'HTG', 'HUF', 'IDR',
-        'ILS', 'INR', 'IQD', 'IRR', 'ISK', 'JMD', 'JOD', 'JPY', 'KES', 'KGS',
-        'KHR', 'KMF', 'KPW', 'KRW', 'KWD', 'KYD', 'KZT', 'LAK', 'LBP', 'LKR',
-        'LRD', 'LSL', 'LYD', 'MAD', 'MDL', 'MGA', 'MKD', 'MMK', 'MNT', 'MOP',
-        'MRO', 'MUR', 'MVR', 'MWK', 'MXN', 'MYR', 'MZN', 'NAD', 'NGN', 'NIO',
-        'NOK', 'NPR', 'NZD', 'OMR', 'PAB', 'PEN', 'PGK', 'PHP', 'PKR', 'PLN',
-        'PYG', 'QAR', 'RON', 'RSD', 'RUB', 'RWF', 'SAR', 'SBD', 'SCR', 'SDG',
-        'SEK', 'SGD', 'SHP', 'SLL', 'SOS', 'SRD', 'SSP', 'STD', 'SVC', 'SYP',
-        'SZL', 'THB', 'TJS', 'TMT', 'TND', 'TOP', 'TRY', 'TTD', 'TWD', 'TZS',
-        'UAH', 'UGX', 'USD', 'UYU', 'UZS', 'VEF', 'VND', 'VUV', 'WST', 'XAF',
-        'XCD', 'XOF', 'XPF', 'YER', 'ZAR', 'ZMW', 'ZWL',
-    );
+    protected static function currencyCodes()
+    {
+        return array_column((new ISO4217)->getAll(), 'alpha3');
+    }
 
     /**
      * Return a boolean, true or false.
@@ -304,7 +291,7 @@ class Miscellaneous extends Base
      */
     public static function currencyCode()
     {
-        return static::randomElement(static::$currencyCode);
+        return static::randomElement(static::currencyCodes());
     }
 
     /**

--- a/test/Faker/Provider/MiscellaneousTest.php
+++ b/test/Faker/Provider/MiscellaneousTest.php
@@ -2,6 +2,7 @@
 
 namespace Faker\Test\Provider;
 
+use Alcohol\ISO4217;
 use Faker\Provider\Miscellaneous;
 use PHPUnit\Framework\TestCase;
 
@@ -50,6 +51,16 @@ class MiscellaneousTest extends TestCase
     public function testCurrencyCode()
     {
         $this->assertRegExp('/^[A-Z]{3}$/', Miscellaneous::currencyCode());
+    }
+
+    public function testValidCurrencyCode()
+    {
+        // fetch all valid currency codes
+        $validCodes = array_column((new ISO4217)->getAll(), 'alpha3');
+        // repeat often to detect errors in randomly generated codes
+        for($i=0; $i < 100; ++$i) {
+            $this->assertContains(Miscellaneous::currencyCode(), $validCodes);
+        }
     }
 
     public function testEmoji()


### PR DESCRIPTION
This is a proposal to stay up to date with changing currency codes. 

Background:
In our current project, we perform validation of currency codes. In UnitTests, these codes are generated by Faker and produce randomly failing tests due to a divergence between actual currency codes and the ones that Faker produces. 

This applies to the following codes, which are not considered valid by our application that uses `alcohol/iso4217` to retrieve the codes:

* ZWL
* SVC
* BYN

Using the lib makes it more likely to stay up to date with the changes.

If you don't like the idea of adding that lib, please let me know. I would update the static list of currency codes to reflect the current state as well.

