### PR TITLE
PHP 7.4 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ php:
     - 7.0
     - 7.1
     - 7.2
+    - 7.3
     - nightly
 
 sudo: false

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -492,7 +492,7 @@ class Base
         // All A-F inside of [] become ABCDEF
         $regex = preg_replace_callback('/\[([^\]]+)\]/', function ($matches) {
             return '[' . preg_replace_callback('/(\w|\d)\-(\w|\d)/', function ($range) {
-                return implode(range($range[1], $range[2]), '');
+                return implode('', range($range[1], $range[2]));
             }, $matches[1]) . ']';
         }, $regex);
         // All [ABC] become B (or A or C)

--- a/src/Faker/Provider/Internet.php
+++ b/src/Faker/Provider/Internet.php
@@ -175,7 +175,7 @@ class Internet extends Base
         }
         $words = $this->generator->words($nbWords);
 
-        return join($words, '-');
+        return join('-', $words);
     }
 
     /**

--- a/src/Faker/Provider/Lorem.php
+++ b/src/Faker/Provider/Lorem.php
@@ -92,7 +92,7 @@ class Lorem extends Base
         $words = static::words($nbWords);
         $words[0] = ucwords($words[0]);
 
-        return implode($words, ' ') . '.';
+        return implode(' ', $words) . '.';
     }
 
     /**
@@ -131,7 +131,7 @@ class Lorem extends Base
             $nbSentences = self::randomizeNbElements($nbSentences);
         }
 
-        return implode(static::sentences($nbSentences), ' ');
+        return implode(' ', static::sentences($nbSentences));
     }
 
     /**
@@ -193,7 +193,7 @@ class Lorem extends Base
             $text[count($text) - 1] .= '.';
         }
 
-        return implode($text, '');
+        return implode('', $text);
     }
 
     protected static function randomizeNbElements($nbElements)

--- a/src/Faker/Provider/ar_JO/Company.php
+++ b/src/Faker/Provider/ar_JO/Company.php
@@ -45,7 +45,7 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 
     /**
@@ -58,6 +58,6 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 }

--- a/src/Faker/Provider/ar_SA/Company.php
+++ b/src/Faker/Provider/ar_SA/Company.php
@@ -47,7 +47,7 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 
     /**
@@ -60,7 +60,7 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 
     /**

--- a/src/Faker/Provider/en_US/Company.php
+++ b/src/Faker/Provider/en_US/Company.php
@@ -84,7 +84,7 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 
     /**
@@ -97,7 +97,7 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 
     /**

--- a/src/Faker/Provider/es_AR/Company.php
+++ b/src/Faker/Provider/es_AR/Company.php
@@ -48,7 +48,7 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 
     /**
@@ -61,6 +61,6 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 }

--- a/src/Faker/Provider/es_ES/Company.php
+++ b/src/Faker/Provider/es_ES/Company.php
@@ -62,7 +62,7 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 
     /**
@@ -75,6 +75,6 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 }

--- a/src/Faker/Provider/es_PE/Company.php
+++ b/src/Faker/Provider/es_PE/Company.php
@@ -48,7 +48,7 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 
     /**
@@ -61,6 +61,6 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 }

--- a/src/Faker/Provider/fi_FI/Company.php
+++ b/src/Faker/Provider/fi_FI/Company.php
@@ -46,7 +46,7 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 
     /**
@@ -59,6 +59,6 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 }

--- a/src/Faker/Provider/hy_AM/Company.php
+++ b/src/Faker/Provider/hy_AM/Company.php
@@ -36,7 +36,7 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 
     /**
@@ -49,6 +49,6 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 }

--- a/src/Faker/Provider/it_IT/Company.php
+++ b/src/Faker/Provider/it_IT/Company.php
@@ -48,7 +48,7 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 
     /**
@@ -61,7 +61,7 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 
     /**

--- a/src/Faker/Provider/ru_RU/Company.php
+++ b/src/Faker/Provider/ru_RU/Company.php
@@ -68,7 +68,7 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 
     /**

--- a/src/Faker/Provider/sk_SK/Company.php
+++ b/src/Faker/Provider/sk_SK/Company.php
@@ -46,7 +46,7 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 
     /**
@@ -59,6 +59,6 @@ class Company extends \Faker\Provider\Company
             $result[] = static::randomElement($word);
         }
 
-        return join($result, ' ');
+        return join(' ', $result);
     }
 }


### PR DESCRIPTION
For PHP 7.4 the implode methods will break:

`implode(): Passing glue string after array is deprecated. Swap the parameters`

I also updated travis to match 7.3. However there is no 7.4 env available in Travis yet as far as i know