### PR TITLE
Calling a non static method as static not allowed.

### DIFF
--- a/src/Faker/Provider/nl_NL/Person.php
+++ b/src/Faker/Provider/nl_NL/Person.php
@@ -288,7 +288,7 @@ class Person extends \Faker\Provider\Person
      */
     public static function titleMale()
     {
-        return static::title();
+        return static::randomElement(static::$title);
     }
 
     /**
@@ -296,7 +296,7 @@ class Person extends \Faker\Provider\Person
      */
     public static function titleFemale()
     {
-        return static::title();
+        return static::randomElement(static::$title);
     }
 
     /**


### PR DESCRIPTION
Title method is not static so it raises a php strict warning