### PR TITLE
Implementation of the function that generates Brazilian area codes fixed.

### DIFF
--- a/src/Faker/Provider/pt_BR/PhoneNumber.php
+++ b/src/Faker/Provider/pt_BR/PhoneNumber.php
@@ -28,7 +28,7 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
             '93', '94', '95', '96', '97', '98', '99'
         );
 
-        return array_rand($areaCodes, 1);
+        return $areaCodes[array_rand($areaCodes, 1)];
     }
 
     /**

--- a/src/Faker/Provider/pt_BR/PhoneNumber.php
+++ b/src/Faker/Provider/pt_BR/PhoneNumber.php
@@ -4,7 +4,6 @@ namespace Faker\Provider\pt_BR;
 
 class PhoneNumber extends \Faker\Provider\PhoneNumber
 {
-
     protected static $landlineFormats = array('2###-####', '3###-####', '4###-####');
 
     /**
@@ -14,7 +13,8 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     protected static $cellphoneFormats = array('9####-####');
 
     /**
-     * Pick one random entry out of an array of area codes.
+     * Generates a 2-digit area code not composed by zeroes.
+     * @link http://www.anatel.gov.br/legislacao/resolucoes/16-2001/383-resolucao-263.
      * @return string
      */
     public static function areaCode()
@@ -28,7 +28,7 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
             '93', '94', '95', '96', '97', '98', '99'
         );
 
-        return $areaCodes[array_rand($areaCodes, 1)];
+        return self::randomElement($areaCodes);
     }
 
     /**

--- a/src/Faker/Provider/pt_BR/PhoneNumber.php
+++ b/src/Faker/Provider/pt_BR/PhoneNumber.php
@@ -14,12 +14,21 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     protected static $cellphoneFormats = array('9####-####');
 
     /**
-     * Generates a 2-digit area code not composed by zeroes.
+     * Pick one random entry out of an array of area codes.
      * @return string
      */
     public static function areaCode()
     {
-        return static::randomDigitNotNull().static::randomDigitNotNull();
+        $areaCodes = array(
+            '11', '12', '13', '14', '15', '16', '17', '18', '19', '21', '22', '24',
+            '27', '28', '31', '32', '33', '34', '35', '37', '38', '41', '42', '43',
+            '44', '45', '46', '47', '48', '49', '51', '53', '54', '55', '61', '62',
+            '63', '64', '65', '66', '67', '68', '69', '71', '73', '74', '75', '77',
+            '79', '81', '82', '83', '84', '85', '86', '87', '88', '89', '91', '92',
+            '93', '94', '95', '96', '97', '98', '99'
+        );
+
+        return array_rand($areaCodes, 1);
     }
 
     /**


### PR DESCRIPTION
Implementation of the function that generates Brazilian area codes is fixed based on a list provided by the national organization that rules telecommunications.

Link to the resolution published in the ANATEL web site: http://www.anatel.gov.br/legislacao/resolucoes/16-2001/383-resolucao-263.