### PR TITLE
fix regexify

### DIFF
--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -497,7 +497,8 @@ class Base
         }, $regex);
         // All [ABC] become B (or A or C)
         $regex = preg_replace_callback('/\[([^\]]+)\]/', function ($matches) {
-            return Base::randomElement(str_split($matches[1]));
+            preg_match_all('/\\\.|./', $matches[1], $splitStrs);
+            return Base::randomElement($splitStrs[0]);
         }, $regex);
         // replace \d with number and \w with letter and . with ascii
         $regex = preg_replace_callback('/\\\w/', 'static::randomLetter', $regex);

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -344,7 +344,7 @@ class BaseTest extends TestCase
             array('[a-z]{2,3}', 'brackets quantifiers on character class range'),
             array('(a|b){2,3}', 'brackets quantifiers on alternation'),
             array('\.\*\?\+', 'escaped characters'),
-            array('[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}', 'complex regex')
+            array('[A-Z0-9\._%\+\-]+@[A-Z0-9\.\-]+\.[A-Z]{2,4}', 'complex regex')
         );
     }
 


### PR DESCRIPTION
Fix the bug that when using regexify function if the pattern contain escaping special characters in square brackets such like [\.\+A-z] it would return unmatched string.