### PR TITLE
Typo in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1285,7 +1285,7 @@ echo $faker->metropolitanCity; // "서울특별시"
 echo $faker->borough; // "강남구"
 ```
 
-### `Faker\Provider\ko_KR\PhoneNumer`
+### `Faker\Provider\ko_KR\PhoneNumber`
 
 ```php
 <?php


### PR DESCRIPTION
Missing a `b` in `PhoneNumber` for `ko_KR`.