### PR TITLE
Prevent Transliterator class autoloading

### DIFF
--- a/src/Faker/Provider/Internet.php
+++ b/src/Faker/Provider/Internet.php
@@ -233,7 +233,7 @@ class Internet extends Base
         }
 
         $transId = 'Any-Latin; Latin-ASCII; NFD; [:Nonspacing Mark:] Remove; NFC;';
-        if (class_exists('Transliterator') && $transliterator = \Transliterator::create($transId)) {
+        if (class_exists('Transliterator', false) && $transliterator = \Transliterator::create($transId)) {
             $transString = $transliterator->transliterate($string);
         } else {
             $transString = static::toAscii($string);


### PR DESCRIPTION
Autoloading breaks in Yii 1 applications when checking if the `Transliterator` class exist.

I disabled autoloading in the call to `class_exists`