### PR TITLE
Add  new Sport provider

### DIFF
--- a/src/Faker/Factory.php
+++ b/src/Faker/Factory.php
@@ -6,7 +6,7 @@ class Factory
 {
     const DEFAULT_LOCALE = 'en_US';
 
-    protected static $defaultProviders = array('Address', 'Barcode', 'Biased', 'Color', 'Company', 'DateTime', 'File', 'HtmlLorem', 'Image', 'Internet', 'Lorem', 'Miscellaneous', 'Payment', 'Person', 'PhoneNumber', 'Text', 'UserAgent', 'Uuid');
+    protected static $defaultProviders = array('Address', 'Barcode', 'Biased', 'Color', 'Company', 'DateTime', 'File', 'HtmlLorem', 'Image', 'Internet', 'Lorem', 'Miscellaneous', 'Payment', 'Person', 'PhoneNumber', 'Sport', 'Text', 'UserAgent', 'Uuid');
 
     /**
      * Create a new generator

--- a/src/Faker/Provider/Sport.php
+++ b/src/Faker/Provider/Sport.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Faker\Provider;
+
+class Sport extends Base
+{
+    protected static $sports = array(
+        'Volleyball',
+    );
+
+    public function sport()
+    {
+        return static::randomElement(static::$sports);
+    }
+}

--- a/src/Faker/Provider/en_GB/Sport.php
+++ b/src/Faker/Provider/en_GB/Sport.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Faker\Provider\en_GB;
+
+class Sport extends \Faker\Provider\Sport
+{
+    protected static $sports = array(
+        'American Football',
+        'Baseball',
+        'Basketball',
+        'Beach Volleyball',
+        'Bowling',
+        'Boxing',
+        'Canoeing',
+        'Cricket',
+        'Cricket',
+        'Curling',
+        'Cycling',
+        'Diving',
+        'Fishing',
+        'Football',
+        'Golf',
+        'Gymnastic',
+        'Handball',
+        'Hockey',
+        'Ice Hockey',
+        'Ice Skating',
+        'Judo',
+        'Karate',
+        'Kayaking',
+        'Lacrosse',
+        'Rollerblading',
+        'Rowing',
+        'Rugby League',
+        'Rugby Union',
+        'Skateboarding',
+        'Skating',
+        'Skiing',
+        'Snowboarding',
+        'Softball',
+        'Swimming',
+        'Taekwondo',
+        'Tennis',
+        'Volleyball',
+        'Waterpolo',
+        'Wrestling',
+    );
+}

--- a/src/Faker/Provider/en_US/Sport.php
+++ b/src/Faker/Provider/en_US/Sport.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Faker\Provider\en_US;
+
+class Sport extends \Faker\Provider\Sport
+{
+    protected static $sports = array(
+        'Baseball',
+        'Basketball',
+        'Beach Volleyball',
+        'Bowling',
+        'Boxing',
+        'Canoeing',
+        'Cricket',
+        'Curling',
+        'Cycling',
+        'Diving',
+        'Fishing',
+        'Football',
+        'Golf',
+        'Gymnastic',
+        'Handball',
+        'Hockey',
+        'Ice Hockey',
+        'Ice Skating',
+        'Judo',
+        'Karate',
+        'Kayaking',
+        'Lacrosse',
+        'Rollerblading',
+        'Rowing',
+        'Rugby',
+        'Skateboarding',
+        'Skating',
+        'Skiing',
+        'Snowboarding',
+        'Soccer',
+        'Softball',
+        'Swimming',
+        'Taekwondo',
+        'Tennis',
+        'Volleyball',
+        'Waterpolo',
+        'Wrestling',
+    );
+}

--- a/src/Faker/Provider/it_IT/Sport.php
+++ b/src/Faker/Provider/it_IT/Sport.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Faker\Provider\it_IT;
+
+class Sport extends \Faker\Provider\Sport
+{
+    protected static $sports = array(
+        'Baseball',
+        'Beach Volleyball',
+        'Bocce',
+        'Bowling',
+        'Calcio',
+        'Canottaggio',
+        'Ciclismo',
+        'Cricket',
+        'Football Americano',
+        'Ginnastica',
+        'Golf',
+        'Hockey su ghiaccio',
+        'Hockey',
+        'Judo',
+        'Karate',
+        'Kayaking',
+        'Lotta',
+        'Nuoto',
+        'Pallacanestro',
+        'Pallamano',
+        'Pallanuoto',
+        'Pallavolo',
+        'Pattinaggio su ghiaccio',
+        'Pattinattio a rotelle',
+        'Pesca',
+        'Pugilato',
+        'Rollerblading',
+        'Rugby',
+        'Sci',
+        'Skateboarding',
+        'Snowboarding',
+        'Softball',
+        'Taekwondo',
+        'Tennis',
+        'Tuffi',
+    );
+}

--- a/test/Faker/Provider/en_US/SportTest.php
+++ b/test/Faker/Provider/en_US/SportTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Faker\Test\Provider\en_US;
+
+use Faker\Generator;
+use Faker\Provider\en_US\Sport;
+use PHPUnit\Framework\TestCase;
+
+class SportTest extends TestCase
+{
+    /**
+     * @var Generator
+     */
+    private $faker;
+
+    public function setUp()
+    {
+        $faker = new Generator();
+        $faker->addProvider(new Sport($faker));
+        $this->faker = $faker;
+    }
+
+    public function testSport()
+    {
+        $sport = $this->faker->sport();
+        $pattern = '/^[A-Za-z ]+$/';
+        $this->assertRegExp($pattern, $sport);
+    }
+}


### PR DESCRIPTION
I am in need of generating data related to sports: sport names, teams and venues for example. At the moment I use a lot of `$faker->company` for the names but that doesn't sound right. So I thought I contribute to the project and add a new provider for sport data.

**This is a Work In Progress still**

This is initial work. If there is interest for such provider I would add team and venue and maybe a some more translations.

**Please let me know in the comments if you would like this new provider**