### PR TITLE
Modification to xx_CA providers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "fzaninotto/faker",
+    "name": "vincentdh/faker",
     "type": "library",
     "description": "Faker is a PHP library that generates fake data for you.",
     "keywords": ["faker", "fixtures", "data"],

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -48,6 +48,16 @@ class Base
     }
 
     /**
+     * Returns a random number between 2 and 9
+     *
+     * @return integer
+     */
+    public static function randomDigit2to9()
+    {
+        return mt_rand(2, 9);
+    }
+
+    /**
      * Generates a random digit, which cannot be $except
      *
      * @param int $except
@@ -363,6 +373,7 @@ class Base
     /**
      * Replaces all hash sign ('#') occurrences with a random number
      * Replaces all percentage sign ('%') occurrences with a not null number
+     * Replaces all "N" occurrences with a digit between 2 and 9
      *
      * @param  string $string String that needs to bet parsed
      * @return string
@@ -392,6 +403,7 @@ class Base
                 $string[$toReplace[$i]] = $numbers[$i];
             }
         }
+        $string = self::replaceWildcard($string, 'N', 'static::randomDigit2to9');
         $string = self::replaceWildcard($string, '%', 'static::randomDigitNotNull');
 
         return $string;

--- a/src/Faker/Provider/en_CA/Address.php
+++ b/src/Faker/Provider/en_CA/Address.php
@@ -91,5 +91,4 @@ class Address extends \Faker\Provider\en_US\Address
 
         return static::toUpper($string);
     }
-
 }

--- a/src/Faker/Provider/en_CA/Address.php
+++ b/src/Faker/Provider/en_CA/Address.php
@@ -10,7 +10,11 @@ class Address extends \Faker\Provider\en_US\Address
 {
     protected static $postcode = array('?#? #?#', '?#?-#?#', '?#?#?#');
 
-    protected static $postcodeLetters = array('A','B','C','E','G','H','J','K','L','M','N','P','R','S','T','V','X','Y');
+    protected static $validpostcode = array('?#? #?#');
+
+    protected static $postcodeFirstLetters = array('A','B','C','E','G','H','J','K','L','M','N','P','R','S','T','V','X','Y');
+
+    protected static $postcodeLetters = array('A','B','C','E','G','H','J','K','L','M','N','P','R','S','T','V','W','X','Y','Z');
 
     protected static $province = array(
         'Alberta', 'British Columbia', 'Manitoba', 'New Brunswick', 'Newfoundland and Labrador', 'Northwest Territories', 'Nova Scotia', 'Nunavut', 'Ontario', 'Prince Edward Island', 'Quebec', 'Saskatchewan', 'Yukon Territory',
@@ -41,6 +45,15 @@ class Address extends \Faker\Provider\en_US\Address
     }
 
     /**
+     * Returns a postalcode-safe first letter
+     * @example A1B 2C3
+     */
+    public static function randomPostcodeFirstLetter()
+    {
+        return static::randomElement(static::$postcodeFirstLetters);
+    }
+
+    /**
      * Returns a postalcode-safe letter
      * @example A1B 2C3
      */
@@ -51,6 +64,8 @@ class Address extends \Faker\Provider\en_US\Address
 
     /**
      * @example A1B 2C3
+     * @example A1B-2C3
+     * @example A1B2C3
      */
     public static function postcode()
     {
@@ -61,4 +76,20 @@ class Address extends \Faker\Provider\en_US\Address
 
         return static::toUpper($string);
     }
+
+    /**
+     * Return a postal code that respects the Canadian Post standards
+     * @example A1B 2C3
+     */
+    public static function validpostcode()
+    {
+        $string = static::randomElement(static::$validpostcode);
+
+        $string = preg_replace_callback('/\#/u', 'static::randomDigit', $string);
+        $string = preg_replace_callback('/\?/u', 'static::randomPostcodeLetter', $string);
+        $string = preg_replace_callback('/^./', 'static::randomPostcodeFirstLetter', $string);
+
+        return static::toUpper($string);
+    }
+
 }

