### PR TITLE
.nz domain updates

### DIFF
--- a/src/Faker/Provider/en_NZ/Internet.php
+++ b/src/Faker/Provider/en_NZ/Internet.php
@@ -9,6 +9,6 @@ class Internet extends \Faker\Provider\Internet
      * @var array
      */
     protected static $tld = array(
-        'com', 'co.nz', 'ac.nz', 'geek.nz', 'gen.nz', 'kiwi.nz', 'maori.nz', 'net.nz', 'org.nz', 'school.nz', 'govt.nz', 'iwi.nz', 'mil.nz', 'health.nz', 'parliment.nz'
+        'com', 'nz', 'ac.nz', 'co.nz', 'geek.nz', 'gen.nz', 'kiwi.nz', 'maori.nz', 'net.nz', 'org.nz', 'school.nz', 'cri.nz', 'govt.nz', 'health.nz', 'iwi.nz', 'mil.nz', 'parliament.nz',
     );
 }

--- a/src/Faker/Provider/en_NZ/Internet.php
+++ b/src/Faker/Provider/en_NZ/Internet.php
@@ -5,7 +5,9 @@ namespace Faker\Provider\en_NZ;
 class Internet extends \Faker\Provider\Internet
 {
     /**
-     * An array of common en_NZ (New Zeland) TLD's
+     * An array of New Zealand TLDs.
+     *
+     * @link https://en.wikipedia.org/wiki/.nz
      * @var array
      */
     protected static $tld = array(


### PR DESCRIPTION
- Add .nz 1st level suffix
- Adds missing cri.nz 2nd level suffix
- Fix typos in parliament.nz and "New Zealand"
- Add link to .nz details