### PR TITLE
Correct documentation

### DIFF
--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -173,7 +173,7 @@ class Base
     /**
      * Returns randomly ordered subsequence of $count elements from a provided array
      *
-     * @param  array            $array           Array to take elements from. Defaults to a-f
+     * @param  array            $array           Array to take elements from. Defaults to a-c
      * @param  integer          $count           Number of elements to take.
      * @param  boolean          $allowDuplicates Allow elements to be picked several times. Defaults to false
      * @throws \LengthException When requesting more elements than provided


### PR DESCRIPTION
Documentation says a-f, but code says a-c. Correcting documentation.

Fixes #1570