--- a/src/Faker/Provider/fr_CA/Address.php
+++ b/src/Faker/Provider/fr_CA/Address.php
@@ -4,6 +4,14 @@ namespace Faker\Provider\fr_CA;
 
 class Address extends \Faker\Provider\fr_FR\Address
 {
+    protected static $postcode = array('?#? #?#', '?#?-#?#', '?#?#?#');
+
+    protected static $validpostcode = array('?#? #?#');
+
+    protected static $postcodeFirstLetters = array('A','B','C','E','G','H','J','K','L','M','N','P','R','S','T','V','X','Y');
+
+    protected static $postcodeLetters = array('A','B','C','E','G','H','J','K','L','M','N','P','R','S','T','V','W','X','Y','Z');
+
     protected static $cityPrefix = array('Saint-', 'Sainte-', 'St-', 'Ste-');
 
     /**
@@ -53,8 +61,6 @@ class Address extends \Faker\Provider\fr_FR\Address
     protected static $streetSuffix = array(
         'Autoroute', 'Avenue', 'Boulevard', 'Chemin', 'Route', 'Rue', 'Pont'
     );
-
-    protected static $postcode = array('?#? #?#', '?#?#?#');
 
     /**
      * @example 'Avenue Bolduc'
@@ -110,6 +116,22 @@ class Address extends \Faker\Provider\fr_FR\Address
     /**
      * @example 'Québec'
      */
+    public static function province()
+    {
+        return static::randomElement(static::$state);
+    }
+
+    /**
+     * @example 'QC'
+     */
+    public static function provinceAbbr()
+    {
+        return static::randomElement(static::$stateAbbr);
+    }
+
+    /**
+     * @example 'Québec'
+     */
     public static function state()
     {
         return static::randomElement(static::$state);
@@ -122,4 +144,53 @@ class Address extends \Faker\Provider\fr_FR\Address
     {
         return static::randomElement(static::$stateAbbr);
     }
+
+    /**
+     * Returns a postalcode-safe first letter
+     * @example A1B 2C3
+     */
+    public static function randomPostcodeFirstLetter()
+    {
+        return static::randomElement(static::$postcodeFirstLetters);
+    }
+
+    /**
+     * Returns a postalcode-safe letter
+     * @example A1B 2C3
+     */
+    public static function randomPostcodeLetter()
+    {
+        return static::randomElement(static::$postcodeLetters);
+    }
+
+    /**
+     * @example A1B 2C3
+     * @example A1B-2C3
+     * @example A1B2C3
+     */
+    public static function postcode()
+    {
+        $string = static::randomElement(static::$postcode);
+
+        $string = preg_replace_callback('/\#/u', 'static::randomDigit', $string);
+        $string = preg_replace_callback('/\?/u', 'static::randomPostcodeLetter', $string);
+
+        return static::toUpper($string);
+    }
+
+    /**
+     * Return a postal code that respects the Canadian Post standards
+     * @example A1B 2C3
+     */
+    public static function validpostcode()
+    {
+        $string = static::randomElement(static::$validpostcode);
+
+        $string = preg_replace_callback('/\#/u', 'static::randomDigit', $string);
+        $string = preg_replace_callback('/\?/u', 'static::randomPostcodeLetter', $string);
+        $string = preg_replace_callback('/^./', 'static::randomPostcodeFirstLetter', $string);
+
+        return static::toUpper($string);
+    }
+
 }

--- a/src/Faker/Provider/fr_CA/Address.php
+++ b/src/Faker/Provider/fr_CA/Address.php
@@ -192,5 +192,4 @@ class Address extends \Faker\Provider\fr_FR\Address
 
         return static::toUpper($string);
     }
-
 }

--- a/test/Faker/Provider/fr_CA/AddressTest.php
+++ b/test/Faker/Provider/fr_CA/AddressTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Faker\Provider\en_CA;
+namespace Faker\Provider\fr_CA;
 
 use Faker\Generator;
-use Faker\Provider\en_CA\Address;
+use Faker\Provider\fr_CA\Address;
 use PHPUnit\Framework\TestCase;
 
 class AddressTest extends TestCase


### PR DESCRIPTION
 * Modify fr_CA to add province generation to match en_CA.  Left the state for compatibility
 * Add validpostalcode to fr_CA and en_CA to generate a postal code that matches Canada Post standards (https://en.wikipedia.org/wiki/Postal_codes_in_Canada#Number_of_possible_postal_codes)