### PR TITLE
Allow nested alternations and literal brackets in regexify

### DIFF
--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -344,6 +344,7 @@ class BaseTest extends TestCase
             array('[a-z]{2,3}', 'brackets quantifiers on character class range'),
             array('(a|b){2,3}', 'brackets quantifiers on alternation'),
             array('\.\*\?\+', 'escaped characters'),
+            array('(a|(b|c))', 'nested alternation'),
             array('[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}', 'complex regex')
         );
     }

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -344,7 +344,8 @@ class BaseTest extends TestCase
             array('[a-z]{2,3}', 'brackets quantifiers on character class range'),
             array('(a|b){2,3}', 'brackets quantifiers on alternation'),
             array('\.\*\?\+', 'escaped characters'),
-            array('(a|(b|c))', 'nested alternation'),
+            array('(a|(b|c))', 'nested alternations'),
+            array('(a|\)b|c)', 'literal brackets in alternations'),
             array('[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}', 'complex regex')
         );
     }


### PR DESCRIPTION
See https://github.com/fzaninotto/Faker/issues/1452

I would appreciate some guidance around the test cases. On my machine, the mt_srand calls in Generator->seed completely mess up mt_rand, so phpunit fails tests left right and centre. 

From what I've seen, though, I haven't broken anything. Also, are the test cases I have included enough to cover my changes?