### PR TITLE
Drop support for legacy PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,6 @@ language: php
 dist: precise
 
 php:
-    - 5.3
-    - 5.4
-    - 5.5
-    - 5.6
-    - 7.0
     - 7.1
     - 7.2
     - nightly

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^5.3.3 || ^7.0"
+        "php": "^7.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.35 || ^5.7",

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ Faker is a PHP library that generates fake data for you. Whether you need to boo
 
 Faker is heavily inspired by Perl's [Data::Faker](http://search.cpan.org/~jasonk/Data-Faker-0.07/), and by ruby's [Faker](https://rubygems.org/gems/faker).
 
-Faker requires PHP >= 5.3.3.
+Faker requires PHP >= 7.1.
 
 [![Monthly Downloads](https://poser.pugx.org/fzaninotto/faker/d/monthly.png)](https://packagist.org/packages/fzaninotto/faker) [![Build Status](https://travis-ci.org/fzaninotto/Faker.svg?branch=master)](https://travis-ci.org/fzaninotto/Faker) [![SensioLabsInsight](https://insight.sensiolabs.com/projects/eceb78a9-38d4-4ad5-8b6b-b52f323e3549/mini.png)](https://insight.sensiolabs.com/projects/eceb78a9-38d4-4ad5-8b6b-b52f323e3549)
 


### PR DESCRIPTION
Hello,

when worked on a new PR trying to implement new generator, I stumbled upon failing builds on legacy PHP versions.

We should drop support for legacy PHP versions in new major release.

secure.php.net/supported-versions.php

By the end of 2018 security support for 5.6 and 7.0 ends. 5.5 and lower are not worth mentioning.

Let's move on. PHP 7.3 will be out soon, PHP 8 is already being [actively discussed](https://twitter.com/nikolaposa/status/1018966511388647429).
