### PR TITLE
Add imageLocal method to Image provider

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -271,6 +271,8 @@ Methods accepting a `$timezone` argument default to `date_default_timezone_get()
     image($dir, $width, $height, 'cats', false) // '13b73edae8443990be1aa8f1a483bc27.jpg' it's a filename without path
     image($dir, $width, $height, 'cats', true, false) // it's a no randomize images (default: `true`)
     image($dir, $width, $height, 'cats', true, true, 'Faker') // 'tmp/13b73edae8443990be1aa8f1a483bc27.jpg' it's a cat with 'Faker' text. Default, `null`.
+    imageLocal($dir, $width, $height) // '13b73edae8443990be1aa8f1a483bc27.jpg' it's a filename without path
+    imageLocal($dir, $width, $height, false) // '13b73edae8443990be1aa8f1a483bc27.jpg' it's a filename without path
 
 ### `Faker\Provider\Uuid`
 

--- a/src/Faker/Provider/Image.php
+++ b/src/Faker/Provider/Image.php
@@ -72,7 +72,7 @@ class Image extends Base
         // Generate a random filename. Use the server address so that a file
         // generated at the same time on a different server won't have a collision.
         $name = md5(uniqid(empty($_SERVER['SERVER_ADDR']) ? '' : $_SERVER['SERVER_ADDR'], true));
-        $filename = $name .'.jpg';
+        $filename = $name . '.jpg';
         $filepath = $dir . DIRECTORY_SEPARATOR . $filename;
 
         $url = static::imageUrl($width, $height, $category, $randomize, $word);
@@ -100,6 +100,36 @@ class Image extends Base
             return new \RuntimeException('The image formatter downloads an image from a remote HTTP server. Therefore, it requires that PHP can request remote hosts, either via cURL or fopen()');
         }
 
+        return $fullPath ? $filepath : $filename;
+    }
+
+    /**
+     * Generate an image with a random solid color, save it to disk, and return its location
+     *
+     * @example '/path/to/dir/13b73edae8443990be1aa8f1a483bc27.jpg'
+     */
+    public static function imageLocal($dir = null, $width = 640, $height = 480, $fullPath = true)
+    {
+        $dir = is_null($dir) ? sys_get_temp_dir() : $dir; // GNU/Linux / OS X / Windows compatible
+        // Validate directory path
+        if (!is_dir($dir) || !is_writable($dir)) {
+            throw new \InvalidArgumentException(sprintf('Cannot write to directory "%s"', $dir));
+        }
+
+        // Generate a random filename. Use the server address so that a file
+        // generated at the same time on a different server won't have a collision.
+        $name = md5(uniqid(empty($_SERVER['SERVER_ADDR']) ? '' : $_SERVER['SERVER_ADDR'], true));
+        $filename = $name . '.jpg';
+        $filepath = $dir . DIRECTORY_SEPARATOR . $filename;
+
+        $image = imagecreatetruecolor($width, $height);
+        $fill = imagecolorallocate($image, mt_rand(0, 255), mt_rand(0, 255), mt_rand(0, 255));
+        imagefill($image, 0, 0, $fill);
+ 
+        if (!imagejpeg($image, $filepath)) {
+            return new \RuntimeException('The generated image could not be saved.');
+        }
+    
         return $fullPath ? $filepath : $filename;
     }
 }

--- a/test/Faker/Provider/ImageTest.php
+++ b/test/Faker/Provider/ImageTest.php
@@ -73,4 +73,22 @@ class ImageTest extends TestCase
             unlink($file);
         }
     }
+
+    public function testImageLocalCanGenerateAndSaveWithDefaults()
+    {
+        $file = Image::imageLocal();
+        $this->assertFileExists($file);
+
+        if (function_exists('getimagesize')) {
+            list($width, $height, $type, $attr) = getimagesize($file);
+            $this->assertEquals(640, $width);
+            $this->assertEquals(480, $height);
+            $this->assertEquals(constant('IMAGETYPE_JPEG'), $type);
+        } else {
+            $this->assertEquals('jpg', pathinfo($file, PATHINFO_EXTENSION));
+        }
+        if (file_exists($file)) {
+            unlink($file);
+        }
+    }
 }


### PR DESCRIPTION
## Overview

This PR adds a new method to the Image provider called `imageLocal()`.

The idea behind this method is to avoid an HTTP request for an image if any image file will do. It generates an image of a solid, random color of the given `$width` and `$height`. 

Please let me know if there are any questions or issues. Thanks!