### PR TITLE
Enhancement: Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+charset = utf-8
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.yml]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 /test/              export-ignore
+/.editorconfig      export-ignore
 /.gitattributes     export-ignore
 /.gitignore         export-ignore
 /.travis.yml        export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,25 +3,25 @@ language: php
 dist: precise
 
 php:
-    - 5.3
-    - 5.4
-    - 5.5
-    - 5.6
-    - 7.0
-    - 7.1
-    - 7.2
-    - 7.3
-    - nightly
+  - 5.3
+  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
+  - nightly
 
 matrix:
-    allow_failures:
-        - nightly
+  allow_failures:
+    - nightly
 
 cache:
   directories:
     - $HOME/.composer/cache
 
 before_script:
-    - travis_retry composer install --no-interaction --prefer-dist
+  - travis_retry composer install --no-interaction --prefer-dist
 
 script: make sniff test


### PR DESCRIPTION
This PR

* [x] adds a basic `.editorconfig` configuration
* [x] consistently indents `.travis.yml` with 2 spaces

💁‍♂ For reference, see https://editorconfig.org.