### PR TITLE
Push the max date far into the future so the test can pass

### DIFF
--- a/test/Faker/Provider/DateTimeTest.php
+++ b/test/Faker/Provider/DateTimeTest.php
@@ -236,7 +236,7 @@ class DateTimeTest extends TestCase
 
     public function testFixedSeedWithMaximumTimestamp()
     {
-        $max = '2018-03-01 12:00:00';
+        $max = '2118-03-01 12:00:00';
 
         mt_srand(1);
         $unixTime = DateTimeProvider::unixTime($max);


### PR DESCRIPTION
There is a fixed date in the \Faker\Test\Provider\DateTimeTest::testFixedSeedWithMaximumTimestamp test that is set to 2018-03-01 12:00:00.

As this is now in the past it is causing the \Faker\Provider\DateTime::dateTimeThisMonth to throw an error which is causing the test to fail.

This increases the max date to 100 years in the future to avoid having to change this again, and allows the tests to pass once more