### PR TITLE
Enhancement: Assert that postcode generated by Austrian Address provider matches format

### DIFF
--- a/test/Faker/Provider/de_AT/AddressTest.php
+++ b/test/Faker/Provider/de_AT/AddressTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Faker\Test\Provider\de_AT;
+
+
+use Faker\Generator;
+use Faker\Provider\de_AT\Address;
+use PHPUnit\Framework\TestCase;
+
+class AddressTest extends TestCase
+{
+    /**
+     * @var Generator
+     */
+    private $faker;
+
+    protected function setUp()
+    {
+        $faker = new Generator();
+
+        $faker->addProvider(new Address($faker));
+
+        $this->faker = $faker;
+    }
+
+    /**
+     * @see https://en.wikipedia.org/wiki/List_of_postal_codes_in_Austria
+     */
+    public function testPostcodeReturnsPostcodeThatMatchesAustrianFormat()
+    {
+        $postcode = $this->faker->postcode;
+
+        $this->assertRegExp('/^[1-9]\d{3}$/', $postcode);
+    }
+}


### PR DESCRIPTION
This PR

* [x] asserts that the `postcode` formatter of the Austrian `Address` provider returns a `string` matching the expected format

Follows #1545.