### PR TITLE
New tlds for en_ZA locale.

### DIFF
--- a/src/Faker/Provider/en_ZA/Address.php
+++ b/src/Faker/Provider/en_ZA/Address.php
@@ -8,31 +8,31 @@ class Address extends \Faker\Provider\en_US\Address
     protected static $citySuffix = array('fontein','town', 'ton', 'land', 'ville', 'berg', 'burgh', 'borough', 'bury', 'view', 'port', 'mouth', 'stad', 'furt', 'chester', 'mouth', 'fort', 'haven', 'side', 'shire');
     protected static $buildingNumber = array('#####', '####', '###');
     protected static $streetSuffix = array(
-        'Alley', 'Avenue', 'Branch', 'Bridge', 'Brook', 'Brooks', 'Burg', 'Burgs', 'Bypass', 'Camp', 'Canyon', 'Cape', 'Causeway', 'Center', 'Centers', 'Circle', 'Circles', 'Cliff', 'Cliffs', 'Club', 'Common', 'Corner', 'Corners', 'Course', 'Court', 'Courts', 'Cove', 'Coves', 'Creek', 'Crescent', 'Crest', 'Crossing', 'Crossroad', 'Curve', 'Dale', 'Dam', 'Divide', 'Drive', 'Drive', 'Drives', 'Estate', 'Estates', 'Expressway', 'Extension', 'Extensions', 'Fall', 'Falls', 'Ferry', 'Field', 'Fields', 'Flat', 'Flats', 'Ford', 'Fords', 'Forest', 'Forge', 'Forges', 'Fork', 'Forks', 'Fort', 'Freeway', 'Garden', 'Gardens', 'Gateway', 'Glen', 'Glens', 'Green', 'Greens', 'Grove', 'Groves', 'Harbor', 'Harbors', 'Haven', 'Heights', 'Highway', 'Hill', 'Hills', 'Hollow', 'Inlet', 'Inlet', 'Island', 'Island', 'Islands', 'Islands', 'Isle', 'Isle', 'Junction', 'Junctions', 'Key', 'Keys', 'Knoll', 'Knolls', 'Lake', 'Lakes', 'Land', 'Landing', 'Lane', 'Light', 'Lights', 'Loaf', 'Lock', 'Locks', 'Locks', 'Lodge', 'Lodge', 'Loop', 'Mall', 'Manor', 'Manors', 'Meadow', 'Meadows', 'Mews', 'Mill', 'Mills', 'Mission', 'Mission', 'Motorway', 'Mount', 'Mountain', 'Mountain', 'Mountains', 'Mountains', 'Neck', 'Orchard', 'Oval', 'Overpass', 'Park', 'Parks', 'Parkway', 'Parkways', 'Pass', 'Passage', 'Path', 'Pike', 'Pine', 'Pines', 'Place', 'Plain', 'Plains', 'Plains', 'Plaza', 'Plaza', 'Point', 'Points', 'Port', 'Port', 'Ports', 'Ports', 'Prairie', 'Prairie', 'Radial', 'Ramp', 'Ranch', 'Rapid', 'Rapids', 'Rest', 'Ridge', 'Ridges', 'River', 'Road', 'Road', 'Roads', 'Roads', 'Route', 'Row', 'Rue', 'Run', 'Shoal', 'Shoals', 'Shore', 'Shores', 'Skyway', 'Spring', 'Springs', 'Springs', 'Spur', 'Spurs', 'Square', 'Square', 'Squares', 'Squares', 'Station', 'Station', 'Stravenue', 'Stravenue', 'Stream', 'Stream', 'Street', 'Street', 'Streets', 'Summit', 'Summit', 'Terrace', 'Throughway', 'Trace', 'Track', 'Trafficway', 'Trail', 'Trail', 'Tunnel', 'Tunnel', 'Turnpike', 'Turnpike', 'Underpass', 'Union', 'Unions', 'Valley', 'Valleys', 'Via', 'Viaduct', 'View', 'Views', 'Village', 'Village', 'Villages', 'Ville', 'Vista', 'Vista', 'Walk', 'Walks', 'Wall', 'Way', 'Ways', 'Well', 'Wells',
+        'Alley', 'Avenue', 'Branch', 'Bridge', 'Brook', 'Brooks', 'Burg', 'Burgs', 'Bypass', 'Camp', 'Canyon', 'Cape', 'Causeway', 'Center', 'Centers', 'Circle', 'Circles', 'Cliff', 'Cliffs', 'Club', 'Common', 'Corner', 'Corners', 'Course', 'Court', 'Courts', 'Cove', 'Coves', 'Creek', 'Crescent', 'Crest', 'Crossing', 'Crossroad', 'Curve', 'Dale', 'Dam', 'Divide', 'Drive', 'Drive', 'Drives', 'Estate', 'Estates', 'Expressway', 'Extension', 'Extensions', 'Fall', 'Falls', 'Ferry', 'Field', 'Fields', 'Flat', 'Flats', 'Ford', 'Fords', 'Forest', 'Forge', 'Forges', 'Fork', 'Forks', 'Fort', 'Freeway', 'Garden', 'Gardens', 'Gateway', 'Glen', 'Glens', 'Green', 'Greens', 'Grove', 'Groves', 'Harbor', 'Harbors', 'Haven', 'Heights', 'Highway', 'Hill', 'Hills', 'Hollow', 'Inlet', 'Inlet', 'Island', 'Island', 'Islands', 'Islands', 'Isle', 'Isle', 'Junction', 'Junctions', 'Key', 'Keys', 'Knoll', 'Knolls', 'Lake', 'Lakes', 'Land', 'Landing', 'Lane', 'Light', 'Lights', 'Loaf', 'Lock', 'Locks', 'Locks', 'Lodge', 'Lodge', 'Loop', 'Mall', 'Manor', 'Manors', 'Meadow', 'Meadows', 'Mews', 'Mill', 'Mills', 'Mission', 'Mission', 'Motorway', 'Mount', 'Mountain', 'Mountain', 'Mountains', 'Mountains', 'Neck', 'Orchard', 'Oval', 'Overpass', 'Park', 'Parks', 'Parkway', 'Parkways', 'Pass', 'Passage', 'Path', 'Pike', 'Pine', 'Pines', 'Place', 'Plain', 'Plains', 'Plains', 'Plaza', 'Plaza', 'Point', 'Points', 'Port', 'Port', 'Ports', 'Ports', 'Prairie', 'Prairie', 'Radial', 'Ramp', 'Ranch', 'Rapid', 'Rapids', 'Rest', 'Ridge', 'Ridges', 'River', 'Road', 'Road', 'Roads', 'Roads', 'Route', 'Row', 'Rue', 'Run', 'Shoal', 'Shoals', 'Shore', 'Shores', 'Skyway', 'Spring', 'Springs', 'Springs', 'Spur', 'Spurs', 'Square', 'Square', 'Squares', 'Squares', 'Station', 'Station', 'Stravenue', 'Stravenue', 'Stream', 'Stream', 'Street', 'Street', 'Streets', 'Summit', 'Summit', 'Terrace', 'Throughway', 'Trace', 'Track', 'Trafficway', 'Trail', 'Trail', 'Tunnel', 'Tunnel', 'Turnpike', 'Turnpike', 'Underpass', 'Union', 'Unions', 'Valley', 'Valleys', 'Via', 'Viaduct', 'View', 'Views', 'Village', 'Village', 'Villages', 'Ville', 'Vista', 'Vista', 'Walk', 'Walks', 'Wall', 'Way', 'Ways', 'Well', 'Wells'
     );
     protected static $postcode = array('####');
     protected static $province = array(
-        'Eastern Cape', 'Free State', 'Gauteng', 'KwaZulu-Natal', 'Limpopo', 'Mpumalanga', 'North-West', 'Northern Cape', 'Western Cape',
+        'Eastern Cape', 'Free State', 'Gauteng', 'KwaZulu-Natal', 'Limpopo', 'Mpumalanga', 'North-West', 'Northern Cape', 'Western Cape'
     );
     protected static $provinceAbbr = array(
-        'EC', 'FS', 'GP', 'KZN', 'LP', 'MP', 'NW', 'NC', 'WC',
+        'EC', 'FS', 'GP', 'KZN', 'LP', 'MP', 'NW', 'NC', 'WC'
     );
     protected static $cityFormats = array(
         '{{cityPrefix}} {{firstName}}{{citySuffix}}',
         '{{cityPrefix}} {{firstName}}',
         '{{firstName}}{{citySuffix}}',
-        '{{lastName}}{{citySuffix}}',
+        '{{lastName}}{{citySuffix}}'
     );
     protected static $streetNameFormats = array(
         '{{firstName}} {{streetSuffix}}',
-        '{{lastName}} {{streetSuffix}}',
+        '{{lastName}} {{streetSuffix}}'
     );
     protected static $streetAddressFormats = array(
         '{{buildingNumber}} {{streetName}}',
-        '{{buildingNumber}} {{streetName}} {{secondaryAddress}}',
+        '{{buildingNumber}} {{streetName}} {{secondaryAddress}}'
     );
     protected static $addressFormats = array(
-        "{{streetAddress}}\n{{city}}, {{provinceAbbr}} {{postcode}}",
+        "{{streetAddress}}\n{{city}}, {{provinceAbbr}} {{postcode}}"
     );
     protected static $secondaryAddressFormats = array('Apt. ###', 'Suite ###');
 

