### PR TITLE
Added two Color methods to be more web-related explicitly

### DIFF
--- a/src/Faker/Provider/Color.php
+++ b/src/Faker/Provider/Color.php
@@ -113,4 +113,12 @@ class Color extends Base
     {
         return static::randomElement(static::$allColorNames);
     }
+
+    /**
+     * @example 'olive'
+     */
+    public static function htmlColorName()
+    {
+        return static::randomElement(static::$safeColorNames);
+    }
 }

--- a/src/Faker/Provider/Color.php
+++ b/src/Faker/Provider/Color.php
@@ -121,4 +121,12 @@ class Color extends Base
     {
         return static::randomElement(static::$safeColorNames);
     }
+
+    /**
+     * @example 'NavajoWhite'
+     */
+    public static function x11ColorName()
+    {
+        return static::randomElement(static::$allColorNames);
+    }
 }


### PR DESCRIPTION
Added two new methods to Color provider:
 - Color::htmlColorName()
 - Color::x11ColorName()
Those are just colorName() and safeColorName() renamed but with those new names it is more clear the relation with web colors.