### PR TITLE
Adding data for es-Co 'Colombia' in the provider database

### DIFF
--- a/src/Faker/Provider/es_CO/Company.php
+++ b/src/Faker/Provider/es_CO/Company.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Faker\Provider\es_CO;
+
+class Company extends \Faker\Provider\Company {
+
+    protected static $formats = array(
+        '{{companyPrefix}} {{lastName}} {{companySuffix}}',
+        '{{companyPrefix}} {{lastName}}',
+        '{{companyPrefix}} {{lastName}} {{lastName}}',
+        '{{lastName}} {{lastName}} {{companySuffix}}',
+        '{{lastName}} y {{lastName}} {{companySuffix}}',
+        '{{lastName}} de {{lastName}} {{companySuffix}}',
+        '{{lastName}}, {{lastName}} y {{lastName}} {{companySuffix}}',
+        '{{lastName}} {{lastName}}',
+        '{{lastName}} y {{lastName}}',
+        '{{lastName}} de {{lastName}}'
+    );
+    protected static $companyPrefix = array(
+        'Asociación', 'Centro', 'Corporación', 'Cooperativa', 'Empresa', 'Gestora', 'Global', 'Grupo', 'Viajes',
+        'Inversiones', 'Lic.', 'Dr.', 'Dra.', 'Contratistas', 'Ing.', ''
+    );
+    protected static $companySuffix = array('y Hermanos', 'e Hijos', 'y Asociados', 'S.A.', 'S.A.S.', 'Ltda.', '& Cia.', 'S. en C', 'S.C.A.', 'Corp.');
+
+    /**
+     * @example 'Grupo'
+     */
+    public static function companyPrefix() {
+        return static::randomElement(static::$companyPrefix);
+    }
+
+    /**
+     * Generate random Taxpayer Identification Number (NIT in Colombia). Ex 900515123-4
+     * @param string $separator The separator format to be used, the most commonly used 
+     *      are hyphen '-', whitespace ' ' and nothing ''
+     * @return string The NIT number in string format
+     * 
+     */
+    public function taxPayerIdentificationNumber($separator = '-', $addVerificationNumber = true) {
+        $verificationNumber = $addVerificationNumber ? ($separator . static::numerify('#')) : '';
+        return static::numerify('#########') . $verificationNumber;
+    }
+
+}

--- a/src/Faker/Provider/es_CO/Internet.php
+++ b/src/Faker/Provider/es_CO/Internet.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Faker\Provider\es_ES;
+namespace Faker\Provider\es_CO;
 
 class Internet extends \Faker\Provider\Internet
 {

--- a/src/Faker/Provider/es_CO/Internet.php
+++ b/src/Faker/Provider/es_CO/Internet.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Faker\Provider\es_ES;
+
+class Internet extends \Faker\Provider\Internet
+{
+    protected static $freeEmailDomain = array('gmail.com', 'hotmail.com', 'hotmail.es', 'yahoo.com', 'yahoo.es');
+    protected static $tld = array('com', 'co', 'com.co', 'net', 'net.co');
+}

--- a/src/Faker/Provider/es_CO/PhoneNumber.php
+++ b/src/Faker/Provider/es_CO/PhoneNumber.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Faker\Provider\es_ES;
+namespace Faker\Provider\es_CO;
 
 class PhoneNumber extends \Faker\Provider\PhoneNumber
 {

--- a/src/Faker/Provider/es_CO/PhoneNumber.php
+++ b/src/Faker/Provider/es_CO/PhoneNumber.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Faker\Provider\es_ES;
+
+class PhoneNumber extends \Faker\Provider\PhoneNumber
+{
+    protected static $formats = array(
+        /* Estandard landline telephone number formats */
+        '#######',
+        '### ####',
+        '### ## ##',
+        /* Landline telephone numbers with national indicative */
+        '+57 #######',
+        '+57 ### ####',
+        '+57 ### ## ##',
+        /* Landline telephone numbers with regional indicatives */
+        '+57-# #######',
+        '+57-# ### ####',
+        '+57-# ### ## ##',
+        '+57-# ### ## ##',
+        /* Estandard cellphone number formats */
+        '3#########',
+        '3## #######',
+        '3## ### ####',
+        '3##-#######',
+        '3##-###-####',
+        /* Cellphone numbers with national indicative */
+        '+57 3#########',
+        '+57 3## #######',
+        '+57 3## ### ####',
+        '+57 3##-#######',
+        '+57 3##-###-####',
+    );
+}


### PR DESCRIPTION
There was no data for Colombia 'es-CO' in the provider database.
I added some of the basics by now and I am preparing the rest that is under my knowledge.

I read the contributor guidelines and used the files of other countries as reference for structure, styling and information contained. If I am missing something, I'm sorry, its my first time on here. Let me know and I'll gladly fix it.



