### PR TITLE
pl_PL - phoneNumber, mobilePhoneNumber

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1466,6 +1466,18 @@ echo $faker->regon; // "714676680"
 echo $faker->regonLocal; // "15346111382836"
 ```
 
+### `Faker\Provider\pl_PL\PhoneNumber`
+
+```php
+<?php
+
+// Generates a random phone number
+echo $faker->phoneNumber; // "714676680"
+// Generates a random mobile phone number using real WST
+echo $faker->mobilePhoneNumber; // "0048793461113"
+```
+
+
 ### `Faker\Provider\pl_PL\Payment`
 
 ```php

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -33,6 +33,7 @@ namespace Faker;
  * @property string $isbn10
  *
  * @property string $phoneNumber
+ * @property string $mobilePhoneNumber
  * @property string $e164PhoneNumber
  *
  * @property string $company

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -33,7 +33,6 @@ namespace Faker;
  * @property string $isbn10
  *
  * @property string $phoneNumber
- * @property string $mobilePhoneNumber
  * @property string $e164PhoneNumber
  *
  * @property string $company

--- a/src/Faker/Provider/pl_PL/PhoneNumber.php
+++ b/src/Faker/Provider/pl_PL/PhoneNumber.php
@@ -21,6 +21,7 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
         '0048 {{mobileNetworkIdentifier}}# ### ###',
         '0048{{mobileNetworkIdentifier}}# ### ###',
         '{{mobileNetworkIdentifier}}# ### ###',
+        '{{mobileNetworkIdentifier}}#######',
     );
 
     /**

--- a/src/Faker/Provider/pl_PL/PhoneNumber.php
+++ b/src/Faker/Provider/pl_PL/PhoneNumber.php
@@ -5,14 +5,59 @@ namespace Faker\Provider\pl_PL;
 class PhoneNumber extends \Faker\Provider\PhoneNumber
 {
     protected static $formats = array(
-        '+48 ## ### ## ##',
-        '0048 ## ### ## ##',
-        '### ### ###',
-        '+48 ### ### ###',
-        '0048 ### ### ###',
-        '#########',
-        '(##) ### ## ##',
-        '+48(##)#######',
-        '0048(##)#######',
+        '+48 {{areaCode}} ### ## ##',
+        '+48 {{areaCode}}### ## ##',
+        '#######',
+        '({{areaCode}}) ### ## ##',
+        '+48({{areaCode}})#######',
+        '0048({{areaCode}})#######',
     );
+
+    protected static $mobileFormats = array(
+        '+48 {{mobileNetworkIdentifier}}# ### ###',
+        '+48{{mobileNetworkIdentifier}}# ### ###',
+        '+(48) {{mobileNetworkIdentifier}}# ### ###',
+        '+(48){{mobileNetworkIdentifier}}# ### ###',
+        '0048 {{mobileNetworkIdentifier}}# ### ###',
+        '0048{{mobileNetworkIdentifier}}# ### ###',
+        '{{mobileNetworkIdentifier}}# ### ###',
+    );
+
+    /**
+     * Only certain area codes are allowed
+     * {@link} http://prawo.sejm.gov.pl/isap.nsf/DocDetails.xsp?id=WDU20130001281
+     */
+    public function areaCode()
+    {
+        $areaCodes = [
+            12, 13, 14, 15, 16, 17, 18, 22, 23, 24, 25, 29, 32, 33, 34, 41, 42,
+            43, 44, 46, 48, 52, 54, 55, 56, 58, 59, 61, 62, 63, 65, 67, 68, 71,
+            74, 75, 76, 77, 81, 82, 83, 84, 85, 86, 87, 89, 91, 94, 95,
+        ];
+
+        return $this->generator->randomElement($areaCodes);
+    }
+
+
+    /**
+     * Only certain mobile network identifiers are allowed
+     *
+     * {@link} http://prawo.sejm.gov.pl/isap.nsf/DocDetails.xsp?id=WDU20130001281
+     */
+    public function mobileNetworkIdentifier()
+    {
+        $networkIdentifiers = [50, 51, 53, 57, 60, 66, 69, 72, 73, 78, 79, 88];
+
+        return $this->generator->randomElement($networkIdentifiers);
+    }
+
+    /**
+     * @example '0048123123123'
+     */
+    public function mobilePhoneNumber()
+    {
+        $format = static::randomElement(static::$mobileFormats);
+
+        return static::numerify($this->generator->parse($format));
+    }
 }

