### PR TITLE
Refactoring tests

### DIFF
--- a/test/Faker/DefaultGeneratorTest.php
+++ b/test/Faker/DefaultGeneratorTest.php
@@ -10,14 +10,14 @@ class DefaultGeneratorTest extends TestCase
     public function testGeneratorReturnsNullByDefault()
     {
         $generator = new DefaultGenerator;
-        $this->assertSame(null, $generator->value);
+        $this->assertNull($generator->value);
     }
 
     public function testGeneratorReturnsDefaultValueForAnyPropertyGet()
     {
         $generator = new DefaultGenerator(123);
         $this->assertSame(123, $generator->foo);
-        $this->assertNotSame(null, $generator->bar);
+        $this->assertNotNull($generator->bar);
     }
 
     public function testGeneratorReturnsDefaultValueForAnyMethodCall()

--- a/test/Faker/GeneratorTest.php
+++ b/test/Faker/GeneratorTest.php
@@ -20,7 +20,7 @@ class GeneratorTest extends TestCase
         $generator = new Generator;
         $provider = new FooProvider();
         $generator->addProvider($provider);
-        $this->assertTrue(is_callable($generator->getFormatter('fooFormatter')));
+        $this->assertInternalType('callable', $generator->getFormatter('fooFormatter'));
     }
 
     public function testGetFormatterReturnsCorrectFormatter()

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -9,28 +9,28 @@ class BaseTest extends TestCase
 {
     public function testRandomDigitReturnsInteger()
     {
-        $this->assertTrue(is_integer(BaseProvider::randomDigit()));
+        $this->assertInternalType('integer', BaseProvider::randomDigit());
     }
 
     public function testRandomDigitReturnsDigit()
     {
-        $this->assertTrue(BaseProvider::randomDigit() >= 0);
-        $this->assertTrue(BaseProvider::randomDigit() < 10);
+        $this->assertGreaterThanOrEqual(0, BaseProvider::randomDigit());
+        $this->assertLessThan(10, BaseProvider::randomDigit());
     }
 
     public function testRandomDigitNotNullReturnsNotNullDigit()
     {
-        $this->assertTrue(BaseProvider::randomDigitNotNull() > 0);
-        $this->assertTrue(BaseProvider::randomDigitNotNull() < 10);
+        $this->assertGreaterThan(0, BaseProvider::randomDigitNotNull());
+        $this->assertLessThan(10, BaseProvider::randomDigitNotNull());
     }
 
 
     public function testRandomDigitNotReturnsValidDigit()
     {
         for ($i = 0; $i <= 9; $i++) {
-            $this->assertTrue(BaseProvider::randomDigitNot($i) >= 0);
-            $this->assertTrue(BaseProvider::randomDigitNot($i) < 10);
-            $this->assertTrue(BaseProvider::randomDigitNot($i) !== $i);
+            $this->assertGreaterThanOrEqual(0, BaseProvider::randomDigitNot($i));
+            $this->assertLessThan(10, BaseProvider::randomDigitNot($i));
+            $this->assertNotSame(BaseProvider::randomDigitNot($i), $i);
         }
     }
 
@@ -52,14 +52,14 @@ class BaseTest extends TestCase
 
     public function testRandomNumberReturnsInteger()
     {
-        $this->assertTrue(is_integer(BaseProvider::randomNumber()));
-        $this->assertTrue(is_integer(BaseProvider::randomNumber(5, false)));
+        $this->assertInternalType('integer', BaseProvider::randomNumber());
+        $this->assertInternalType('integer', BaseProvider::randomNumber(5, false));
     }
 
     public function testRandomNumberReturnsDigit()
     {
-        $this->assertTrue(BaseProvider::randomNumber(3) >= 0);
-        $this->assertTrue(BaseProvider::randomNumber(3) < 1000);
+        $this->assertGreaterThanOrEqual(0, BaseProvider::randomNumber(3));
+        $this->assertLessThan(1000, BaseProvider::randomNumber(3));
     }
 
     public function testRandomNumberAcceptsStrictParamToEnforceNumberSize()
@@ -99,7 +99,7 @@ class BaseTest extends TestCase
 
     public function testRandomLetterReturnsString()
     {
-        $this->assertTrue(is_string(BaseProvider::randomLetter()));
+        $this->assertInternalType('string', BaseProvider::randomLetter());
     }
 
     public function testRandomLetterReturnsSingleLetter()
@@ -110,12 +110,12 @@ class BaseTest extends TestCase
     public function testRandomLetterReturnsLowercaseLetter()
     {
         $lowercaseLetters = 'abcdefghijklmnopqrstuvwxyz';
-        $this->assertTrue(strpos($lowercaseLetters, BaseProvider::randomLetter()) !== false);
+        $this->assertNotFalse(strpos($lowercaseLetters, BaseProvider::randomLetter()));
     }
 
     public function testRandomAsciiReturnsString()
     {
-        $this->assertTrue(is_string(BaseProvider::randomAscii()));
+        $this->assertInternalType('string', BaseProvider::randomAscii());
     }
 
     public function testRandomAsciiReturnsSingleCharacter()
@@ -126,7 +126,7 @@ class BaseTest extends TestCase
     public function testRandomAsciiReturnsAsciiCharacter()
     {
         $lowercaseLetters = '!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
-        $this->assertTrue(strpos($lowercaseLetters, BaseProvider::randomAscii()) !== false);
+        $this->assertNotFalse(strpos($lowercaseLetters, BaseProvider::randomAscii()));
     }
 
     public function testRandomElementReturnsNullWhenArrayEmpty()

--- a/test/Faker/Provider/DateTimeTest.php
+++ b/test/Faker/Provider/DateTimeTest.php
@@ -72,8 +72,8 @@ class DateTimeTest extends TestCase
     {
         $timestamp = DateTimeProvider::unixTime();
         $this->assertInternalType('int', $timestamp);
-        $this->assertTrue($timestamp >= 0);
-        $this->assertTrue($timestamp <= time());
+        $this->assertGreaterThanOrEqual(0, $timestamp);
+        $this->assertLessThanOrEqual(time(), $timestamp);
     }
 
     public function testDateTime()

--- a/test/Faker/Provider/PaymentTest.php
+++ b/test/Faker/Provider/PaymentTest.php
@@ -48,7 +48,7 @@ class PaymentTest extends TestCase
 
     public function testCreditCardTypeReturnsValidVendorName()
     {
-        $this->assertTrue(in_array($this->faker->creditCardType, array('Visa', 'MasterCard', 'American Express', 'Discover Card')));
+        $this->assertContains($this->faker->creditCardType, array('Visa', 'MasterCard', 'American Express', 'Discover Card'));
     }
 
     public function creditCardNumberProvider()

--- a/test/Faker/Provider/kk_KZ/PersonTest.php
+++ b/test/Faker/Provider/kk_KZ/PersonTest.php
@@ -25,6 +25,6 @@ class PersonTest extends TestCase
         $individualIdentificationNumber = $this->faker->individualIdentificationNumber($birthDate);
         $controlDigit                   = Person::checkSum($individualIdentificationNumber);
 
-        $this->assertTrue($controlDigit === (int)substr($individualIdentificationNumber, 11, 1));
+        $this->assertSame($controlDigit, (int)substr($individualIdentificationNumber, 11, 1));
     }
 }

