### PR TITLE
Added de_DE\PhoneNumber::mobileNumber()

### DIFF
--- a/src/Faker/Provider/de_DE/PhoneNumber.php
+++ b/src/Faker/Provider/de_DE/PhoneNumber.php
@@ -17,4 +17,33 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
         '(0####) ######',
         '(0####) #####',
     );
+
+    /**
+     * An array of de_DE mobile (cell) phone number formats
+     * @var array
+     */
+    protected static $mobileFormats = array(
+      // Local
+      '0151#######', '0152#######', '0157#######', '0159#######',
+      '0160#######', '0162#######', '0163#######',
+      '0170#######', '0171#######', '0172#######',
+      '0173#######', '0174#######', '0175#######',
+      '0176#######', '0177#######', '0178#######',
+      '0179#######',
+      '0151 #######', '0152 #######', '0157 #######', '0159 #######',
+      '0160 #######', '0162 #######', '0163 #######',
+      '0170 #######', '0171 #######', '0172 #######',
+      '0173 #######', '0174 #######', '0175 #######',
+      '0176 #######', '0177 #######', '0178 #######',
+      '0179 #######',
+    );
+
+    /**
+     * Return a de_DE mobile phone number
+     * @return string
+     */
+    public static function mobileNumber()
+    {
+        return static::numerify(static::randomElement(static::$mobileFormats));
+    }
 }


### PR DESCRIPTION
Added similar function for german mobile numbers as other locale providers got already. i.e. `en_GB\PhoneNumber::mobileNumber()`