### PR TITLE
Fix: Allow nightly builds to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,11 @@ php:
     - 7.1
     - 7.2
     - 7.3
-    - 7.4snapshot
+    - nightly
+
+matrix:
+    allow_failures:
+        - nightly
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ php:
     - 7.1
     - 7.2
     - 7.3
-    - nightly
+    - 7.4snapshot
 
 cache:
   directories:


### PR DESCRIPTION
This PR

* [x] allows `nightly` builds to fail

Somewhat related to #1758, as 3rd-party extensions (such as Xdebug) are not installed on nightly builds (see https://docs.travis-ci.com/user/languages/php/#nightly-builds).
