### PR TITLE
Fix: No need to update composer itself

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ cache:
     - $HOME/.composer/cache
 
 before_script:
-    - travis_retry composer self-update
     - travis_retry composer install --no-interaction --prefer-dist
 
 script: make sniff test


### PR DESCRIPTION
This PR

* [x] removes an unnecessary invocation of `composer self-update`

💁‍♂ It's already updated, see for example

* https://travis-ci.org/fzaninotto/Faker/jobs/575886873#L129
* https://travis-ci.org/fzaninotto/Faker/jobs/575886873#L151