### PR TITLE
[en_US] CompanyTest: Fix EIN regex to disallow empty prefix

### DIFF
--- a/test/Faker/Provider/en_US/CompanyTest.php
+++ b/test/Faker/Provider/en_US/CompanyTest.php
@@ -2,10 +2,11 @@
 
 namespace Faker\Test\Provider\en_US;
 
-use Faker\Provider\en_US\Company;
 use Faker\Generator;
+use Faker\Provider\en_US\Company;
+use PHPUnit\Framework\TestCase;
 
-class CompanyTest extends \PHPUnit_Framework_TestCase
+class CompanyTest extends TestCase
 {
 
     /**
@@ -28,6 +29,6 @@ class CompanyTest extends \PHPUnit_Framework_TestCase
         $number = $this->faker->ein;
 
         // should be in the format ##-#######, with a valid prefix
-        $this->assertRegExp('/^(0[1-6]||1[0-6]|2[0-7]|[35]\d|[468][0-8]|7[1-7]|9[0-58-9])-\d{7}$/', $number);
+        $this->assertRegExp('/^(0[1-6]|1[0-6]|2[0-7]|[35]\d|[468][0-8]|7[1-7]|9[0-589])-\d{7}$/', $number);
     }
 }


### PR DESCRIPTION
### [en_US] CompanyTest.php
1. Fix the regular expression that contained two consequent pipes which allowed for the EIN prefix to be empty ("-1234567" would be a valid EIN according to this test).
2. Remove an unneeded hyphen for the last character class (there are no digits between 8 and 9).
3. Use PSR-1 for PHPUnit TestCase.