### PR TITLE
[it_IT] Improve vat ID generated using official rules

### DIFF
--- a/src/Faker/Provider/it_IT/Company.php
+++ b/src/Faker/Provider/it_IT/Company.php
@@ -2,6 +2,8 @@
 
 namespace Faker\Provider\it_IT;
 
+use Faker\Calculator\Luhn;
+
 class Company extends \Faker\Provider\Company
 {
     protected static $formats = array(
@@ -69,6 +71,8 @@ class Company extends \Faker\Provider\Company
      */
     public static function vatId()
     {
-        return static::numerify('IT###########');
+        $code = sprintf('%s%03d', static::numerify('#######'), static::numberBetween(1, 121));
+
+        return sprintf('IT%s%d', $code, Luhn::computeCheckDigit($code));
     }
 }


### PR DESCRIPTION
SSIA.
Italy VAT Code should be:
 - 7 number (random)
 - 3 number (allowed values are city ISTAT code, that is a number between 1 and 121)
 - Luhn control code