### PR TITLE
Remove obsolete currency codes

### DIFF
--- a/src/Faker/Provider/Miscellaneous.php
+++ b/src/Faker/Provider/Miscellaneous.php
@@ -203,6 +203,10 @@ class Miscellaneous extends Base
     /**
      * @link https://en.wikipedia.org/wiki/ISO_4217
      * On date of 2017-07-07
+     *
+     * With the following exceptions:
+     * SVC has been replaced by the USD in 2001: https://en.wikipedia.org/wiki/Salvadoran_col%C3%B3n
+     * ZWL has been suspended since 2009: https://en.wikipedia.org/wiki/Zimbabwean_dollar
      */
     protected static $currencyCode = array(
         'AED', 'AFN', 'ALL', 'AMD', 'ANG', 'AOA', 'ARS', 'AUD', 'AWG', 'AZN',
@@ -217,10 +221,10 @@ class Miscellaneous extends Base
         'MRO', 'MUR', 'MVR', 'MWK', 'MXN', 'MYR', 'MZN', 'NAD', 'NGN', 'NIO',
         'NOK', 'NPR', 'NZD', 'OMR', 'PAB', 'PEN', 'PGK', 'PHP', 'PKR', 'PLN',
         'PYG', 'QAR', 'RON', 'RSD', 'RUB', 'RWF', 'SAR', 'SBD', 'SCR', 'SDG',
-        'SEK', 'SGD', 'SHP', 'SLL', 'SOS', 'SRD', 'SSP', 'STD', 'SVC', 'SYP',
-        'SZL', 'THB', 'TJS', 'TMT', 'TND', 'TOP', 'TRY', 'TTD', 'TWD', 'TZS',
-        'UAH', 'UGX', 'USD', 'UYU', 'UZS', 'VEF', 'VND', 'VUV', 'WST', 'XAF',
-        'XCD', 'XOF', 'XPF', 'YER', 'ZAR', 'ZMW', 'ZWL',
+        'SEK', 'SGD', 'SHP', 'SLL', 'SOS', 'SRD', 'SSP', 'STD', 'SYP', 'SZL',
+        'THB', 'TJS', 'TMT', 'TND', 'TOP', 'TRY', 'TTD', 'TWD', 'TZS', 'UAH',
+        'UGX', 'USD', 'UYU', 'UZS', 'VEF', 'VND', 'VUV', 'WST', 'XAF', 'XCD',
+        'XOF', 'XPF', 'YER', 'ZAR', 'ZMW',
     );
 
     /**


### PR DESCRIPTION
This is an alternative approach to solve the issue described in #1360.

I removed SVC and ZWL from the list of currency codes.

While still in the list of official [ISO 4217 currency names](https://en.wikipedia.org/wiki/ISO_4217#Active_codes), these currencies are obsolete:

SVC has been replaced by the USD in 2001:
https://en.wikipedia.org/wiki/Salvadoran_col%C3%B3n

ZWL has been suspended since 2009:
https://en.wikipedia.org/wiki/Zimbabwean_dollar

Using them in Faker can cause 3rd party validations to fail.