### PR TITLE
Updated implode and join statements to follow the argument order from the documentation.

### DIFF
--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -492,7 +492,7 @@ class Base
         // All A-F inside of [] become ABCDEF
         $regex = preg_replace_callback('/\[([^\]]+)\]/', function ($matches) {
             return '[' . preg_replace_callback('/(\w|\d)\-(\w|\d)/', function ($range) {
-                return implode(range($range[1], $range[2]), '');
+                return implode('', range($range[1], $range[2]));
             }, $matches[1]) . ']';
         }, $regex);
         // All [ABC] become B (or A or C)

--- a/src/Faker/Provider/Internet.php
+++ b/src/Faker/Provider/Internet.php
@@ -175,7 +175,7 @@ class Internet extends Base
         }
         $words = $this->generator->words($nbWords);
 
-        return join($words, '-');
+        return join('-', $words);
     }
 
     /**

--- a/src/Faker/Provider/Lorem.php
+++ b/src/Faker/Provider/Lorem.php
@@ -92,7 +92,7 @@ class Lorem extends Base
         $words = static::words($nbWords);
         $words[0] = ucwords($words[0]);
 
-        return implode($words, ' ') . '.';
+        return implode(' ', $words) . '.';
     }
 
     /**
@@ -131,7 +131,7 @@ class Lorem extends Base
             $nbSentences = self::randomizeNbElements($nbSentences);
         }
 
-        return implode(static::sentences($nbSentences), ' ');
+        return implode(' ', static::sentences($nbSentences));
     }
 
     /**
@@ -193,7 +193,7 @@ class Lorem extends Base
             $text[count($text) - 1] .= '.';
         }
 
-        return implode($text, '');
+        return implode('', $text);
     }
 
     protected static function randomizeNbElements($nbElements)

--- a/src/Faker/Provider/Text.php
+++ b/src/Faker/Provider/Text.php
@@ -53,7 +53,7 @@ abstract class Text extends Base
             $currentWords = static::explode($next);
             $currentWords[] = $word;
             array_shift($currentWords);
-            $next = static::implode($currentWords);
+            $next = static::implode('', $currentWords);
 
             // ensure text starts with an uppercase letter
             if ($resultLength == 0 && !static::validStart($word)) {
@@ -69,7 +69,7 @@ abstract class Text extends Base
         array_pop($result);
 
         // build result
-        $result = static::implode($result);
+        $result = static::implode('', $result);
 
         return static::appendEnd($result);
     }
@@ -85,7 +85,7 @@ abstract class Text extends Base
             }
 
             for ($i = 0, $count = count($parts); $i < $count; $i++) {
-                $stringIndex = static::implode($index);
+                $stringIndex = static::implode('', $index);
                 if (!isset($words[$stringIndex])) {
                     $words[$stringIndex] = array();
                 }

--- a/src/Faker/Provider/ar_JO/Company.php
+++ b/src/Faker/Provider/ar_JO/Company.php
@@ -45,7 +45,7 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 
     /**
@@ -58,6 +58,6 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 }

--- a/src/Faker/Provider/ar_SA/Company.php
+++ b/src/Faker/Provider/ar_SA/Company.php
@@ -47,7 +47,7 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 
     /**
@@ -60,7 +60,7 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 
     /**

--- a/src/Faker/Provider/en_US/Company.php
+++ b/src/Faker/Provider/en_US/Company.php
@@ -84,7 +84,7 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 
     /**
@@ -97,7 +97,7 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 
     /**

--- a/src/Faker/Provider/es_AR/Company.php
+++ b/src/Faker/Provider/es_AR/Company.php
@@ -48,7 +48,7 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 
     /**
@@ -61,6 +61,6 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 }

--- a/src/Faker/Provider/es_ES/Company.php
+++ b/src/Faker/Provider/es_ES/Company.php
@@ -62,7 +62,7 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 
     /**
@@ -75,6 +75,6 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 }

--- a/src/Faker/Provider/es_PE/Company.php
+++ b/src/Faker/Provider/es_PE/Company.php
@@ -48,7 +48,7 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 
     /**
@@ -61,6 +61,6 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 }

--- a/src/Faker/Provider/fi_FI/Company.php
+++ b/src/Faker/Provider/fi_FI/Company.php
@@ -46,7 +46,7 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 
     /**
@@ -59,6 +59,6 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 }

--- a/src/Faker/Provider/hy_AM/Company.php
+++ b/src/Faker/Provider/hy_AM/Company.php
@@ -36,7 +36,7 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 
     /**
@@ -49,6 +49,6 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 }

--- a/src/Faker/Provider/it_IT/Company.php
+++ b/src/Faker/Provider/it_IT/Company.php
@@ -48,7 +48,7 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 
     /**
@@ -61,7 +61,7 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 
     /**

--- a/src/Faker/Provider/ru_RU/Company.php
+++ b/src/Faker/Provider/ru_RU/Company.php
@@ -68,7 +68,7 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 
     /**

--- a/src/Faker/Provider/sk_SK/Company.php
+++ b/src/Faker/Provider/sk_SK/Company.php
@@ -46,7 +46,7 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 
     /**
@@ -59,6 +59,6 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 }

--- a/src/Faker/Provider/th_TH/Company.php
+++ b/src/Faker/Provider/th_TH/Company.php
@@ -27,6 +27,6 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($slogan);
         }
 
-        return implode($result);
+        return implode('', $result);
     }
 }


### PR DESCRIPTION
The documented argument order for the `implode` function is `implode($glue, $pieces);`. Although the function accepts any order for "historical reasons".
https://www.php.net/manual/en/function.implode.php

But in PHP 7.4.0beta2 (which I am using to build a Laravel application with) seems to have deprecated this support and the arguments must now be entered in the documented order.

Running `php artisan migrate --seed` encounters this deprecation warning and fails altogether. So I decided to contribute in a change to all `implode` calls.

**Note:** `join` is just an alias of `implode`.