### PR TITLE
allow `randomElements` to accept a Traversable object

### DIFF
--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -168,8 +168,19 @@ class Base
      *
      * @return array New array with $count elements from $array
      */
-    public static function randomElements(array $array = array('a', 'b', 'c'), $count = 1, $allowDuplicates = false)
+    public static function randomElements($array = array('a', 'b', 'c'), $count = 1, $allowDuplicates = false)
     {
+        if ($array instanceof \Traversable) {
+
+            $return = [];
+
+            foreach($array as $element){
+                $return[] = $element;
+            }
+
+            $array = $return;
+        }
+
         $allKeys = array_keys($array);
         $numKeys = count($allKeys);
 
@@ -206,7 +217,7 @@ class Base
      */
     public static function randomElement($array = array('a', 'b', 'c'))
     {
-        if (!$array) {
+        if (!$array || ($array instanceof \Traversable && !count($array))) {
             return null;
         }
         $elements = static::randomElements($array, 1);

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -2,8 +2,8 @@
 
 namespace Faker\Provider;
 
-use Faker\DefaultGenerator;
 use Faker\Generator;
+use Faker\DefaultGenerator;
 use Faker\UniqueGenerator;
 use Faker\ValidGenerator;
 

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -2,8 +2,8 @@
 
 namespace Faker\Provider;
 
-use Faker\Generator;
 use Faker\DefaultGenerator;
+use Faker\Generator;
 use Faker\UniqueGenerator;
 use Faker\ValidGenerator;
 
@@ -174,7 +174,7 @@ class Base
 
             $return = [];
 
-            foreach($array as $element){
+            foreach ($array as $element) {
                 $return[] = $element;
             }
 

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -170,7 +170,7 @@ class Base
      */
     public static function randomElements($array = array('a', 'b', 'c'), $count = 1, $allowDuplicates = false)
     {
-        $traversables = [];
+        $traversables = array();
 
         if ($array instanceof \Traversable) {
             foreach ($array as $element) {

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -170,13 +170,15 @@ class Base
      */
     public static function randomElements($array = array('a', 'b', 'c'), $count = 1, $allowDuplicates = false)
     {
+        $traversables = [];
+
         if ($array instanceof \Traversable) {
             foreach ($array as $element) {
                 $traversables[] = $element;
             }
         }
 
-        $arr = isset($traversables) ? $traversables : $array;
+        $arr = count($traversables) ? $traversables : $array;
 
         $allKeys = array_keys($arr);
         $numKeys = count($allKeys);

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -172,7 +172,7 @@ class Base
     {
         if ($array instanceof \Traversable) {
 
-            $return = [];
+            $return = array();
 
             foreach ($array as $element) {
                 $return[] = $element;

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -171,15 +171,12 @@ class Base
     public static function randomElements($array = array('a', 'b', 'c'), $count = 1, $allowDuplicates = false)
     {
         if ($array instanceof \Traversable) {
-
-            $return = array();
-
             foreach ($array as $element) {
-                $return[] = $element;
+                $traversables[] = $element;
             }
-
-            $array = $return;
         }
+
+        $array = isset($traversables) ? $traversables : $array;
 
         $allKeys = array_keys($array);
         $numKeys = count($allKeys);

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -176,9 +176,9 @@ class Base
             }
         }
 
-        $array = isset($traversables) ? $traversables : $array;
+        $arr = isset($traversables) ? $traversables : $array;
 
-        $allKeys = array_keys($array);
+        $allKeys = array_keys($arr);
         $numKeys = count($allKeys);
 
         if (!$allowDuplicates && $numKeys < $count) {
@@ -199,7 +199,7 @@ class Base
                 $keys[$num] = true;
             }
 
-            $elements[] = $array[$allKeys[$num]];
+            $elements[] = $arr[$allKeys[$num]];
             $numElements++;
         }
 

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -4,6 +4,7 @@ namespace Faker\Test\Provider;
 
 use Faker\Provider\Base as BaseProvider;
 use PHPUnit\Framework\TestCase;
+use Traversable;
 
 class BaseTest extends TestCase
 {
@@ -134,6 +135,11 @@ class BaseTest extends TestCase
         $this->assertNull(BaseProvider::randomElement(array()));
     }
 
+    public function testRandomElementReturnsNullWhenCollectionEmpty()
+    {
+        $this->assertNull(BaseProvider::randomElement(new Collection([])));
+    }
+
     public function testRandomElementReturnsElementFromArray()
     {
         $elements = array('23', 'e', 32, '#');
@@ -144,6 +150,12 @@ class BaseTest extends TestCase
     {
         $elements = array('tata' => '23', 'toto' => 'e', 'tutu' => 32, 'titi' => '#');
         $this->assertContains(BaseProvider::randomElement($elements), $elements);
+    }
+
+    public function testRandomElementReturnsElementFromCollection()
+    {
+        $collection = new Collection(['one', 'two', 'three']);
+        $this->assertContains(BaseProvider::randomElement($collection), $collection);
     }
 
     public function testShuffleReturnsStringWhenPassedAStringArgument()
@@ -553,4 +565,8 @@ class BaseTest extends TestCase
         $this->assertCount(3, $allowDuplicates);
         $this->assertContainsOnly('string', $allowDuplicates);
     }
+}
+
+class Collection extends \ArrayObject
+{
 }

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -137,7 +137,7 @@ class BaseTest extends TestCase
 
     public function testRandomElementReturnsNullWhenCollectionEmpty()
     {
-        $this->assertNull(BaseProvider::randomElement(new Collection([])));
+        $this->assertNull(BaseProvider::randomElement(new Collection(array())));
     }
 
     public function testRandomElementReturnsElementFromArray()
@@ -154,7 +154,7 @@ class BaseTest extends TestCase
 
     public function testRandomElementReturnsElementFromCollection()
     {
-        $collection = new Collection(['one', 'two', 'three']);
+        $collection = new Collection(array('one', 'two', 'three'));
         $this->assertContains(BaseProvider::randomElement($collection), $collection);
     }
 


### PR DESCRIPTION
Often times when using Faker in our seeders, we will have Collection objects, not simple arrays. This PR allows the `randomElement()` and `randomElements()` methods to accept both arrays **and** objects that implement the `Traversable` interface.

rather than adding a bunch of conditionals to deal with arrays or objects, I decided to just normalize all Traversable objects to arrays at the start.  this lets the existing code operate as before.