### PR TITLE
Add missing properties

### DIFF
--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -33,6 +33,8 @@ namespace Faker;
  * @property string $isbn10
  *
  * @property string $phoneNumber
+ * @property string $tollFreePhoneNumber
+ * @property string $e164PhoneNumber
  *
  * @property string $company
  * @property string $companySuffix


### PR DESCRIPTION
Add the [documented](https://github.com/fzaninotto/Faker#fakerprovideren_usphonenumber), but missing $e164PhoneNumber and $tollFreePhoneNumber properties to Generator.