### PR TITLE
Fix failing test because of hardcoded datetime

### DIFF
--- a/test/Faker/Provider/DateTimeTest.php
+++ b/test/Faker/Provider/DateTimeTest.php
@@ -236,7 +236,7 @@ class DateTimeTest extends TestCase
 
     public function testFixedSeedWithMaximumTimestamp()
     {
-        $max = date('Y-m-d H:i:s');
+        $max = date(DATE_W3C);
 
         mt_srand(1);
         $unixTime = DateTimeProvider::unixTime($max);


### PR DESCRIPTION
`DateTimeProvider::dateTimeThisMonth()` is working with -1 month as starting date. In the test the `$max` date was much older than that, and this is resulted in an error!