### PR TITLE
Fix: Add allowed type DateTime to param annotation

### DIFF
--- a/src/Faker/Provider/DateTime.php
+++ b/src/Faker/Provider/DateTime.php
@@ -9,7 +9,7 @@ class DateTime extends Base
     protected static $defaultTimezone = null;
 
     /**
-     * @param string|float|int $max
+     * @param \DateTime|string|float|int $max
      * @return int|false
      */
     protected static function getMaxTimestamp($max = 'now')
@@ -147,7 +147,7 @@ class DateTime extends Base
      * an interval
      * Accepts date string that can be recognized by strtotime().
      *
-     * @param string $date      Defaults to 30 years ago
+     * @param \DateTime|string $date      Defaults to 30 years ago
      * @param string $interval  Defaults to 5 days after
      * @param string|null $timezone time zone in which the date time should be set, default to DateTime::$defaultTimezone, if set, otherwise the result of `date_default_timezone_get`
      * @example dateTimeInInterval('1999-02-02 11:42:52', '+ 5 days')


### PR DESCRIPTION
This PR

* [x] adds the missing type `DateTime` to `@param` annotations of methods which allow them