### PR TITLE
UUID 4 Generator

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -275,6 +275,7 @@ Methods accepting a `$timezone` argument default to `date_default_timezone_get()
 ### `Faker\Provider\Uuid`
 
     uuid                   // '7e57d004-2b97-0e7a-b45f-5387367791cd'
+    uuid4                  // '084664e0-6073-43a2-90b9-e61806f8fb0a'
 
 ### `Faker\Provider\Barcode`
 

--- a/src/Faker/Provider/Uuid.php
+++ b/src/Faker/Provider/Uuid.php
@@ -54,4 +54,13 @@ class Uuid extends Base
 
         return $uuid;
     }
+
+    public static function uuid4()
+    {
+        $data = openssl_random_pseudo_bytes(16);
+        $data[6] = chr(ord($data[6]) & 0x0f | 0x40); // set version to 0100
+        $data[8] = chr(ord($data[8]) & 0x3f | 0x80); // set bits 6-7 to 10
+
+        return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($data), 4));
+    }
 }

--- a/test/Faker/Provider/UuidTest.php
+++ b/test/Faker/Provider/UuidTest.php
@@ -12,6 +12,9 @@ class UuidTest extends TestCase
     {
         $uuid = BaseProvider::uuid();
         $this->assertTrue($this->isUuid($uuid));
+
+        $uuid = BaseProvider::uuid4();
+        $this->assertTrue($this->isUuid($uuid));
     }
 
     public function testUuidExpectedSeed()


### PR DESCRIPTION
Adds generator for UUID v4 as the current `uuid()` function generates v3 that is not so widely used nowadays.

Based on https://github.com/fzaninotto/Faker/pull/1535, solves https://github.com/fzaninotto/Faker/issues/1352