### PR TITLE
Switch presentational b and i elements for semantic strong and em

### DIFF
--- a/src/Faker/Provider/HtmlLorem.php
+++ b/src/Faker/Provider/HtmlLorem.php
@@ -24,8 +24,8 @@ class HtmlLorem extends Base
     const UL_TAG = "ul";
     const LI_TAG = "li";
     const H_TAG = "h";
-    const B_TAG = "b";
-    const I_TAG = "i";
+    const B_TAG = "strong";
+    const I_TAG = "em";
     const TITLE_TAG = "title";
     const FORM_TAG = "form";
     const INPUT_TAG = "input";


### PR DESCRIPTION
Currently the body HTML generated by `randomHtml` contains elements that some validators object to.

This is slightly complicated again by HTML5 introducing new meaning for the `b` and `i` elements but switching [still looks sensible](http://html5doctor.com/i-b-em-strong-element/).

Merging #1421 too would make this even more useful.