### PR TITLE
Enhancement: Assert that imageUrl can be used with gray flag

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -265,7 +265,7 @@ Methods accepting a `$timezone` argument default to `date_default_timezone_get()
     imageUrl($width = 640, $height = 480) // 'http://lorempixel.com/640/480/'
     imageUrl($width, $height, 'cats')     // 'http://lorempixel.com/800/600/cats/'
     imageUrl($width, $height, 'cats', true, 'Faker') // 'http://lorempixel.com/800/400/cats/Faker'
-    imageUrl($width, $height, 'cats', true, 'Faker', true) // 'http://lorempixel.com/grey/800/400/cats/Faker/' Monochrome image
+    imageUrl($width, $height, 'cats', true, 'Faker', true) // 'http://lorempixel.com/gray/800/400/cats/Faker/' Monochrome image
     image($dir = '/tmp', $width = 640, $height = 480) // '/tmp/13b73edae8443990be1aa8f1a483bc27.jpg'
     image($dir, $width, $height, 'cats')  // 'tmp/13b73edae8443990be1aa8f1a483bc27.jpg' it's a cat!
     image($dir, $width, $height, 'cats', false) // '13b73edae8443990be1aa8f1a483bc27.jpg' it's a filename without path

--- a/test/Faker/Provider/ImageTest.php
+++ b/test/Faker/Provider/ImageTest.php
@@ -27,6 +27,34 @@ class ImageTest extends TestCase
         $this->assertRegExp('#^https://lorempixel.com/800/400/nature/Faker#', Image::imageUrl(800, 400, 'nature', false, 'Faker'));
     }
 
+    public function testImageUrlReturnsLinkToRegularImageWhenGrayIsFalse()
+    {
+        $imageUrl = Image::imageUrl(
+            800,
+            400,
+            'nature',
+            false,
+            'Faker',
+            false
+        );
+
+        $this->assertSame('https://lorempixel.com/800/400/nature/Faker/', $imageUrl);
+    }
+
+    public function testImageUrlReturnsLinkToRegularImageWhenGrayIsTrue()
+    {
+        $imageUrl = Image::imageUrl(
+            800,
+            400,
+            'nature',
+            false,
+            'Faker',
+            true
+        );
+
+        $this->assertSame('https://lorempixel.com/gray/800/400/nature/Faker/', $imageUrl);
+    }
+
     public function testImageUrlAddsARandomGetParameterByDefault()
     {
         $url = Image::imageUrl(800, 400);


### PR DESCRIPTION
This PR

* [x] asserts that `Image::imageUrl()` can be used with `$gray` flag and produces different results depending on its value

Somewhat related to #1714.