### PR TITLE
Fix-Isreal--Israel

### DIFF
--- a/src/Faker/Provider/en_NG/Person.php
+++ b/src/Faker/Provider/en_NG/Person.php
@@ -74,7 +74,7 @@ class Person extends \Faker\Provider\Person
         'Funmilayo',
         'Gbadamosi', 'Gbogboade', 'Grace',
         'Habeeb', 'Hanifat', 'Isaac',
-        'Ismail', 'Isokun', 'Isreal', 'Iyalla',
+        'Ismail', 'Isokun', 'Israel', 'Iyalla',
         'Jamiu', 'Jimoh', 'Joshua', 'Justina',
         'Katherine', 'Kayode', 'Kayode', 'Kimberly',
         'Ladega', 'Latifat', 'Lawal', 'Leonard',


### PR DESCRIPTION
Fixed a little typo, from "Isreal" to "Israel".