### PR TITLE
Exclude files and folder from release archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+/.gitignore export-ignore
+/.gitattributes export-ignore
+/.travis.yml export-ignore
+/CHANGELOG.md export-ignore
+/CONTRIBUTING.md export-ignore
+/phpunit.xml.dist export-ignore
+/Makefile export-ignore
+/test export-ignore
+/.github export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,6 @@
 /.gitignore export-ignore
 /.gitattributes export-ignore
 /.travis.yml export-ignore
-/CHANGELOG.md export-ignore
 /CONTRIBUTING.md export-ignore
 /phpunit.xml.dist export-ignore
 /Makefile export-ignore


### PR DESCRIPTION
Hi,

Let's not publish all those file.
`.gitattributes` can be used to exclude files from final archive that is downloaded by composer.

We can test it locally by creating the `.gitattributes` files and running
git archive --format zip -o export.zip master command.

Read more
- https://madewithlove.be/gitattributes/
- https://alexbilbie.com/2012/11/exclude-objects-with-gitattributes/
- http://www.pixelite.co.nz/article/using-git-attributes-exclude-files-your-release/
