### PR TITLE
Fix: Remove sudo configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ php:
     - 7.3
     - nightly
 
-sudo: false
-
 cache:
   directories:
     - $HOME/.composer/cache


### PR DESCRIPTION
This PR

* [x] removes the deprecated `sudo` configuration from `.travis.yml`

💁‍♂ For reference, see https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration.