### PR TITLE
Add fr_BE national number generator

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1074,6 +1074,15 @@ echo $faker->vat;           // "BE 0123456789" - Belgian Value Added Tax number
 echo $faker->vat(false);    // "BE0123456789" - unspaced Belgian Value Added Tax number
 ```
 
+### `Faker\Provider\fr_BE\Person`
+
+```php
+<?php
+
+echo $faker->nn();         // "83051711784" - Belgian National Number
+echo $faker->nn('female'); // "50032089858" - Belgian National Number for a female
+```
+
 ### `Faker\Provider\es_VE\Person`
 
 ```php

--- a/src/Faker/Provider/fr_BE/Person.php
+++ b/src/Faker/Provider/fr_BE/Person.php
@@ -46,4 +46,22 @@ class Person extends \Faker\Provider\Person
     protected static $titleMale = array('M.', 'Dr.', 'Pr.', 'Me.', 'Mgr');
 
     protected static $titleFemale = array('Mme.', 'Mlle', 'Dr.', 'Pr.', 'Me.');
+
+    /**
+     * In Belgium, the ‘numéro de registre national’ (abbreviated “N.N.”)
+     * is a number which is used to uniquely identify each citizen and/or
+     * owner of an ID card.
+     *
+     * Since this has already been implemented in the nl_BE provider, this
+     * method simply “proxies” the call to it to avoid code duplication.
+     *
+     * @link https://fr.wikipedia.org/wiki/Num%C3%A9ro_de_registre_national Wikipedia page in French
+     *
+     * @param string|null $gender 'male', 'female' or null for any
+     * @return string
+     */
+    public static function nn($gender = null)
+    {
+        return \Faker\Provider\nl_BE\Person::rrn($gender);
+    }
 }


### PR DESCRIPTION
This feature has actually already been implemented in the `nl_BE/Person` provider by @ppelgrims in PR #1361.

Since the output required for an `fr_BE/Person` provider would be exactly the same (as the Belgian database of national numbers does not care about languages), to avoid duplicating code, the method added by this PR simply “proxies” the call to the original implementation in the `nl_BE` provider.
This seemed like the most logical thing to do. Please tell me if, for any reason, code duplication would be preferable.

This PR also adds the provider in the *[Language specific formatters](https://github.com/fzaninotto/Faker#language-specific-formatters)* section of the README.