### PR TITLE
Fix typo in fr_CA Provider

### DIFF
--- a/src/Faker/Provider/fr_CA/Address.php
+++ b/src/Faker/Provider/fr_CA/Address.php
@@ -76,7 +76,7 @@ class Address extends \Faker\Provider\fr_FR\Address
     protected static $secondaryAddressFormats = array('Apt. ###', 'Suite ###', 'Bureau ###');
 
     protected static $state = array(
-        'Alberta', 'Colombie-Brittanique', 'Manitoba', 'Nouveau-Brunswick', 'Terre-Neuve-et-Labrador', 'Nouvelle-Écosse', 'Ontario', 'Île-du-Prince-Édouard', 'Québec', 'Saskatchewan'
+        'Alberta', 'Colombie-Britannique', 'Manitoba', 'Nouveau-Brunswick', 'Terre-Neuve-et-Labrador', 'Nouvelle-Écosse', 'Ontario', 'Île-du-Prince-Édouard', 'Québec', 'Saskatchewan'
     );
 
     protected static $stateAbbr = array(


### PR DESCRIPTION
Fixed the typo from Colombie-Brittanique to Colombie-Britannique
[source](https://en.wikipedia.org/wiki/British_Columbia)