### PR TITLE
Make en_CA Phone Provider Extend the en_US One

### DIFF
--- a/src/Faker/Provider/en_CA/PhoneNumber.php
+++ b/src/Faker/Provider/en_CA/PhoneNumber.php
@@ -2,7 +2,7 @@
 
 namespace Faker\Provider\en_CA;
 
-class PhoneNumber extends \Faker\Provider\PhoneNumber
+class PhoneNumber extends \Faker\Provider\en_CA\PhoneNumber
 {
     protected static $formats = array(
         '%##-###-####',

--- a/src/Faker/Provider/en_CA/PhoneNumber.php
+++ b/src/Faker/Provider/en_CA/PhoneNumber.php
@@ -2,7 +2,7 @@
 
 namespace Faker\Provider\en_CA;
 
-class PhoneNumber extends \Faker\Provider\en_CA\PhoneNumber
+class PhoneNumber extends \Faker\Provider\en_US\PhoneNumber
 {
     protected static $formats = array(
         '%##-###-####',


### PR DESCRIPTION
Everything else applies to Canada.

It may even be possible to remove the Canadian class, or remove everything in it to avoid a BC.