### PR TITLE
Enhancement: Disable Xdebug as early as possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ cache:
   directories:
     - $HOME/.composer/cache
 
+before_install:
+  - phpenv config-rm xdebug.ini || true
+
 before_script:
     - travis_retry composer install --no-interaction --prefer-dist
 


### PR DESCRIPTION
This PR

* [x] disables Xdebug as early as possible on Travis

💁‍♂ We currently don't need it, and this potentially speeds up builds. For reference, see https://docs.travis-ci.com/user/languages/php/#disabling-preinstalled-php-extensions.