### PR TITLE
Fix ir locale phone number prefix

### DIFF
--- a/src/Faker/Provider/fa_IR/PhoneNumber.php
+++ b/src/Faker/Provider/fa_IR/PhoneNumber.php
@@ -8,11 +8,6 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
      * @link https://fa.wikipedia.org/wiki/%D8%B4%D9%85%D8%A7%D8%B1%D9%87%E2%80%8C%D9%87%D8%A7%DB%8C_%D8%AA%D9%84%D9%81%D9%86_%D8%AF%D8%B1_%D8%A7%DB%8C%D8%B1%D8%A7%D9%86#.D8.AA.D9.84.D9.81.D9.86.E2.80.8C.D9.87.D8.A7.DB.8C_.D9.87.D9.85.D8.B1.D8.A7.D9.87
      */
     protected static $formats = array(
-        '021########',
-        '026########',
-        '031########',
-    );
-    protected static $mobileNumberPrefixes = array(
         '0910#######',//mci
         '0911#######',
         '0912#######',
@@ -41,6 +36,6 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     );
     public static function mobileNumber()
     {
-        return static::numerify(static::randomElement(static::$mobileNumberPrefixes));
+        return static::numerify(static::randomElement(static::$formats));
     }
 }


### PR DESCRIPTION
- user can't generate the correct phone number prefix when doing it with
the Generator

- it was revealed that Generator was using the wrong fa_ir locale format

- this is to fix issue #1706 