### PR TITLE
Restore a random seed when the Generator is destroyed

### DIFF
--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -278,4 +278,9 @@ class Generator
     {
         return $this->format($method, $attributes);
     }
+
+    public function __destruct()
+    {
+        $this->seed();
+    }
 }


### PR DESCRIPTION
Without this patch, the `mt_rand` seed could stay at the very same
value, and so break all other usages to `mt_rand`.

---

Oh, We had really hard time to find this bug :)
We are using Faker in our test suite, and we get a really strange
behavior : some entity were generated with the exact same UUID.
ATM, our implement of UUID generation is based on `mt_rand`.
Anyway, we found that Faker modifies the seed and let it to the same
value. So with this patch, we restore the seed to a random value.
And eveything goes fine now.