### PR TITLE
Updated ES_es VAT provider, fixed control digit calculation

### DIFF
--- a/src/Faker/Provider/es_ES/Payment.php
+++ b/src/Faker/Provider/es_ES/Payment.php
@@ -89,9 +89,9 @@ class Payment extends \Faker\Provider\Payment
      * International Bank Account Number (IBAN)
      * @link http://en.wikipedia.org/wiki/International_Bank_Account_Number
      *
-     * @param  string $prefix for generating bank account number of a specific bank
-     * @param  string $countryCode ISO 3166-1 alpha-2 country code
-     * @param  integer $length total length without country code and 2 check digits
+     * @param  string  $prefix      for generating bank account number of a specific bank
+     * @param  string  $countryCode ISO 3166-1 alpha-2 country code
+     * @param  integer $length      total length without country code and 2 check digits
      *
      * @return string
      */
@@ -101,7 +101,7 @@ class Payment extends \Faker\Provider\Payment
     }
 
     /**
-     * Value Added Tax (VAT) CIF
+     * Value Added Tax (VAT)
      *
      * @example 'B93694545'
      *

--- a/src/Faker/Provider/es_ES/Payment.php
+++ b/src/Faker/Provider/es_ES/Payment.php
@@ -4,14 +4,95 @@ namespace Faker\Provider\es_ES;
 
 class Payment extends \Faker\Provider\Payment
 {
-    private static $vatMap = array('A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'N', 'P', 'Q', 'R', 'S', 'U', 'V', 'W');
+    const CHECKSUM_DIGIT_LETTER = 0;
+    const CHECKSUM_DIGIT_NUMBER = 1;
+
+    private static $vatSocietyType = array(
+        'A', //  Sociedades anónimas.
+        'B', //  Sociedades de responsabilidad limitada.
+        'C', //  Sociedades colectivas.
+        'D', //  Sociedades comanditarias.
+        'E', //  Comunidades de bienes.
+        'F', //  Sociedades cooperativas.
+        'G', //  Asociaciones y fundaciones.
+        'H', //  Comunidades de propietarios en régimen de propiedad horizontal.
+        'J', //  Sociedades civiles.
+        'N', //  Entidades no residentes.
+        'P', //  Corporaciones locales.
+        'Q', //  Organismos autónomos', 'estatales o no', 'y asimilados', 'y congregaciones e instituciones religiosas.
+        'R', //  Congregaciones e instituciones religiosas (desde 2008', 'ORDEN EHA/451/2008)
+        'S', //  Órganos de la Administración del Estado y comunidades autónomas
+        'U', //  Uniones Temporales de Empresas.
+        'V', //  Sociedad Agraria de Transformación.
+        'W', //  Establecimientos permanentes de entidades no residentes en España
+    );
+
+    private static $vatProvinces = array(
+        '00', //  No Residente
+        '01', // Álava
+        '02', // Albacete
+        '03', '53', '54', // Alicante
+        '04', // Almería
+        '05', // Ávila
+        '06', // Badajoz
+        '07', '57', '16', // Islas Baleares
+        '08', '58', '59', '60', '61', '62', '63', '64', '65', '66', '68', // Barcelona
+        '09', // Burgos
+        '10', // Cáceres
+        '11', '72', // Cádiz
+        '12', // Castellón
+        '13', // Ciudad Real
+        '14', '56', // Córdoba
+        '15', '70', // La Coruña
+        '16', // Cuenca
+        '17', '55', '67', // Gerona
+        '18', '19', // Granada
+        '19', // Guadalajara
+        '20', '71', // Guipúzcoa
+        '21', // Huelva
+        '22', // Huesca
+        '23', // Jaén
+        '24', // León
+        '25', // Lérida
+        '26', // La Rioja
+        '27', // Lugo
+        '28', '78', '79', '80', '81', '82', '83', '84', '85', '86', '87', // Madrid
+        '29', '92', '93', // Málaga
+        '30', '73', // Murcia
+        '31', '71', // Navarra
+        '32', // Orense
+        '33', '74', // Asturias
+        '34', // Palencia
+        '35', '76', // Las Palmas
+        '36', '94', '27', // Pontevedra
+        '37', // Salamanca
+        '38', '75', // Santa Cruz de Tenerife
+        '39', // Cantabria
+        '40', // Segovia
+        '41', '90', '91', // Sevilla
+        '42', // Soria
+        '43', '77', // Tarragona
+        '44', // Teruel
+        '45', // Toledo
+        '46', '96', '97', '98', // Valencia
+        '47', // Valladolid
+        '48', '95', // Vizcaya
+        '49', // Zamora
+        '50', '99', // Zaragoza
+        '51', // Ceuta
+        '52', // Melilla
+    );
+
+    private static $vatCheksumDigits = 'JABCDEFGHI';
 
     /**
      * International Bank Account Number (IBAN)
      * @link http://en.wikipedia.org/wiki/International_Bank_Account_Number
-     * @param  string  $prefix      for generating bank account number of a specific bank
-     * @param  string  $countryCode ISO 3166-1 alpha-2 country code
-     * @param  integer $length      total length without country code and 2 check digits
+     *
+     * @param  string $prefix for generating bank account number of a specific bank
+     * @param  string $countryCode ISO 3166-1 alpha-2 country code
+     * @param  integer $length total length without country code and 2 check digits
+     *
      * @return string
      */
     public static function bankAccountNumber($prefix = '', $countryCode = 'ES', $length = null)