--- a/test/Faker/Provider/nl_BE/PersonTest.php
+++ b/test/Faker/Provider/nl_BE/PersonTest.php
@@ -27,13 +27,13 @@ class PersonTest extends TestCase
     public function testRrnIsValid()
     {
         $rrn = $this->faker->rrn();
-        
+
         $this->assertEquals(11, strlen($rrn));
 
         $ctrlNumber = substr($rrn, 9, 2);
         $calcCtrl = 97 - (substr($rrn, 0, 9) % 97);
         $altcalcCtrl = 97 - ((2 . substr($rrn, 0, 9)) % 97);
-        $this->assertTrue(in_array($ctrlNumber, array($calcCtrl, $altcalcCtrl)));
+        $this->assertContains($ctrlNumber, array($calcCtrl, $altcalcCtrl));
 
         $middle = substr($rrn, 6, 3);
         $this->assertGreaterThan(1, $middle);


### PR DESCRIPTION
I've refactored some tests, using:
- `assertInternalType` instead of `is_*` methods;
- `assertNull` and `assertNotNull` instead of strict comparisons with `null` keyword;
- `assertTrue` instead of strict comparisons with `true` keyword;
- `assertFalse` and `assertNotFalse` instead of strict comparisons with `false` keyword;
- `assertGreaterThan`, `assertGreaterThanOrEqual`, `assertLessThan` and `assertLessThanOrEqual` for mathematical comparisons;
- `assertSame` and `assertNotSame` instead of strict comparisons;
- `assertContains` instead of `in_array` method.