### PR TITLE
Fix "Resource temporarily unavailable" when cURL fails due to SSL verification

### DIFF
--- a/src/Faker/Provider/Image.php
+++ b/src/Faker/Provider/Image.php
@@ -84,15 +84,16 @@ class Image extends Base
             $ch = curl_init($url);
             curl_setopt($ch, CURLOPT_FILE, $fp);
             $success = curl_exec($ch) && curl_getinfo($ch, CURLINFO_HTTP_CODE) === 200;
-            if ($success) {
-                fclose($fp);
-            } elseif(file_exists($filepath)) {
-                @unlink($filepath); // although the file may exists, it may be "Temporary unvailable" because cURL failed for some reason
+            
+            if(!$success || file_exists($filepath)) {
+                @unlink($filepath); // although the file may exists, it may be "Temporary unvailable" because cURL failed for some reason.
             }
+            
+            fclose($fp);
             curl_close($ch);
         }
         
-        //If cURL fails for some reason, try to get the image via allow_url_fopen method
+        // When cURL fails for some reason, try to get the image via allow_url_fopen method.
         if (!$success && ini_get('allow_url_fopen')) {
             // use remote fopen() via copy()
             $success = copy($url, $filepath);

--- a/src/Faker/Provider/Image.php
+++ b/src/Faker/Provider/Image.php
@@ -68,38 +68,37 @@ class Image extends Base
         if (!is_dir($dir) || !is_writable($dir)) {
             throw new \InvalidArgumentException(sprintf('Cannot write to directory "%s"', $dir));
         }
-
         // Generate a random filename. Use the server address so that a file
         // generated at the same time on a different server won't have a collision.
         $name = md5(uniqid(empty($_SERVER['SERVER_ADDR']) ? '' : $_SERVER['SERVER_ADDR'], true));
         $filename = $name .'.jpg';
         $filepath = $dir . DIRECTORY_SEPARATOR . $filename;
-
         $url = static::imageUrl($width, $height, $category, $randomize, $word);
-
+        
         // save file
+        $success = false;
+        
         if (function_exists('curl_exec')) {
             // use cURL
             $fp = fopen($filepath, 'w');
             $ch = curl_init($url);
             curl_setopt($ch, CURLOPT_FILE, $fp);
             $success = curl_exec($ch) && curl_getinfo($ch, CURLINFO_HTTP_CODE) === 200;
-            fclose($fp);
-            curl_close($ch);
-
-            if (!$success) {
-                unlink($filepath);
-
-                // could not contact the distant URL or HTTP error - fail silently.
-                return false;
+            if ($success) {
+                fclose($fp);
+            } elseif(file_exists($filepath)) {
+                @unlink($filepath); // although the file may exists, it may be "Temporary unvailable" because cURL failed for some reason
             }
-        } elseif (ini_get('allow_url_fopen')) {
+            curl_close($ch);
+        }
+        
+        //If cURL fails for some reason, try to get the image via allow_url_fopen method
+        if (!$success && ini_get('allow_url_fopen')) {
             // use remote fopen() via copy()
             $success = copy($url, $filepath);
         } else {
             return new \RuntimeException('The image formatter downloads an image from a remote HTTP server. Therefore, it requires that PHP can request remote hosts, either via cURL or fopen()');
         }
-
         return $fullPath ? $filepath : $filename;
     }
 }


### PR DESCRIPTION
This PR fixes a bug that shows "Resource temporarily unavailable" when cURL fails due to SSL verification.

The past PR has been closed due to previous issues where my build was failing to pass because of another bug, which was later fixed on a separate commit.