@@ -20,7 +101,7 @@ class Payment extends \Faker\Provider\Payment
     }
 
     /**
-     * Value Added Tax (VAT)
+     * Value Added Tax (VAT) CIF
      *
      * @example 'B93694545'
      *
@@ -31,9 +112,85 @@ class Payment extends \Faker\Provider\Payment
      */
     public static function vat()
     {
-        $letter = static::randomElement(self::$vatMap);
-        $number = static::numerify('########');
+        $societyType = static::randomElement(self::$vatSocietyType);
+        $province    = static::randomElement(self::$vatProvinces);
+        $inscription = static::numerify('#####');
+        $digitType   = static::getControlDigitType($societyType, $province);
+        $digit       = static::getControlDigit($province . $inscription, $digitType);
 
-        return $letter . $number;
+        return $societyType . $province . $inscription . $digit;
     }
+
+    /**
+     * @param string $digits a seven digits string (province + inscription number)
+     * @param string $digitType CHECKSUM_DIGIT_NUMBER or CHECKSUM_DIGIT_LETTER indicates the checksum digit type
+     *
+     * @return string control digit
+     */
+    private static function getControlDigit($digits, $digitType)
+    {
+        $evenSum = static::getEvenChecksum($digits);
+        $oddSum  = static::getOddChecksum($digits);
+        $digit   = (int)substr($evenSum + $oddSum, -1);
+        $digit   = $digit > 0 ? 10 - $digit : $digit;
+        if ($digitType === self::CHECKSUM_DIGIT_NUMBER) {
+            return (string)$digit;
+        }
+
+        return static::$vatCheksumDigits[$digit];
+    }
+
+    /**
+     * @param string $societyType one of self::SOCIETY_TYPE, indicates CIF society type
+     * @param string $province two digit province id
+     *
+     * @return int with self::CHECKSUM_DIGIT_NUMBER or self::CHECKSUM_DIGIT_LETTER, indicates the checksum digit type
+     */
+    private static function getControlDigitType($societyType, $province)
+    {
+        if (in_array($societyType, array('A', 'B', 'E', 'H'), true)) {
+            return self::CHECKSUM_DIGIT_NUMBER;
+        }
+        if ($province === '00' || in_array($societyType, array('P', 'Q', 'S', 'W'), true)) {
+            return self::CHECKSUM_DIGIT_LETTER;
+        }
+
+        return rand(0, 1) ? self::CHECKSUM_DIGIT_LETTER : self::CHECKSUM_DIGIT_NUMBER;
+    }
+
+    /**
+     * This checksum is calculated with the sum of all the digits in even position (1 based index  (╯°□°）╯)
+     *
+     * @param string $digits seven digit string  (province + inscription number)
+     *
+     * @return int even digits checksum
+     */
+    private static function getEvenChecksum($digits)
+    {
+        $checksum = 0;
+        foreach (range(1, strlen($digits) - 1, 2) as $digit) {
+            $checksum += (int)$digits[$digit];
+        }
+
+        return $checksum;
+    }
+
+    /**
+     * This checsum is calculated with the sum of all digits in odd position, multiplying them *2 and adding the last
+     * digit of the multiplication result
+     *
+     * @param string $digits seven digit string  (province + inscription number)
+     *
+     * @return int
+     */
+    private static function getOddChecksum($digits)
+    {
+        $checksum = 0;
+        foreach (range(0, strlen($digits) - 1, 2) as $digit) {
+            $checksum += array_sum(str_split((int)$digits[$digit] * 2));
+        }
+
+        return $checksum;
+    }
+
 }

