### PR TITLE
Enhancement: Introduce build and help targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,5 @@
 .PHONY: fix sniff test
 
-vendor/autoload.php:
-	composer install --no-interaction --prefer-dist
-
 fix: vendor/autoload.php
 	vendor/bin/phpcbf --standard=PSR2 src
 
@@ -11,3 +8,6 @@ sniff: vendor/autoload.php
 
 test: vendor/autoload.php
 	vendor/bin/phpunit --verbose
+
+vendor/autoload.php:
+	composer install --no-interaction --prefer-dist

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-.PHONY: fix sniff test
+.PHONY: build fix sniff test
+
+build: fix test
 
 fix: vendor/autoload.php
 	vendor/bin/phpcbf --standard=PSR2 src

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,17 @@
-.PHONY: build fix sniff test
+.PHONY: build fix help sniff test
 
-build: fix test
+help:
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-fix: vendor/autoload.php
+build: fix test ## Runs fix and test targets
+
+fix: vendor/autoload.php ## Fixes code style issues with phpcbf
 	vendor/bin/phpcbf --standard=PSR2 src
 
-sniff: vendor/autoload.php
+sniff: vendor/autoload.php ## Detects code style issues with phpcs
 	vendor/bin/phpcs --standard=PSR2 src -n
 
-test: vendor/autoload.php
+test: vendor/autoload.php ## Runs tests with phpunit
 	vendor/bin/phpunit --verbose
 
 vendor/autoload.php:

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,13 @@
+.PHONY: fix sniff test
+
 vendor/autoload.php:
 	composer install --no-interaction --prefer-dist
 
-.PHONY: fix
 fix: vendor/autoload.php
 	vendor/bin/phpcbf --standard=PSR2 src
 
-.PHONY: sniff
 sniff: vendor/autoload.php
 	vendor/bin/phpcs --standard=PSR2 src -n
 
-.PHONY: test
 test: vendor/autoload.php
 	vendor/bin/phpunit --verbose


### PR DESCRIPTION
This PR

* [x] declares all phony targets at the start of the `Makefile`
* [x] keeps other targets sorted by name
* [x] introduces a `build` target which depends on `fix` and `test`
* [x] introduces a `help` target which displays a list of targets with descriptions (when they have been provided as comments)