### PR TITLE
workaround for memory leak

### DIFF
--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -193,17 +193,26 @@ namespace Faker;
  */
 class Generator
 {
-    protected $providers = array();
-    protected $formatters = array();
+    protected static $providers = array();
+    protected static $formatters = array();
+
+    public function __construct()
+    {
+        foreach (self::$providers as &$provider) {
+            unset($provider);
+        }
+
+        self::$providers = self::$formatters = array();
+    }
 
     public function addProvider($provider)
     {
-        array_unshift($this->providers, $provider);
+        array_unshift(self::$providers, $provider);
     }
 
     public function getProviders()
     {
-        return $this->providers;
+        return self::$providers;
     }
 
     public function seed($seed = null)
@@ -231,16 +240,16 @@ class Generator
      */
     public function getFormatter($formatter)
     {
-        if (isset($this->formatters[$formatter])) {
-            return $this->formatters[$formatter];
+        if (isset(self::$formatters[$formatter])) {
+            return self::$formatters[$formatter];
         }
-        foreach ($this->providers as $provider) {
-            if (method_exists($provider, $formatter)) {
-                $this->formatters[$formatter] = array($provider, $formatter);
 
-                return $this->formatters[$formatter];
+        foreach (self::$providers as $provider) {
+            if (method_exists($provider, $formatter)) {
+                return self::$formatters[$formatter] = array($provider, $formatter);
             }
         }
+
         throw new \InvalidArgumentException(sprintf('Unknown formatter "%s"', $formatter));
     }
 


### PR DESCRIPTION
Current, Faker has mutual reference between Generator and Providers. These mutual references will result in memory leak[0]. The only way to free those memory is calling gc_collect_cycles[1].

This pull request uses a workaround to prevent memory endlessly growing, however, memory leak is still exist. To solve the problem completely, it will need to refactor the whole project.

[0] https://www.php.net/manual/en/features.gc.refcounting-basics.php#features.gc.cleanup-problems
[1] https://php.net/manual/en/function.gc-collect-cycles.php

related issues: #1471 #1125 #921
related pull requests: #1005
—

Code to reproduce the bug.

```php
<?php

require __DIR__.'/vendor/autoload.php';

echo sprintf('%.2f MB'.PHP_EOL, memory_get_usage() / 1024 / 1024);

for ($i = 0; $i < 10; ++$i) {
    Faker\Factory::create('zh_TW')->realText(150);

    echo sprintf('%.2f MB'.PHP_EOL, memory_get_usage() / 1024 / 1024);
}
```

master branch output

```text
0.44 MB
18.22 MB
34.54 MB
50.86 MB
67.17 MB
83.49 MB
99.81 MB
116.13 MB
PHP Fatal error:  Allowed memory size of 134217728 bytes exhausted (tried to allocate 20480 bytes)
```

this workaround output

```text
0.44 MB
18.22 MB
18.22 MB
18.22 MB
18.22 MB
18.22 MB
18.22 MB
18.22 MB
18.22 MB
18.22 MB
18.22 MB
```