### PR TITLE
Update the parameters to check if the setter is callable

### DIFF
--- a/src/Faker/ORM/Doctrine/EntityPopulator.php
+++ b/src/Faker/ORM/Doctrine/EntityPopulator.php
@@ -211,7 +211,7 @@ class EntityPopulator
                 }
                 // Try a standard setter if it's available, otherwise fall back on reflection
                 $setter = sprintf("set%s", ucfirst($field));
-                if (is_callable($obj, $setter)) {
+                if (is_callable(array($obj, $setter))) {
                     $obj->$setter($value);
                 } else {
                     $this->class->reflFields[$field]->setValue($obj, $value);


### PR DESCRIPTION
There was a change made in #1363 to the `\Faker\ORM\Doctrine\EntityPopulator::fillColumns` method to prevent errors if the setter was a private method.

The `method_exists` call was changed to `is_callable`, but the parameters passed to the call were not updated which means it will always return false.

This updates them to check if the setter is callable.

Tests will pass if #1469 if merged in