--- a/src/Faker/Provider/en_ZA/Company.php
+++ b/src/Faker/Provider/en_ZA/Company.php
@@ -7,6 +7,12 @@ namespace Faker\Provider\en_ZA;
  */
 class Company extends \Faker\Provider\Company
 {
+    protected static $formats = array(
+        '{{lastName}} {{companySuffix}}',
+        '{{lastName}}-{{lastName}}',
+        '{{lastName}}, {{lastName}} and {{lastName}}',
+    );
+    
     /**
      * @link https://en.wikipedia.org/wiki/South_African_company_law
      */

--- a/src/Faker/Provider/en_ZA/Company.php
+++ b/src/Faker/Provider/en_ZA/Company.php
@@ -7,9 +7,21 @@ namespace Faker\Provider\en_ZA;
  */
 class Company extends \Faker\Provider\Company
 {
+    /**
+     * @link https://en.wikipedia.org/wiki/South_African_company_law
+     */
+    protected static $companySuffix = array(
+        'Ltd',
+        '(Pty) Ltd',
+        'NPC',
+        'SOC Ltd',
+        'Inc',
+        'CC'
+    );
+    
     protected static $legalEntities = array(
         '01', '02', '06', '07', '08', '09', '10', '11', '12', '14', '15', '16', '17', '20', '21', '22', '23', '24', '25',
-        '26', '30', '31', '80',
+        '26', '30', '31', '80'
     );
 
     /**

--- a/src/Faker/Provider/en_ZA/Internet.php
+++ b/src/Faker/Provider/en_ZA/Internet.php
@@ -13,6 +13,6 @@ class Internet extends \Faker\Provider\Internet
         'co.za', 'co.za', 'co.za', 'co.za', 'com', 'com', 'net', 'gov.za', 'ac.za', 'edu.za', 'law.za', 'mil.za',
         'net.za', 'nom.za', 'org.za', 'school.za', 'ecape.school.za', 'fs.school.za', 'gp.school.za', 'kzn.school.za',
         'mpm.za', 'ncape.school.za', 'lp.school.za', 'nw.school.za', 'wcape.school.za', 'web.za', 'agric.za', 'nis.za',
-        'grondar.za',
+        'grondar.za', 'joburg', 'capetown', 'durban'
     );
 }


### PR DESCRIPTION
## Internet.php

- [x] Added support for `.joburg`, `.capetown` and `.durban` new TLDs. The reference to these TLDs [come from here][tld].

## Address.php

- [x] Fixes incorrect code standards and compliance with other locales.

## Company.php

- [x] Added new company suffixes. 
- [x] Included the required `$formats` static method for new companySuffix

## From `CONTRIBUTING.md`:

- [x] Unit tests should still pass after your patch. Run the tests on your dev server (with `make test`) or check the continuous integration status for your pull request.
- [ ] Avoid changing existing sets of data. Some developers use Faker with seeding for unit tests ; changing the data makes their tests fail.`1`
- [x] If you commit a new feature, be prepared to help maintaining it. Watch the project on GitHub, and please comment on issues or PRs regarding the feature you contributed.
- [x] Publishing your Pull Request on the Faker GitHub repository means that you agree with this license for your contribution.

`1` I know this PR breaks this rule however, I believe the new TLDs are important to add for the future use of the locale.

[tld]: https://www.zadna.org.za/content/page/za-cities-tlds1/