### PR TITLE
Fix Polish PESEL faker

### DIFF
--- a/src/Faker/Provider/pl_PL/Person.php
+++ b/src/Faker/Provider/pl_PL/Person.php
@@ -159,11 +159,12 @@ class Person extends \Faker\Provider\Person
         for ($i = 6; $i < $length; $i++) {
             $result[$i] = static::randomDigit();
         }
-        if ($sex == "M") {
-            $result[$length - 1] |= 1;
-        } elseif ($sex == "F") {
-            $result[$length - 1] ^= 1;
+
+        $result[$length - 1] |= 1;
+        if ($sex == "F") {
+            $result[$length - 1] -= 1;
         }
+
         $checksum = 0;
         for ($i = 0; $i < $length; $i++) {
             $checksum += $weights[$i] * $result[$i];

--- a/test/Faker/Provider/pl_PL/PersonTest.php
+++ b/test/Faker/Provider/pl_PL/PersonTest.php
@@ -89,7 +89,7 @@ class PersonTest extends TestCase
     public function testPeselCheckSum()
     {
         $pesel   = $this->faker->pesel();
-        $weights = [1, 3, 7, 9, 1, 3, 7, 9, 1, 3, 1];
+        $weights = array(1, 3, 7, 9, 1, 3, 7, 9, 1, 3, 1);
         $sum     = 0;
 
         foreach ($weights as $key => $weight) {

--- a/test/Faker/Provider/pl_PL/PersonTest.php
+++ b/test/Faker/Provider/pl_PL/PersonTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Faker\Provider\pl_PL;
+
+use DateTime;
+use Faker\Generator;
+use PHPUnit\Framework\TestCase;
+
+class PersonTest extends TestCase
+{
+    /**
+     * @var Generator
+     */
+    private $faker;
+
+    public function setUp()
+    {
+        $faker = new Generator();
+        $faker->addProvider(new Person($faker));
+        $this->faker = $faker;
+    }
+
+    public function testPeselLenght()
+    {
+        $pesel = $this->faker->pesel();
+
+        $this->assertEquals(11, strlen($pesel));
+    }
+
+    public function testPeselDate()
+    {
+        $date  = new DateTime('1990-01-01');
+        $pesel = $this->faker->pesel($date);
+
+        $this->assertEquals('90', substr($pesel, 0, 2));
+        $this->assertEquals('01', substr($pesel, 2, 2));
+        $this->assertEquals('01', substr($pesel, 4, 2));
+    }
+
+    public function testPeselDateWithYearAfter2000()
+    {
+        $date  = new DateTime('2001-01-01');
+        $pesel = $this->faker->pesel($date);
+
+        $this->assertEquals('01', substr($pesel, 0, 2));
+        $this->assertEquals('21', substr($pesel, 2, 2));
+        $this->assertEquals('01', substr($pesel, 4, 2));
+    }
+
+    public function testPeselDateWithYearAfter2100()
+    {
+        $date  = new DateTime('2101-01-01');
+        $pesel = $this->faker->pesel($date);
+
+        $this->assertEquals('01', substr($pesel, 0, 2));
+        $this->assertEquals('41', substr($pesel, 2, 2));
+        $this->assertEquals('01', substr($pesel, 4, 2));
+    }
+
+    public function testPeselDateWithYearAfter2200()
+    {
+        $date  = new DateTime('2201-01-01');
+        $pesel = $this->faker->pesel($date);
+
+        $this->assertEquals('01', substr($pesel, 0, 2));
+        $this->assertEquals('61', substr($pesel, 2, 2));
+        $this->assertEquals('01', substr($pesel, 4, 2));
+    }
+
+    public function testPeselDateWithYearBefore1900()
+    {
+        $date  = new DateTime('1801-01-01');
+        $pesel = $this->faker->pesel($date);
+
+        $this->assertEquals('01', substr($pesel, 0, 2));
+        $this->assertEquals('81', substr($pesel, 2, 2));
+        $this->assertEquals('01', substr($pesel, 4, 2));
+    }
+
+    public function testPeselSex()
+    {
+        $male   = $this->faker->pesel(null, 'M');
+        $female = $this->faker->pesel(null, 'F');
+
+        $this->assertEquals(1, $male[9] % 2);
+        $this->assertEquals(0, $female[9] % 2);
+    }
+
+    public function testPeselCheckSum()
+    {
+        $pesel   = $this->faker->pesel();
+        $weights = [1, 3, 7, 9, 1, 3, 7, 9, 1, 3, 1];
+        $sum     = 0;
+
+        foreach ($weights as $key => $weight) {
+            $sum += $pesel[$key] * $weight;
+        }
+
+        $this->assertEquals(0, $sum % 10);
+    }
+}


### PR DESCRIPTION
Hi, polish PESEL faker has bug while generating PESEL for women.

10th digit in PESEL determines person sex. Even value mean woman, whether odd meas man. For now, tests sometimes fails, sometime passes. It's because of weird calculation using XOR.

This PR fixes this bug and add some tests to PESEL faker. In the past there were similar PR, but without tests: https://github.com/fzaninotto/Faker/pull/1037.

To run tests use this line: `phpunit --filter PersonTest test/Faker/Provider/pl_PL/PersonTest.php`