### PR TITLE
PHPDoc for `passthrough` function on Generator

### DIFF
--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -155,6 +155,7 @@ namespace Faker;
  * @method Generator optional($weight = 0.5, $default = null)
  * @method Generator unique($reset = false, $maxRetries = 10000)
  * @method Generator valid($validator = null, $maxRetries = 10000)
+ * @method mixed passthrough($passthrough)
  *
  * @method integer biasedNumberBetween($min = 0, $max = 100, $function = 'sqrt')
  *


### PR DESCRIPTION
added in #1493 - fixup the missing PHPDoc

from ![currently broken](https://i.imgur.com/cY9ZsbG.png)

to ![inspection working after](https://i.imgur.com/aAQ0rwR.png)