### PR TITLE
Normalize name of variable

### DIFF
--- a/src/Faker/Provider/el_GR/Company.php
+++ b/src/Faker/Provider/el_GR/Company.php
@@ -42,7 +42,7 @@ class Company extends \Faker\Provider\Company
     );
 
 
-    protected static $οbject = array(
+    protected static $object = array(
         'Προγραμματιστής',
         'Δικηγόρος',
         'Γιατρός',
@@ -79,6 +79,6 @@ class Company extends \Faker\Provider\Company
      */
     public static function object()
     {
-        return static::randomElement(static::$οbject);
+        return static::randomElement(static::$object);
     }
 }


### PR DESCRIPTION
Invalid character

The character `ο` is not equal to `o`   //  it seems the same

`'ο'`   ---to int->  206 // Not Letter
`'o'`   ---to int->  111   // Letter 'o'

