### PR TITLE
Return FrozenTime for CakePHP >= 3.3

### DIFF
--- a/src/Faker/ORM/CakePHP/ColumnTypeGuesser.php
+++ b/src/Faker/ORM/CakePHP/ColumnTypeGuesser.php
@@ -56,7 +56,11 @@ class ColumnTypeGuesser
             case 'timestamp':
             case 'time':
                 return function () use ($generator) {
-                    return $generator->datetime();
+                    $datetime = $generator->datetime();
+                    if (floatval(\Cake\Core\Configure::version() >= 3.3)) {
+                        return new \Cake\I18n\FrozenTime($datetime->format('Y-m-d H:i:s'));
+                    }
+                    return $datetime;
                 };
 
             case 'binary':


### PR DESCRIPTION
CakePHP 3.3 introduced the new FrozenTime class, which new Cake apps default to using, rather than the standard PHP DateTime class. This change follows CakePHP conventions and returns the FrozenTime class.

If you want to make it safer, you can first check for the existence of the Configure class:

 ```
                   $datetime = $generator->datetime();
                    if (class_exists('\Cake\Core\Configure') && floatval(\Cake\Core\Configure::version() >= 3.3)) {
                        return new \Cake\I18n\FrozenTime($datetime->format('Y-m-d H:i:s'));
                    }
                    return $datetime;
```