### PR TITLE
Prevent errors on private methods

### DIFF
--- a/src/Faker/ORM/Doctrine/EntityPopulator.php
+++ b/src/Faker/ORM/Doctrine/EntityPopulator.php
@@ -211,7 +211,7 @@ class EntityPopulator
                 }
                 // Try a standard setter if it's available, otherwise fall back on reflection
                 $setter = sprintf("set%s", ucfirst($field));
-                if (method_exists($obj, $setter)) {
+                if (is_callable($obj, $setter)) {
                     $obj->$setter($value);
                 } else {
                     $this->class->reflFields[$field]->setValue($obj, $value);


### PR DESCRIPTION
Use `is_callable` to prevent errors if a method is private.