--- a/test/Faker/Provider/es_ES/PaymentTest.php
+++ b/test/Faker/Provider/es_ES/PaymentTest.php
@@ -28,34 +28,52 @@ class PaymentTest extends TestCase
     }
 
     /**
-     * Validation taken from https://github.com/amnesty/drupal-nif-nie-cif-validator/
-     * @link https://github.com/amnesty/drupal-nif-nie-cif-validator/blob/master/includes/nif-nie-cif.php
+     * Validation taken from https://github.com/ronanguilloux/IsoCodes
+     * @link https://github.com/ronanguilloux/IsoCodes/blob/master/src/IsoCodes/Cif.php
      */
-    function isValidCIF($docNumber)
+    function isValidCIF($cif)
     {
-        $fixedDocNumber = strtoupper($docNumber);
+        $cifCodes = 'JABCDEFGHI';
 
-        return $this->isValidCIFFormat($fixedDocNumber);
+        if (9 !== strlen($cif)) {
+            return false;
+        }
+        $cif = strtoupper(trim($cif));
+        $sum = (string) $this->getCifSum($cif);
+
+        $n = (10 - substr($sum, -1)) % 10;
+
+        if (preg_match('/^[ABCDEFGHJKNPQRSUVW]{1}/', $cif)) {
+            if (in_array($cif[0], array('A', 'B', 'E', 'H'))) {
+                // Numerico
+                return $cif[8] == $n;
+            } elseif (in_array($cif[0], array('K', 'P', 'Q', 'S'))) {
+                // Letras
+                return $cif[8] == $cifCodes[$n];
+            } else {
+                // Alfanumérico
+                if (is_numeric($cif[8])) {
+                    return $cif[8] == $n;
+                } else {
+                    return $cif[8] == $cifCodes[$n];
+                }
+            }
+        }
+
+        return false;
     }
 
-    function isValidCIFFormat($docNumber)
+    public function getCifSum($cif)
     {
-        return $this->respectsDocPattern($docNumber, '/^[PQSNWR][0-9][0-9][0-9][0-9][0-9][0-9][0-9][A-Z0-9]/')
-                ||
-               $this->respectsDocPattern($docNumber, '/^[ABCDEFGHJUV][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]/');
-    }
+        $sum = $cif[2] + $cif[4] + $cif[6];
 
-    function respectsDocPattern($givenString, $pattern)
-    {
-        $isValid = FALSE;
-        $fixedString = strtoupper($givenString);
-        if (is_int(substr($fixedString, 0, 1))) {
-            $fixedString = substr("000000000" . $givenString, -9);
+        for ($i = 1; $i < 8; $i += 2) {
+            $tmp = (string) (2 * $cif[$i]);
+            $tmp = $tmp[0] + ((strlen($tmp) == 2) ? $tmp[1] : 0);
+            $sum += $tmp;
         }
-        if (preg_match($pattern, $fixedString)) {
-            $isValid = TRUE;
-        }
-        return $isValid;
+
+        return $sum;
     }
 
 }

--- a/test/Faker/Provider/es_ES/PaymentTest.php
+++ b/test/Faker/Provider/es_ES/PaymentTest.php
@@ -63,6 +63,10 @@ class PaymentTest extends TestCase
         return false;
     }
 
+    /**
+     * Validation taken from https://github.com/ronanguilloux/IsoCodes
+     * @link https://github.com/ronanguilloux/IsoCodes/blob/master/src/IsoCodes/Nif.php
+     */
     public function getCifSum($cif)
     {
         $sum = $cif[2] + $cif[4] + $cif[6];


### PR DESCRIPTION
Current ES_es provider faker->vat only generates a random control digit that causes strict vat (CIF) validators to fail.

This version generates a strict VAT number (society type + province + inscription number + control digit) that passes the validation libraries