### PR TITLE
Implemented numbersThatEquatesTo() method

### DIFF
--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -139,6 +139,25 @@ class Base
         $max = $int1 < $int2 ? $int2 : $int1;
         return mt_rand($min, $max);
     }
+
+    /**
+     * Returns an array of numbers that equates to $value
+     * 
+     * @param  integer $value   The number that should be equated to.
+     * @param  array  $numbers  An array of numbers defaulting to 0
+     * @return array
+     */
+    public static function numbersThatEquatesTo($value, $numbers = [])
+    {
+        if (array_sum($numbers) < $value) {
+            $sum = $value - array_sum($numbers);
+            array_push($numbers, self::numberBetween(1, $sum));
+
+            return self::numbersThatEquatesTo($value, $numbers);
+        } else {
+            return $numbers;
+        }
+    }
     
     /**
      * Returns the passed value


### PR DESCRIPTION
I was in need of a method like this, so I made one for Faker as well.

# Usage
You call the method with the value you want the numbers to equate to and it will return an array of numbers that equates to that value.

`$faker->numbersThatEquatesTo(100)`

a couple return examples:

```
array:6 [
  0 => 6
  1 => 80
  2 => 5
  3 => 7
  4 => 1
  5 => 1
]
```

```
array:6 [
  0 => 72
  1 => 20
  2 => 4
  3 => 2
  4 => 1
  5 => 1
]
```

```
array:3 [
  0 => 78
  1 => 20
  2 => 2
]
```

If you already have a set of numbers that you want to be included, then you may pass them as the second argument in an array.

`$faker->numbersThatEquatesTo(100, [0, 2, 4])`

return examples with second parameter:

```
array:7 [
  0 => 0
  1 => 2
  2 => 4
  3 => 69
  4 => 15
  5 => 9
  6 => 1
]
```

```
array:10 [
  0 => 0
  1 => 2
  2 => 4
  3 => 36
  4 => 37
  5 => 6
  6 => 5
  7 => 7
  8 => 2
  9 => 1
]
```

```
array:9 [
  0 => 0
  1 => 2
  2 => 4
  3 => 8
  4 => 55
  5 => 18
  6 => 4
  7 => 8
  8 => 1
]
```