### PR TITLE
Fix for Spot2 ORM EntityPopulator

### DIFF
--- a/src/Faker/ORM/Spot/EntityPopulator.php
+++ b/src/Faker/ORM/Spot/EntityPopulator.php
@@ -151,7 +151,7 @@ class EntityPopulator
 
                 $formatters[$fieldName] = function ($inserted) use ($required, $entityName, $locator) {
                     if (!empty($inserted[$entityName])) {
-                        return $inserted[$entityName][mt_rand(0, count($inserted[$entityName]) - 1)]->getId();
+                        return $inserted[$entityName][mt_rand(0, count($inserted[$entityName]) - 1)]->get('id');
                     }
 
                     if ($required && $this->useExistingData) {


### PR DESCRIPTION
In Spot2 you don't need to create getId methods for your entities and Faker requires from you to have such. Changing it like this will not force developer to create getId methods in Spot2 entity classes.