### PR TITLE
Replace LoremPixel with Unsplash

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -261,16 +261,13 @@ Methods accepting a `$timezone` argument default to `date_default_timezone_get()
 
 ### `Faker\Provider\Image`
 
-    // Image generation provided by LoremPixel (http://lorempixel.com/)
-    imageUrl($width = 640, $height = 480) // 'http://lorempixel.com/640/480/'
-    imageUrl($width, $height, 'cats')     // 'http://lorempixel.com/800/600/cats/'
-    imageUrl($width, $height, 'cats', true, 'Faker') // 'http://lorempixel.com/800/400/cats/Faker'
-    imageUrl($width, $height, 'cats', true, 'Faker', true) // 'http://lorempixel.com/grey/800/400/cats/Faker/' Monochrome image
+    // Image generation provided by Unsplash (https://source.unsplash.com/)
+    imageUrl($width = 640, $height = 480) // 'https://source.unsplash.co towerm/640x480/'
+    imageUrl($width, $height, 'nature')     // 'https://source.unsplash.com/640x480/?nature'
+    imageUrl($width, $height, 'nature,water')     // 'https://source.unsplash.com/640x480/?nature,water'
     image($dir = '/tmp', $width = 640, $height = 480) // '/tmp/13b73edae8443990be1aa8f1a483bc27.jpg'
     image($dir, $width, $height, 'cats')  // 'tmp/13b73edae8443990be1aa8f1a483bc27.jpg' it's a cat!
     image($dir, $width, $height, 'cats', false) // '13b73edae8443990be1aa8f1a483bc27.jpg' it's a filename without path
-    image($dir, $width, $height, 'cats', true, false) // it's a no randomize images (default: `true`)
-    image($dir, $width, $height, 'cats', true, true, 'Faker') // 'tmp/13b73edae8443990be1aa8f1a483bc27.jpg' it's a cat with 'Faker' text. Default, `null`.
 
 ### `Faker\Provider\Uuid`
 

--- a/test/Faker/Provider/ImageTest.php
+++ b/test/Faker/Provider/ImageTest.php
@@ -9,44 +9,28 @@ class ImageTest extends TestCase
 {
     public function testImageUrlUses640x680AsTheDefaultSize()
     {
-        $this->assertRegExp('#^https://lorempixel.com/640/480/#', Image::imageUrl());
+        $this->assertEquals('https://source.unsplash.com/640x480/', Image::imageUrl());
     }
 
     public function testImageUrlAcceptsCustomWidthAndHeight()
     {
-        $this->assertRegExp('#^https://lorempixel.com/800/400/#', Image::imageUrl(800, 400));
+        $this->assertEquals('https://source.unsplash.com/800x400/', Image::imageUrl(800, 400));
     }
 
-    public function testImageUrlAcceptsCustomCategory()
+    public function testImageUrlAcceptsKeyword()
     {
-        $this->assertRegExp('#^https://lorempixel.com/800/400/nature/#', Image::imageUrl(800, 400, 'nature'));
+        $this->assertEquals('https://source.unsplash.com/800x400/?nature', Image::imageUrl(800, 400, 'nature'));
     }
 
-    public function testImageUrlAcceptsCustomText()
-    {
-        $this->assertRegExp('#^https://lorempixel.com/800/400/nature/Faker#', Image::imageUrl(800, 400, 'nature', false, 'Faker'));
-    }
 
-    public function testImageUrlAddsARandomGetParameterByDefault()
+    public function testImageUrlAcceptsMultipleKeywords()
     {
-        $url = Image::imageUrl(800, 400);
-        $splitUrl = preg_split('/\?/', $url);
-
-        $this->assertEquals(count($splitUrl), 2);
-        $this->assertRegexp('#\d{5}#', $splitUrl[1]);
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testUrlWithDimensionsAndBadCategory()
-    {
-        Image::imageUrl(800, 400, 'bullhonky');
+        $this->assertEquals('https://source.unsplash.com/800x400/?nature,water', Image::imageUrl(800, 400, 'nature,water'));
     }
 
     public function testDownloadWithDefaults()
     {
-        $url = "http://lorempixel.com/";
+        $url = "https://source.unsplash.com/";
         $curlPing = curl_init($url);
         curl_setopt($curlPing, CURLOPT_TIMEOUT, 5);
         curl_setopt($curlPing, CURLOPT_CONNECTTIMEOUT, 5);
@@ -56,10 +40,11 @@ class ImageTest extends TestCase
         curl_close($curlPing);
 
         if ($httpCode < 200 | $httpCode > 300) {
-            $this->markTestSkipped("LoremPixel is offline, skipping image download");
+            $this->markTestSkipped("Unsplash is offline, skipping image download");
         }
 
         $file = Image::image(sys_get_temp_dir());
+
         $this->assertFileExists($file);
         if (function_exists('getimagesize')) {
             list($width, $height, $type, $attr) = getimagesize($file);


### PR DESCRIPTION
LoremPixel is down once again, so I thought I'd try to replace it with Unsplash Source.

This would however add breaking changes:
- No categories (instead they use search keywords)
- No grayscale
- No text overlay
- Images are always random

Therefore the method signature would change from

```php
public static function imageUrl($width = 640, $height = 480, $category = null, $randomize = true, $word = null, $gray = false)
```

to

```php
public static function imageUrl($width = 640, $height = 480, $keywords = null)
```
For the `image` method accordingly.

---

You mentioned you would rather drop image support all together, however, for me and probably many other developers, image generation is a valuable part of the package.

Please let me know if you're not interested or if there's something horribly wrong with the PR (it's my first PR, so I'd be glad for feedback!).