### PR TITLE
Add commerce options

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,7 @@ Faker requires PHP >= 5.3.3.
 	- [Miscellaneous](#fakerprovidermiscellaneous)
 	- [Biased](#fakerproviderbiased)
 	- [Html Lorem](#fakerproviderhtmllorem)
+	- [Product](#fakerproviderproduct)
 - [Modifiers](#modifiers)
 - [Localization](#localization)
 - [Populating Entities Using an ORM or an ODM](#populating-entities-using-an-orm-or-an-odm)
@@ -306,6 +307,29 @@ Methods accepting a `$timezone` argument default to `date_default_timezone_get()
 
     //Generate HTML document which is no more than 2 levels deep, and no more than 3 elements wide at any level.
     randomHtml(2,3)   // <html><head><title>Aut illo dolorem et accusantium eum.</title></head><body><form action="example.com" method="POST"><label for="username">sequi</label><input type="text" id="username"><label for="password">et</label><input type="password" id="password"></form><b>Id aut saepe non mollitia voluptas voluptas.</b><table><thead><tr><tr>Non consequatur.</tr><tr>Incidunt est.</tr><tr>Aut voluptatem.</tr><tr>Officia voluptas rerum quo.</tr><tr>Asperiores similique.</tr></tr></thead><tbody><tr><td>Sapiente dolorum dolorem sint laboriosam commodi qui.</td><td>Commodi nihil nesciunt eveniet quo repudiandae.</td><td>Voluptates explicabo numquam distinctio necessitatibus repellat.</td><td>Provident ut doloremque nam eum modi aspernatur.</td><td>Iusto inventore.</td></tr><tr><td>Animi nihil ratione id mollitia libero ipsa quia tempore.</td><td>Velit est officia et aut tenetur dolorem sed mollitia expedita.</td><td>Modi modi repudiandae pariatur voluptas rerum ea incidunt non molestiae eligendi eos deleniti.</td><td>Exercitationem voluptatibus dolor est iste quod molestiae.</td><td>Quia reiciendis.</td></tr><tr><td>Inventore impedit exercitationem voluptatibus rerum cupiditate.</td><td>Qui.</td><td>Aliquam.</td><td>Autem nihil aut et.</td><td>Dolor ut quia error.</td></tr><tr><td>Enim facilis iusto earum et minus rerum assumenda quis quia.</td><td>Reprehenderit ut sapiente occaecati voluptatum dolor voluptatem vitae qui velit.</td><td>Quod fugiat non.</td><td>Sunt nobis totam mollitia sed nesciunt est deleniti cumque.</td><td>Repudiandae quo.</td></tr><tr><td>Modi dicta libero quisquam doloremque qui autem.</td><td>Voluptatem aliquid saepe laudantium facere eos sunt dolor.</td><td>Est eos quis laboriosam officia expedita repellendus quia natus.</td><td>Et neque delectus quod fugit enim repudiandae qui.</td><td>Fugit soluta sit facilis facere repellat culpa magni voluptatem maiores tempora.</td></tr><tr><td>Enim dolores doloremque.</td><td>Assumenda voluptatem eum perferendis exercitationem.</td><td>Quasi in fugit deserunt ea perferendis sunt nemo consequatur dolorum soluta.</td><td>Maxime repellat qui numquam voluptatem est modi.</td><td>Alias rerum rerum hic hic eveniet.</td></tr><tr><td>Tempore voluptatem.</td><td>Eaque.</td><td>Et sit quas fugit iusto.</td><td>Nemo nihil rerum dignissimos et esse.</td><td>Repudiandae ipsum numquam.</td></tr><tr><td>Nemo sunt quia.</td><td>Sint tempore est neque ducimus harum sed.</td><td>Dicta placeat atque libero nihil.</td><td>Et qui aperiam temporibus facilis eum.</td><td>Ut dolores qui enim et maiores nesciunt.</td></tr><tr><td>Dolorum totam sint debitis saepe laborum.</td><td>Quidem corrupti ea.</td><td>Cum voluptas quod.</td><td>Possimus consequatur quasi dolorem ut et.</td><td>Et velit non hic labore repudiandae quis.</td></tr></tbody></table></body></html>
+
+### `Faker\Provider\Product`
+
+    simpleProduct           // Chromium Pants, Slim Dryer, Uneven Socks
+    fancyProduct            // Medium Sand Blasted Purse, Expensive Lime Camera, Crazy Plum Shirt
+    complexProduct          // Fabulously Clever Low Carbon Toaster, Superbly Narrow Silk Shirt
+    elaborateProduct        // Exorbitantly Wide Incredibly Sparkling Amoled Shirt
+                            // Smashingly Massive Excessively White Carbon Fiber Pen
+                            // Generally Dark Red Brilliantly Curved Synthetic Doorbell
+
+    color                   // Forest Green, Mint Cream, Light Sky Blue
+                            // (color selection borrowed from [Color](#fakerprovidercolor))
+    industry                // Electronics, Manufacturing, Shipbuilding
+    size                    // Average, Miniature, Bulky, Huge
+    shape                   // Jagged, Crooked, Square, Triangular
+    adverb                  // Fabulously, Exorbitantly, Stylishly
+    adjective               // Smooth, Tough, Clear, Inexpensive
+    material                // Polyester, Steel, Fur, Ceramic, Wooden, Fiber
+    product                 // Carpet, Tie, Bag, Speakers, Bottle, Folder
+
+    price                   // random 1-9999, no decimal
+    price(777, 778, true)   // ($min, $max, $real)
+                            // 777.66, 777.29, 777.72
 
 ## Modifiers
 

--- a/src/Faker/Factory.php
+++ b/src/Faker/Factory.php
@@ -6,7 +6,7 @@ class Factory
 {
     const DEFAULT_LOCALE = 'en_US';
 
-    protected static $defaultProviders = array('Address', 'Barcode', 'Biased', 'Color', 'Company', 'DateTime', 'File', 'HtmlLorem', 'Image', 'Internet', 'Lorem', 'Miscellaneous', 'Payment', 'Person', 'PhoneNumber', 'Text', 'UserAgent', 'Uuid');
+    protected static $defaultProviders = array('Address', 'Barcode', 'Biased', 'Color', 'Company', 'DateTime', 'File', 'HtmlLorem', 'Image', 'Internet', 'Lorem', 'Miscellaneous', 'Payment', 'Person', 'PhoneNumber', 'Product', 'Text', 'UserAgent', 'Uuid');
 
     /**
      * Create a new generator

--- a/src/Faker/Provider/Product.php
+++ b/src/Faker/Provider/Product.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Faker\Provider;
+
+use Faker\Provider\Color;
+
+class Product extends Base
+{
+    /**
+     * Returns a simple formatted product name
+     *
+     * @example 'Chromium Pants'
+     */
+    public function simpleProduct()
+    {
+        $format = static::randomElement(static::$simpleFormats);
+
+        return $this->generator->parse($format);
+    }
+
+    /**
+     * Returns a fancy formatted product name
+     *
+     * @example 'Medium Sand Blasted Purse'
+     */
+    public function fancyProduct()
+    {
+        $format = static::randomElement(static::$fancyFormats);
+
+        return $this->generator->parse($format);
+    }
+
+    /**
+     * Returns a complexly formatted product name
+     *
+     * @example 'Fabulously Clever Low Carbon Toaster'
+     */
+    public function complexProduct()
+    {
+        $format = static::randomElement(static::$complexFormats);
+
+        return $this->generator->parse($format);
+    }
+
+    /**
+     * Returns an elaborately formatted product name
+     *
+     * @example 'Exorbitantly Wide Incredibly Sparkling Amoled Shirt'
+     */
+    public function elaborateProduct()
+    {
+        $format = static::randomElement(static::$elaborateFormats);
+
+        return $this->generator->parse($format);
+    }
+
+    /**
+     * Returns a random adjective
+     *
+     * @example 'High-class'
+     */
+    public static function adjective()
+    {
+        return static::randomElement(static::$adjectives);
+    }
+
+    /**
+     * Returns a random adverb
+     *
+     * @example 'Astonishingly'
+     */
+    public static function adverb()
+    {
+        return static::randomElement(static::$adverbs);
+    }
+
+    /**
+     * Returns a random color, provided by Faker\Color
+     *
+     * @example 'Alice Blue'
+     */
+    public static function color()
+    {
+        $color = preg_split('/(?=[A-Z])/', Color::colorName());
+
+        return implode(' ', $color);
+    }
+
+    /**
+     * Returns a random size
+     *
+     * @example 'Miniature'
+     */
+    public static function size()
+    {
+        return static::randomElement(static::$sizes);
+    }
+
+    /**
+     * Returns a random shape
+     *
+     * @example 'Spherical'
+     */
+    public static function shape()
+    {
+        return static::randomElement(static::$shapes);
+    }
+
+    /**
+     * Returns a random material
+     *
+     * @example 'Chromium'
+     */
+    public static function material()
+    {
+        return static::randomElement(static::$materials);
+    }
+
+    /**
+     * Returns a random product
+     *
+     * @example 'Pants'
+     */
+    public static function product()
+    {
+        return static::randomElement(static::$products);
+    }
+
+    /**
+     * Returns a random price
+     *
+     * @param  integer $min
+     * @param  integer $max
+     * @param  boolean $real  Determines if price is in integer or real
+     * @return [numeric]
+     *
+     * @example '100.00'
+     */
+    public static function price($min = 1, $max = 9999, $real = false)
+    {
+        $padding = ($real == true) ? 100 : 1;
+        $price = mt_rand($min * $padding, $max * $padding);
+
+        if ($real == true) {
+            $price = number_format($price / 100, 2, '.', '');
+        }
+
+        return $price;
+    }
+
+    /**
+     * Returns a random industry
+     *
+     * @example 'Pharmaceuticals'
+     */
+    public static function industry()
+    {
+        return static::randomElement(static::$industries);
+    }
+}

--- a/src/Faker/Provider/en_US/Product.php
+++ b/src/Faker/Provider/en_US/Product.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Faker\Provider\en_US;
+
+class Product extends \Faker\Provider\Product
+{
+    protected static $adjectives = array(
+        'Clean', 'Clear', 'Clever', 'Crazy','Dark', 'Distinguished',
+        'Dull', 'Durable', 'Elegant', 'Expensive', 'Fancy',
+        'Forgettable', 'Gentle', 'High-class', 'Inexpensive', 'Lackluster',
+        'Long', 'Low-class', 'Modern', 'Odd', 'Ordinary', 'Rough', 'Rusty',
+        'Second-rate', 'Sharp', 'Shiny', 'Sleek', 'Smart', 'Smooth', 'Solar-powered',
+        'Sparkling', 'Strange', 'Tough'
+    );
+
+    protected static $adverbs = array(
+        'Astonishingly', 'Awesomely', 'Brilliantly', 'Divinely', 'Extra',
+        'Excessively', 'Exorbitantly', 'Extremely', 'Fabulously',
+        'Generally', 'Gloriously', 'Greatly', 'Impossibly', 'Incredibly',
+        'Marvelously', 'Outrageously', 'Outstandingly',
+        'Overly', 'Pleasantly', 'Quite', 'Really',
+        'Smashingly', 'Stylishly', 'Superbly',
+        'Terrifically', 'Underwhelmingly', 'Wildly', 'Wickedly', 'Wonderfully',
+    );
+
+    /**
+     * Shamelessly copied from Amazon
+     */
+    protected static $category = array(
+        'Appliances', 'Apps and Games', 'Arts, Crafts and Sewing',
+        'Automotive Parts and Accessories', 'Baby', 'Beauty and Personal Care', 'Books',
+        'CDs and Vinyl', 'Cell Phones and Accessories', 'Clothing, Shoes and Jewelry',
+        'Collectibles and Fine Art', 'Computers', 'Courses', 'Credit and Payment Cards',
+        'Digital Music', 'Electronics', 'Garden and Outdoor', 'Gift Cards',
+        'Grocery and Gourmet Food', 'Handmade', 'Health, Household and Baby Care',
+        'Home and Business Services', 'Home and Kitchen', 'Industrial and Scientific',
+        'Kindle Store', 'Luggage and Travel Gear', 'Luxury Beauty',
+        'Magazine Subscriptions', 'Movies and TV', 'Musical Instruments',
+        'Office Products', 'Pet Supplies', 'Prime Exclusive Savings',
+        'Prime Pantry', 'Software', 'Sports and Outdoors', 'Tools and Home Improvement',
+        'Toys and Games', 'Vehicles', 'Video Games',
+    );
+
+    /**
+     * See https://en.wikipedia.org/wiki/Outline_of_industry
+     */
+    protected static $industries = array(
+        'Aerospace', 'Agriculture', 'Arms', 'Automotive',
+        'Broadcasting', 'Chemical', 'Computer', 'Construction',
+        'Defense', 'Direct Selling', 'Education', 'Electrical power',
+        'Electronics', 'Energy', 'Entertainment',
+        'Film', 'Financial services', 'Fishing', 'Food', 'Fruit production',
+        'Health care', 'Hospitality', 'Information', 'Insurance', 'Internet',
+        'Manufacturing', 'Mass media', 'Mining', 'Music', 'News media',
+        'Petroleum', 'Pharmaceutical', 'Publishing', 'Pulp and paper',
+        'Shipbuilding', 'Software', 'Steel',
+        'Telecommunications', 'Timber', 'Tobacco', 'Transport', 'Water'
+    );
+
+    protected static $materials = array(
+        'Aluminum', 'Amoled', 'Bronze', 'Candy', 'Carbon', 'Carbon Fiber',
+        'Ceramic', 'Chromium', 'Concrete', 'Copper', 'Cotton', 'Denim', 'Eco',
+        'Fiber', 'Fur', 'Glass', 'Granite', 'High Carbon', 'Iron', 'Kevlar',
+        'Latex', 'Leather', 'Leather', 'Linen', 'Low Carbon', 'Marbled', 'Metallic',
+        'Micro', 'Nylon', 'Paper', 'Plastic', 'Polycarbonate', 'Polyester',
+        'Polyurethane', 'Rubberized', 'Sand Blasted', 'Silicone', 'Silk',
+        'Spandex', 'Stainless', 'Steel', 'Synthetic', 'Wooden', 'Wool',
+    );
+
+    protected static $products = array(
+        'Backpack', 'Bag', 'Basin', 'Belt', 'Blender', 'Boots', 'Bottle',
+        'Box', 'Calculator', 'Cables', 'Camera', 'Cardigan', 'Carpet',
+        'Chair', 'Charger', 'Chinos', 'Clock', 'Coat', 'Desktop Computer',
+        'Dishwasher', 'Doorbell', 'Drone', 'Dryer', 'Envelop', 'Espresso Maker',
+        'Flashlight', 'Folder', 'Glasses', 'Gloves', 'Handbag', 'Handkerchief',
+        'Hat', 'Headset', 'Helmet', 'Humidifier', 'Jacket', 'Jersey', 'Keyboard',
+        'Lamp', 'Laptop', 'Mattress', 'Microphone', 'Monitor', 'Mouse', 'Notebook', 'Oven',
+        'Pajamas', 'Pants', 'Pen', 'Pencil', 'Phone', 'Purse', 'Radio',
+        'Raincoat', 'Refrigerator', 'Scale', 'Scanner', 'Shirt', 'Shoes',
+        'Socks', 'Speakers', 'Stapler', 'Stereo', 'Stove', 'Sweater',
+        'Table', 'Tablet', 'Tie', 'Toaster', 'TV', 'Umbrella',
+        'Undergarment', 'VCR', 'Vest', 'Wallet', 'Walkie-Talkie', 'Watch',
+    );
+
+    protected static $shapes = array(
+        'Broad', 'Crooked', 'Curved', 'Deep', 'Even', 'Flat',
+        'Jagged', 'Round', 'Shallow', 'Spherical', 'Square', 'Steep',
+        'Straight', 'Triangular', 'Uneven',
+    );
+
+    protected static $sizes = array(
+        'Average', 'Big', 'Bulky', 'Compact', 'Fat', 'Gigantic', 'Heavy',
+        'Huge', 'Large', 'Light', 'Little', 'Massive', 'Medium',
+        'Miniature', 'Narrow', 'Petite', 'Short', 'Skinny', 'Slim',
+        'Small', 'Tall', 'Thick', 'Thin', 'Tiny', 'Wide',
+    );
+
+    protected static $simpleFormats = array(
+        '{{adjective}} {{product}}',
+        '{{color}} {{product}}',
+        '{{size}} {{product}}',
+        '{{shape}} {{product}}',
+        '{{material}} {{product}}',
+    );
+
+    protected static $fancyFormats = array(
+        '{{adjective}} {{material}} {{product}}',
+        '{{adjective}} {{shape}} {{product}}',
+        '{{adjective}} {{color}} {{product}}',
+        '{{size}} {{material}} {{product}}',
+        '{{size}} {{shape}} {{product}}',
+        '{{size}} {{color}} {{product}}',
+    );
+
+    protected static $complexFormats = array(
+        '{{adverb}} {{adjective}} {{material}} {{product}}',
+        '{{adverb}} {{adjective}} {{shape}} {{product}}',
+        '{{adverb}} {{adjective}} {{color}} {{product}}',
+        '{{adverb}} {{size}} {{material}} {{product}}',
+        '{{adverb}} {{size}} {{shape}} {{product}}',
+        '{{adverb}} {{shape}} {{material}} {{product}}',
+        '{{adverb}} {{color}} {{material}} {{product}}',
+        '{{adverb}} {{color}} {{shape}} {{product}}',
+    );
+
+    protected static $elaborateFormats = array(
+        '{{adverb}} {{size}} {{adverb}} {{adjective}} {{material}} {{product}}',
+        '{{adverb}} {{shape}} {{adverb}} {{adjective}} {{material}} {{product}}',
+        '{{adverb}} {{color}} {{adverb}} {{adjective}} {{material}} {{product}}',
+        '{{adverb}} {{size}} {{adverb}} {{color}} {{material}} {{product}}',
+        '{{adverb}} {{color}} {{adverb}} {{shape}} {{material}} {{product}}',
+    );
+}


### PR DESCRIPTION
## Add option for commerce-related applications

Taken from the proposed documentation, here's how commerce option works:
```
simpleProduct           // Chromium Pants, Slim Dryer, Uneven Socks
fancyProduct            // Medium Sand Blasted Purse, Expensive Lime Camera, Crazy Plum Shirt
complexProduct          // Fabulously Clever Low Carbon Toaster, Superbly Narrow Silk Shirt
elaborateProduct        // Exorbitantly Wide Incredibly Sparkling Amoled Shirt
                        // Smashingly Massive Excessively White Carbon Fiber Pen
                        // Generally Dark Red Brilliantly Curved Synthetic Doorbell

color                   // Forest Green, Mint Cream, Light Sky Blue
                        // (color selection borrowed from [Color](#fakerprovidercolor))
industry                // Electronics, Manufacturing, Shipbuilding
size                    // Average, Miniature, Bulky, Huge
shape                   // Jagged, Crooked, Square, Triangular
adverb                  // Fabulously, Exorbitantly, Stylishly
adjective               // Smooth, Tough, Clear, Inexpensive
material                // Polyester, Steel, Fur, Ceramic, Wooden, Fiber
product                 // Carpet, Tie, Bag, Speakers, Bottle, Folder

price                   // random 1-9999, no decimal
price(777, 778, true)   // ($min, $max, $real)
                        // 777.66, 777.29, 777.72
```