### PR TITLE
VISA retired the 13 digit PAN moved to new cardParams

### DIFF
--- a/src/Faker/Provider/Payment.php
+++ b/src/Faker/Provider/Payment.php
@@ -12,7 +12,7 @@ class Payment extends Base
     protected static $cardVendors = array(
         'Visa', 'Visa', 'Visa', 'Visa', 'Visa',
         'MasterCard', 'MasterCard', 'MasterCard', 'MasterCard', 'MasterCard',
-        'American Express', 'Discover Card'
+        'American Express', 'Discover Card', 'Visa Retired'
     );
 
     /**
@@ -22,24 +22,26 @@ class Payment extends Base
      */
     protected static $cardParams = array(
         'Visa' => array(
-            "4539########",
             "4539###########",
-            "4556########",
             "4556###########",
-            "4916########",
             "4916###########",
-            "4532########",
             "4532###########",
-            "4929########",
             "4929###########",
-            "40240071####",
             "40240071#######",
-            "4485########",
             "4485###########",
-            "4716########",
             "4716###########",
-            "4###########",
             "4##############"
+        ),
+        'Visa Retired' => array(
+            "4539########",
+            "4556########",
+            "4916########",
+            "4532########",
+            "4929########",
+            "40240071####",
+            "4485########",
+            "4716########",
+            "4###########",
         ),
         'MasterCard' => array(
             "2221###########",

--- a/test/Faker/Provider/PaymentTest.php
+++ b/test/Faker/Provider/PaymentTest.php
@@ -48,14 +48,15 @@ class PaymentTest extends TestCase
 
     public function testCreditCardTypeReturnsValidVendorName()
     {
-        $this->assertContains($this->faker->creditCardType, array('Visa', 'MasterCard', 'American Express', 'Discover Card'));
+        $this->assertContains($this->faker->creditCardType, array('Visa', 'Visa Retired', 'MasterCard', 'American Express', 'Discover Card'));
     }
 
     public function creditCardNumberProvider()
     {
         return array(
             array('Discover Card', '/^6011\d{12}$/'),
-            array('Visa', '/^4\d{12,15}$/'),
+            array('Visa', '/^4\d{15}$/'),
+            array('Visa Retired', '/^4\d{12}$/'),
             array('MasterCard', '/^(5[1-5]|2[2-7])\d{14}$/')
         );
     }


### PR DESCRIPTION
VISA retired the 13 digit PAN and 468 exist as of Dec 11, 2013. I have moved the retired card length into its own cardParams ("Visa Retired") to allow backward compatibility and allow the card length to still be generated if needed.