### PR TITLE
Add textMinLength

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -128,6 +128,7 @@ Each of the generator properties (like `name`, `address`, and `lorem`) are calle
     paragraph($nbSentences = 3, $variableNbSentences = true) // 'Ut ab voluptas sed a nam. Sint autem inventore aut officia aut aut blanditiis. Ducimus eos odit amet et est ut eum.'
     paragraphs($nb = 3, $asText = false)             // array('Quidem ut sunt et quidem est accusamus aut. Fuga est placeat rerum ut. Enim ex eveniet facere sunt.', 'Aut nam et eum architecto fugit repellendus illo. Qui ex esse veritatis.', 'Possimus omnis aut incidunt sunt. Asperiores incidunt iure sequi cum culpa rem. Rerum exercitationem est rem.')
     text($maxNbChars = 200)                          // 'Fuga totam reiciendis qui architecto fugiat nemo. Consequatur recusandae qui cupiditate eos quod.'
+    textMinLength($minNbChars)                       // 'Sed mollitia nulla est qui qui tempora sit. Dolorum necessitatibus accusamus rem nam quibusdam beatae.'
 
 ### `Faker\Provider\en_US\Person`
 

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -62,6 +62,7 @@ namespace Faker;
  * @method string|array paragraphs($nb = 3, $asText = false)
  * @property string $text
  * @method string text($maxNbChars = 200)
+ * @method string textMinLength($minNbChars)
  *
  * @method string realText($maxNbChars = 200, $indexSize = 2)
  *

--- a/src/Faker/Provider/Lorem.php
+++ b/src/Faker/Provider/Lorem.php
@@ -196,6 +196,41 @@ class Lorem extends Base
         return implode($text, '');
     }
 
+    /**
+     * Generate a text string with a minimum length.
+     * Depending on the $minNbChars, returns a string made of words, sentences, or paragraphs.
+     *
+     * @example 'Sapiente sunt omnis. Ut pariatur ad autem ducimus et. Voluptas rem voluptas sint modi dolorem amet.'
+     *
+     * @param  integer $minNbChars Minimum number of characters the text should contain (minimum 5)
+     *
+     * @return string
+     */
+    public static function textMinLength($minNbChars)
+    {
+        $type = ($minNbChars < 25) ? 'word' : (($minNbChars < 100) ? 'sentence' : 'paragraph');
+
+        $text = array();
+        $size = 0;
+
+        while ($size < $minNbChars) {
+            $word   = ($size ? ' ' : '') . static::$type();
+            $text[] = $word;
+
+            $size += strlen($word);
+        }
+
+        if ($type === 'word') {
+            // capitalize first letter
+            $text[0] = ucfirst($text[0]);
+
+            // end sentence with full stop
+            $text[count($text) - 1] .= '.';
+        }
+
+        return implode($text, '');
+    }
+
     protected static function randomizeNbElements($nbElements)
     {
         return (int) ($nbElements * mt_rand(60, 140) / 100) + 1;

--- a/test/Faker/Provider/LoremTest.php
+++ b/test/Faker/Provider/LoremTest.php
@@ -87,6 +87,36 @@ class LoremTest extends TestCase
         $expected = "This is a test paragraph. It has three sentences. Exactly three.\n\nThis is a test paragraph. It has three sentences. Exactly three.";
         $this->assertEquals($expected, $paragraphs);
     }
+
+    public function testTextMinLengthReturnsParagraphsWhenAskedSizeGreaterThanOrEqualTo100()
+    {
+        $text = TestableLorem::textMinLength(100);
+        $paragraph = 'This is a test paragraph. It has three sentences. Exactly three.';
+        $this->assertEquals($paragraph.' '.$paragraph, $text);
+    }
+
+    public function testTextMinLengthReturnsSentencesWhenAskedSizeLessThan100AndGreaterThanOrEqualTo25()
+    {
+        $text = TestableLorem::textMinLength(99);
+        $sentence = 'This is a test sentence.';
+        $expected = $sentence.' '.$sentence.' '.$sentence.' '.$sentence;
+        $this->assertEquals($expected, $text);
+    }
+
+    public function testTextMinLengthReturnsWordsWhenAskedSizeLessThan25()
+    {
+        $text = TestableLorem::textMinLength(24);
+        $this->assertEquals('Word word word word word.', $text);
+    }
+
+    public function testTextMinLengthReturnsStringsLongerOrEqualToThanAskedSize()
+    {
+        $sizes = range(1,101,25);
+        foreach($sizes AS $size){
+            $text = TestableLorem::textMinLength($size);
+            $this->assertGreaterThanOrEqual($size, strlen($text));
+        }
+    }
 }
 
 class TestableLorem extends Lorem


### PR DESCRIPTION
This PR adds a new text generator which generates words sentences or paragraphs with a minimum length. This is useful for testing your application's validation and error handling on fields where you've set a maximum length - now you can easily generate a string which is too long and will fail the validation. 