### PR TITLE
Make $suffix protected not private

### DIFF
--- a/src/Faker/Provider/nl_NL/Person.php
+++ b/src/Faker/Provider/nl_NL/Person.php
@@ -26,7 +26,7 @@ class Person extends \Faker\Provider\Person
         'mr.', 'dr.', 'ir.', 'drs', 'bacc.', 'kand.', 'dr.h.c.', 'prof.', 'ds.', 'ing.', 'bc.'
     );
 
-    private static $suffix = array(
+    protected static $suffix = array(
         'BA', 'Bsc', 'LLB', 'LLM', 'MA', 'Msc', 'MPhil', 'D', 'PhD', 'AD', 'B', 'M'
     );
 


### PR DESCRIPTION
When extending \Faker\Provider\nl_NL\Person $suffix cannot be used because it is private. Small fix to make it protected like the other properties.