### PR TITLE
Minor typo fix

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1706,4 +1706,4 @@ echo $faker->VAT; //23456789
 
 ## License
 
-Faker is released under the MIT Licence. See the bundled LICENSE file for details.
+Faker is released under the MIT License. See the bundled LICENSE file for details.


### PR DESCRIPTION
The word **Licence** is written in french. It should be written in english to keep consistency with the other occurrences of the word in this document.