### PR TITLE
Add gb en safe phone number formatters

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -871,6 +871,9 @@ echo $faker->bank; // "Volksbank Stuttgart"
 // Generates a GB safe phone number (reserved by OFCOM for dramatic use)
 echo $faker->safePhoneNumber; // "01632873512"
 
+// Generates a GB mobile number
+echo $faker->mobileNumber; // "07845803796"
+
 // Generates a GB safe mobile number (reserved by OFCOM for dramatic use)
 echo $faker->safeMobileNumber; // "07700900258"
 

--- a/readme.md
+++ b/readme.md
@@ -863,6 +863,19 @@ echo $faker->bank; // "Volksbank Stuttgart"
 
 ```
 
+### `Faker\Provider\en_GB\PhoneNumber`
+
+```php
+<?php
+
+// Generates a GB safe phone number (reserved by OFCOM for dramatic use)
+echo $faker->safePhoneNumber; // "01632873512"
+
+// Generates a GB safe mobile number (reserved by OFCOM for dramatic use)
+echo $faker->safeMobileNumber; // "07700900258"
+
+```
+
 ### `Faker\Provider\en_HK\Address`
 
 ```php

--- a/src/Faker/Provider/en_GB/PhoneNumber.php
+++ b/src/Faker/Provider/en_GB/PhoneNumber.php
@@ -4,6 +4,10 @@ namespace Faker\Provider\en_GB;
 
 class PhoneNumber extends \Faker\Provider\PhoneNumber
 {
+    /**
+     * An array of en_GB phone number formats
+     * @var array
+     */
     protected static $formats = array(
         '+44(0)##########',
         '+44(0)#### ######',
@@ -47,7 +51,6 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
      * @var array
      */
     protected static $mobileFormats = array(
-      // Local
       '07#########',
       '07### ######',
       '07### ### ###'

--- a/src/Faker/Provider/en_GB/PhoneNumber.php
+++ b/src/Faker/Provider/en_GB/PhoneNumber.php
@@ -22,6 +22,27 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     );
 
     /**
+     * An array of en_GB safe (reserved for dramatic use) phone number formats
+     * @var array
+     */
+    protected static $safeFormats = array(
+        '+44(0)1632######',
+        '+44(0)1632 ######',
+        '+44(0)1632#####',
+        '+44(0)1632 #####',
+        '01632######',
+        '01632#####',
+        '01632 ######',
+        '01632 #####',
+        '0163 2## ####',
+        '0163 2######',
+        '(01632) ######',
+        '(01632) #####',
+        '(0163) 2## ####',
+        '(0163) 2######',
+    );
+
+    /**
      * An array of en_GB mobile (cell) phone number formats
      * @var array
      */
@@ -33,11 +54,39 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     );
 
     /**
+     * An array of en_GB safe (reserved for dramatic use) mobile (cell) phone number formats
+     * @var array
+     */
+    protected static $safeMobileFormats = array(
+        '07700900###',
+        '07700 900###',
+        '07700 900 ###'
+    );
+
+    /**
+     * Return a en_GB safe phone number
+     * @return string
+     */
+    public static function safePhoneNumber()
+    {
+        return static::numerify(static::randomElement(static::$safeFormats));
+    }
+
+    /**
      * Return a en_GB mobile phone number
      * @return string
      */
     public static function mobileNumber()
     {
         return static::numerify(static::randomElement(static::$mobileFormats));
+    }
+
+    /**
+     * Return a en_GB safe mobile phone number
+     * @return string
+     */
+    public static function safeMobileNumber()
+    {
+        return static::numerify(static::randomElement(static::$safeMobileFormats));
     }
 }


### PR DESCRIPTION
Adds 'safePhoneNumber' and 'safeMobileNumber' formatters to the en_GB PhoneNumber provider. These numbers are reserved for dramatic use by OFCOM, so are safe to use without risk of calling/texting real numbers.