### PR TITLE
Turkish identity number for tr_TR

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1598,6 +1598,15 @@ echo $faker->personalIdentityNumber() // '950910-0799'
 //Since the numbers are different for male and female persons, optionally you can specify gender.
 echo $faker->personalIdentityNumber('female') // '950910-0781'
 ```
+### `Faker\Provider\tr_TR\Person`
+
+```php
+<?php
+
+//Generates a valid Turkish identity number (in Turkish - T.C. Kimlik No)
+echo $faker->tcNo // '55300634882'
+
+```
 
 
 ### `Faker\Provider\zh_CN\Payment`

--- a/src/Faker/Calculator/TCNo.php
+++ b/src/Faker/Calculator/TCNo.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Faker\Calculator;
+
+use InvalidArgumentException;
+
+class TCNo
+{
+    /**
+     * Generates Turkish Identity Number Checksum
+     * Gets first 9 digit as prefix and calcuates checksums
+     *
+     * https://en.wikipedia.org/wiki/Turkish_Identification_Number
+     *
+     * @param string $identityPrefix
+     * @return string Checksum (two digit)
+     */
+    public static function checksum($identityPrefix)
+    {
+        if (strlen((string)$identityPrefix) !== 9) {
+            throw new InvalidArgumentException('Argument should be an integer and should be 9 digits.');
+        }
+
+        $oddSum = 0;
+        $evenSum = 0;
+
+        $identityArray = array_map('intval', str_split($identityPrefix)); // Creates array from int
+        foreach ($identityArray as $index => $digit) {
+            if ($index % 2 == 0) {
+                $evenSum += $digit;
+            } else {
+                $oddSum += $digit;
+            }
+        }
+
+        $tenthDigit = (7 * $evenSum - $oddSum) % 10;
+        $eleventhDigit = ($evenSum + $oddSum + $tenthDigit) % 10;
+
+        return $tenthDigit . $eleventhDigit;
+    }
+
+    /**
+     * Checks whether an TCNo has a valid checksum
+     *
+     * @param string $tcNo
+     * @return boolean
+     */
+    public static function isValid($tcNo)
+    {
+        return self::checksum(substr($tcNo, 0, -2)) === substr($tcNo, -2, 2);
+    }
+}

--- a/src/Faker/Provider/tr_TR/Person.php
+++ b/src/Faker/Provider/tr_TR/Person.php
@@ -2,6 +2,8 @@
 
 namespace Faker\Provider\tr_TR;
 
+use Faker\Calculator\TCNo;
+
 class Person extends \Faker\Provider\Person
 {
     /**
@@ -93,5 +95,18 @@ class Person extends \Faker\Provider\Person
     public static function titleFemale()
     {
         return static::titleMale();
+    }
+
+    /**
+     * National Personal Identity number (tc kimlik no)
+     * @link https://en.wikipedia.org/wiki/Turkish_Identification_Number
+     * @return string on format XXXXXXXXXXX
+     */
+    public function tcNo()
+    {
+        $randomDigits = static::numerify('#########');
+        $checksum = TCNo::checksum($randomDigits);
+
+        return $randomDigits . $checksum;
     }
 }

--- a/test/Faker/Calculator/TCNoTest.php
+++ b/test/Faker/Calculator/TCNoTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Faker\Test\Calculator;
+
+use Faker\Calculator\TCNo;
+use PHPUnit\Framework\TestCase;
+
+class TCNoTest extends TestCase
+{
+    public function checksumProvider()
+    {
+        return array(
+            array('553006348', '82'),
+            array('350630743', '78'),
+            array('550600932', '88'),
+            array('487932947', '70'),
+            array('168113862', '40')
+        );
+    }
+
+    /**
+     * @dataProvider checksumProvider
+     * @param $tcNo
+     * @param $checksum
+     */
+    public function testChecksum($tcNo, $checksum)
+    {
+        $this->assertEquals($checksum, TCNo::checksum($tcNo), $tcNo);
+    }
+
+    public function validatorProvider()
+    {
+        return array(
+            array('22978160678', true),
+            array('26480045324', true),
+            array('47278360658', true),
+            array('34285002510', true),
+            array('19874561012', true),
+
+            array('11111111111', false),
+            array('11234567899', false),
+        );
+    }
+
+    /**
+     * @dataProvider validatorProvider
+     * @param $tcNo
+     * @param $isValid
+     */
+    public function testIsValid($tcNo, $isValid)
+    {
+        $this->assertEquals($isValid, TCNo::isValid($tcNo), $tcNo);
+    }
+}

--- a/test/Faker/Provider/DateTimeTest.php
+++ b/test/Faker/Provider/DateTimeTest.php
@@ -236,7 +236,7 @@ class DateTimeTest extends TestCase
 
     public function testFixedSeedWithMaximumTimestamp()
     {
-        $max = '2018-03-01 12:00:00';
+        $max = '2019-03-01 12:00:00';
 
         mt_srand(1);
         $unixTime = DateTimeProvider::unixTime($max);

--- a/test/Faker/Provider/tr_TR/CompanyTest.php
+++ b/test/Faker/Provider/tr_TR/CompanyTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Faker\Test\Provider\tr_TR;
+
+use Faker\Provider\tr_TR\Company;
+use Faker\Generator;
+
+class CompanyTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @var Generator
+     */
+    private $faker;
+
+    public function setUp()
+    {
+        $faker = new Generator();
+        $faker->addProvider(new Company($faker));
+        $this->faker = $faker;
+    }
+
+    public function testCompany()
+    {
+        $company = $this->faker->companyField;
+        $this->assertNotNull($company);
+    }
+}

--- a/test/Faker/Provider/tr_TR/PaymentTest.php
+++ b/test/Faker/Provider/tr_TR/PaymentTest.php
@@ -1,0 +1,29 @@
+<?php
+
+
+namespace Faker\Provider\tr_TR;
+
+use Faker\Generator;
+use PHPUnit\Framework\TestCase;
+
+class PaymentTest extends TestCase
+{
+    /**
+     * @var Generator
+     */
+    private $faker;
+
+    public function setUp()
+    {
+        $faker = new Generator();
+        $faker->addProvider(new Payment($faker));
+        $this->faker = $faker;
+    }
+
+    public function testBankAccountNumber()
+    {
+        $accNo = $this->faker->bankAccountNumber;
+        $this->assertEquals(substr($accNo, 0, 2), 'TR');
+        $this->assertEquals(26, strlen($accNo));
+    }
+}

--- a/test/Faker/Provider/tr_TR/PersonTest.php
+++ b/test/Faker/Provider/tr_TR/PersonTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Faker\Test\Provider\tr_TR;
+
+use Faker\Calculator\TCNo;
+use Faker\Provider\tr_TR\Person;
+use Faker\Generator;
+use PHPUnit\Framework\TestCase;
+
+class PersonTest extends TestCase
+{
+
+    /**
+     * @var Generator
+     */
+    private $faker;
+
+    public function setUp()
+    {
+        $faker = new Generator();
+        $faker->addProvider(new Person($faker));
+        $this->faker = $faker;
+    }
+
+    public function testTCNo()
+    {
+        for ($i = 0; $i < 100; $i++) {
+            $number = $this->faker->tcNo;
+
+            $this->assertEquals(11, strlen($number));
+            $this->assertTrue(TCNo::isValid($number));
+        }
+    }
+}

--- a/test/Faker/Provider/tr_TR/PhoneNumberTest.php
+++ b/test/Faker/Provider/tr_TR/PhoneNumberTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Faker\Test\Provider\tr_TR;
+
+use Faker\Generator;
+use Faker\Provider\tr_TR\PhoneNumber;
+use PHPUnit\Framework\TestCase;
+
+class PhoneNumberTest extends TestCase
+{
+
+    /**
+     * @var Generator
+     */
+    private $faker;
+
+    public function setUp()
+    {
+        $faker = new Generator();
+        $faker->addProvider(new PhoneNumber($faker));
+        $this->faker = $faker;
+    }
+
+    public function testPhoneNumber()
+    {
+        for ($i = 0; $i < 100; $i++) {
+            $number = $this->faker->phoneNumber;
+            $baseNumber = preg_replace('/ *x.*$/', '', $number); // Remove possible extension
+            $digits = array_values(array_filter(str_split($baseNumber), 'ctype_digit'));
+
+            $this->assertGreaterThan(10, count($digits));
+        }
+    }
+}


### PR DESCRIPTION
Turkish identity number generator has been added to tr_TR locale's Person entity.
Also a new calculator for generating checksum and validating turkish identity number has been added.
I could not see any unit tests for tr_TR locale so I created some simple unit tests.

Lastly there was a failing unit tests in datetime unit tests which given static date is before current date. I changed that simply to one year later but it can be improved later.