### PR TITLE
Return an it_IT mobile phone number

### DIFF
--- a/src/Faker/Provider/it_IT/PhoneNumber.php
+++ b/src/Faker/Provider/it_IT/PhoneNumber.php
@@ -18,4 +18,14 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
         '3## ### ###',
         '+39 3## ### ###'
     );
+    protected static $mobileFormats = array('3#########');
+    
+     /**
+     * Return an it_IT mobile phone number
+     * @return string
+     */
+    public static function mobileNumber()
+    {
+        return static::numerify(static::randomElement(static::$mobileFormats));
+    }
 }


### PR DESCRIPTION
Extending provider it_IT to generate a mobile phone number (only starting with 3 and 10 digits) almost as in en_HK