### PR TITLE
Bug Fix en_SG mobile number generation

### DIFF
--- a/src/Faker/Provider/en_SG/PhoneNumber.php
+++ b/src/Faker/Provider/en_SG/PhoneNumber.php
@@ -100,8 +100,8 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
         return static::randomElement(static::$zeroToEight);
     }
 
-    public function oneToNine()
+    public function oneToEight()
     {
-        return static::randomElement(static::$oneToNine);
+        return static::randomElement(static::$oneToEight);
     }
 }

--- a/src/Faker/Provider/en_SG/PhoneNumber.php
+++ b/src/Faker/Provider/en_SG/PhoneNumber.php
@@ -11,18 +11,15 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
 
     protected static $zeroToEight = array(0, 1, 2, 3, 4, 5, 6, 7, 8);
 
-    protected static $oneToNine = array(1, 2, 3, 4, 5, 6, 7, 8, 9);
+    protected static $oneToEight = array(1, 2, 3, 4, 5, 6, 7, 8);
 
     protected static $mobileNumberFormats = array(
         '{{internationalCodePrefix}}9{{zeroToEight}}## ####',
         '{{internationalCodePrefix}} 9{{zeroToEight}}## ####',
         '9{{zeroToEight}}## ####',
-        '{{internationalCodePrefix}}8{{oneToNine}}## ####',
-        '{{internationalCodePrefix}} 8{{oneToNine}}## ####',
-        '8{{oneToNine}}## ####',
-        '{{internationalCodePrefix}}7{{oneToNine}}## ####',
-        '{{internationalCodePrefix}} 7{{oneToNine}}## ####',
-        '7{{oneToNine}}## ####',
+        '{{internationalCodePrefix}}8{{oneToEight}}## ####',
+        '{{internationalCodePrefix}} 8{{oneToEight}}## ####',
+        '8{{oneToEight}}## ####',
     );
 
     protected static $fixedLineNumberFormats = array(

--- a/test/Faker/Provider/en_SG/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_SG/PhoneNumberTest.php
@@ -28,7 +28,7 @@ class PhoneNumberTest extends TestCase
             $startsWith9 = preg_match('/^(\+65|65)?\s*9/', $mobileNumber);
         }
 
-        $this->assertRegExp('/^(\+65|65)?\s*9\s*[0-8]{3}\s*\d{4}$/', $mobileNumber);
+        $this->assertRegExp('/^(\+65|65)?\s*9\s*[0-8]\s*\d{6}$/', $mobileNumber);
     }
 
     // http://en.wikipedia.org/wiki/Telephone_numbers_in_Singapore#Numbering_plan
@@ -41,6 +41,6 @@ class PhoneNumberTest extends TestCase
             $mobileNumber = $this->faker->mobileNumber();
             $startsWith8 = preg_match('/^(\+65|65)?\s*8/', $mobileNumber);
         }
-        $this->assertRegExp('/^(\+65|65)?\s*8\s*[1-8]{3}\s*\d{4}$/', $mobileNumber);
+        $this->assertRegExp('/^(\+65|65)?\s*8\s*[1-8]\s*\d{6}$/', $mobileNumber);
     }
 }

--- a/test/Faker/Provider/en_SG/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_SG/PhoneNumberTest.php
@@ -28,7 +28,7 @@ class PhoneNumberTest extends TestCase
             $startsWith9 = preg_match('/^(\+65|65)?\s*9/', $mobileNumber);
         }
 
-        $this->assertRegExp('/^(\+65|65)?\s*9\s*[0-8]\s*\d{6}$/', $mobileNumber);
+        $this->assertRegExp('/^(\+65|65)?\s*9\s*[0-8]\d{2}\s*\d{4}$/', $mobileNumber);
     }
 
     // http://en.wikipedia.org/wiki/Telephone_numbers_in_Singapore#Numbering_plan
@@ -41,6 +41,6 @@ class PhoneNumberTest extends TestCase
             $mobileNumber = $this->faker->mobileNumber();
             $startsWith8 = preg_match('/^(\+65|65)?\s*8/', $mobileNumber);
         }
-        $this->assertRegExp('/^(\+65|65)?\s*8\s*[1-8]\s*\d{6}$/', $mobileNumber);
+        $this->assertRegExp('/^(\+65|65)?\s*8\s*[1-8]\d{2}\s*\d{4}$/', $mobileNumber);
     }
 }

--- a/test/Faker/Provider/en_SG/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_SG/PhoneNumberTest.php
@@ -18,8 +18,8 @@ class PhoneNumberTest extends TestCase
     }
 
     // http://en.wikipedia.org/wiki/Telephone_numbers_in_Singapore#Numbering_plan
-    // y means 0 to 8 only
     // x means 0 to 9
+    // y means 0 to 8 only
     public function testMobilePhoneNumberStartWith9Returns9yxxxxxx()
     {
         $startsWith9 = false;
@@ -32,15 +32,15 @@ class PhoneNumberTest extends TestCase
     }
 
     // http://en.wikipedia.org/wiki/Telephone_numbers_in_Singapore#Numbering_plan
-    // z means 1 to 9 only
     // x means 0 to 9
-    public function testMobilePhoneNumberStartWith7Or8Returns7Or8zxxxxxx()
+    // z means 1 to 8 only
+    public function testMobilePhoneNumberStartWith8Returns8zxxxxxx()
     {
-        $startsWith7Or8 = false;
-        while (!$startsWith7Or8) {
+        $startsWith8 = false;
+        while (!$startsWith8) {
             $mobileNumber = $this->faker->mobileNumber();
-            $startsWith7Or8 = preg_match('/^(\+65|65)?\s*[7-8]/', $mobileNumber);
+            $startsWith8 = preg_match('/^(\+65|65)?\s*8/', $mobileNumber);
         }
-        $this->assertRegExp('/^(\+65|65)?\s*[7-8]\s*[1-9]{3}\s*\d{4}$/', $mobileNumber);
+        $this->assertRegExp('/^(\+65|65)?\s*8\s*[1-8]{3}\s*\d{4}$/', $mobileNumber);
     }
 }


### PR DESCRIPTION
Singapore mobile number only starts with 8 or 9. Not 7. The 2nd digit is never a 9 as well

See: http://en.wikipedia.org/wiki/Telephone_numbers_in_Singapore#Numbering_plan

Hope it helps!

```
8zxx xxxx - Mobile and Data Services

9yxx xxxx - Mobile, Data Services and Pager (until May 2012)

Which also means:

8[1-8]xx xxxx - Mobile and Data Services

9[0-8]xx xxxx - Mobile, Data Services and Pager (until May 2012)

x denotes 0 to 9
y denotes 0 to 8 only
z denotes 1 to 8 only
```