--- a/test/Faker/Provider/pl_PL/PhoneNumberTest.php
+++ b/test/Faker/Provider/pl_PL/PhoneNumberTest.php
@@ -29,6 +29,6 @@ class PhoneNumberTest extends TestCase
     public function testMobilePhoneNumber()
     {
         $mobileNumber = $this->faker->mobilePhoneNumber();
-        $this->assertRegExp('/^(\+48\s\d{2}\s\d{3}\s\d{2}\s\d{2})|(\+48\s\d{5}\s\)| (\+48\d{9})|(\(\+48\)\s\d{3}\s\d{3}\s\d{3})| (\(\+48\)\d{3}\s\d{3}\s\d{3})|((0048)\s\d{3}\s\d{3}\s\d{3})| (\(0048\)\d{9})|(\d{9})|(\d{3}\s\d{3}\s\d{3}))/', $mobileNumber);
+        $this->assertRegExp('/^(\+48\s\d{2}\s\d{3}\s\d{2}\s\d{2})|(\+48\s\d{5}\s\)| (\+48\d{9})|(\(\+48\)\s\d{3}\s\d{3}\s\d{3})| (\(\+48\)\d{3}\s\d{3}\s\d{3})|((0048)\s\d{3}\s\d{3}\s\d{3})| (\(0048\)\d{9})|(\d{9})|(\d{3}\s\d{3}\s\d{3})|(\d{9}))/', $mobileNumber);
     }
 }

--- a/test/Faker/Provider/pl_PL/PhoneNumberTest.php
+++ b/test/Faker/Provider/pl_PL/PhoneNumberTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Faker\Test\Provider\pl_PL;
+
+use Faker\Generator;
+use Faker\Provider\pl_PL\PhoneNumber;
+use PHPUnit\Framework\TestCase;
+
+class PhoneNumberTest extends TestCase
+{
+    /**
+     * @var Generator
+     */
+    private $faker;
+
+    public function setUp()
+    {
+        $faker = new Generator();
+        $faker->addProvider(new PhoneNumber($faker));
+        $this->faker = $faker;
+    }
+
+    public function testPhoneNumber()
+    {
+        $phoneNumber = $this->faker->phoneNumber();
+        $this->assertRegExp('/^((\+48\s\d{2}\s\d{3}\s\d{2}\s\d{2})|(\+48\s\d{5}\s\d{2}\s\d{2})|(\d{3}\s\d{2}\s\d{2})|(\d{9})|(\+48\(\d{2}\)\d{7})|(\d{4}\(\d{2}\)\d{3}\s\d{2}\s\d{2})|(\(\d{2}\)\s\d{3}\s\d{2}\s\d{2})|(\+48\(\d{2}\)\d{3}\s\d{2}\s\d{2})|(\d{4}\(\d{2}\)|\d{7}))/', $phoneNumber);
+    }
+
+    public function testMobilePhoneNumber()
+    {
+        $mobileNumber = $this->faker->mobilePhoneNumber();
+        $this->assertRegExp('/^(\+48\s\d{2}\s\d{3}\s\d{2}\s\d{2})|(\+48\s\d{5}\s\)| (\+48\d{9})|(\(\+48\)\s\d{3}\s\d{3}\s\d{3})| (\(\+48\)\d{3}\s\d{3}\s\d{3})|((0048)\s\d{3}\s\d{3}\s\d{3})| (\(0048\)\d{9})|(\d{9})|(\d{3}\s\d{3}\s\d{3}))/', $mobileNumber);
+    }
+}


### PR DESCRIPTION
 Added pl_PL formatter for mobile phones that are generated according to government specification: http://prawo.sejm.gov.pl/isap.nsf/DocDetails.xsp?id=WDU20130001281

Changed normal phone number generation to met requirements from above specification too. 

Added tests for both normal and mobile phone number. 

Updated provider section of readme. 



