### PR TITLE
Fix: Literal parentheses not outputting with regexify

### DIFF
--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -486,8 +486,16 @@ class Base
             return str_repeat($matches[1], Base::randomElement(range($matches[2], $matches[3])));
         }, $regex);
         // (this|that) becomes 'this' or 'that'
-        $regex = preg_replace_callback('/\((.*?)\)/', function ($matches) {
-            return Base::randomElement(explode('|', str_replace(array('(', ')'), '', $matches[1])));
+        // \(this|that\) become '\(this\)' or '\(that\)'
+        $regex = preg_replace_callback('/(?<open>\\\?\()(?<content>.*?)(?<close>\\\?\))/', function ($matches) {
+            $content = $matches['content'];
+
+            // Escaped open/close parentheses need to stay
+            if (strpos($matches['open'], '\\') === 0 && strpos($matches['close'], '\\') === 0) {
+                $content = $matches[0];
+            }
+
+            return Base::randomElement(explode('|', $content));
         }, $regex);
         // All A-F inside of [] become ABCDEF
         $regex = preg_replace_callback('/\[([^\]]+)\]/', function ($matches) {

--- a/src/Faker/Provider/fr_FR/PhoneNumber.php
+++ b/src/Faker/Provider/fr_FR/PhoneNumber.php
@@ -116,7 +116,7 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
      */
     public function phoneNumber08WithSeparator()
     {
-        $regex = '([012]{1}\d{1}|(9[1-357-9])( \d{2}){3}';
+        $regex = '([012]{1}\d{1}|9[1-357-9])( \d{2}){3}';
         return $this->regexify($regex);
     }
 

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -633,7 +633,7 @@ class BaseTest extends TestCase
                 'input' => '/\w/'
             ),
             'replace meta sequence with ascii' => array(
-                'expected' => '/[[:alnum:]]/',
+                'expected' => '/[0-9]|[a-z]|[~!"#$%&\'()*+,-.\/:;<=>?@\[\]\\\\^_`]/i',
                 'input' => '/./'
             ),
             'superfluous backslashes should be removed' => array(

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -2,6 +2,7 @@
 
 namespace Faker\Test\Provider;
 
+use Faker\Provider\Base;
 use Faker\Provider\Base as BaseProvider;
 use PHPUnit\Framework\TestCase;
 use Traversable;
@@ -564,6 +565,31 @@ class BaseTest extends TestCase
         $allowDuplicates = BaseProvider::randomElements(array('foo', 'bar'), 3, true);
         $this->assertCount(3, $allowDuplicates);
         $this->assertContainsOnly('string', $allowDuplicates);
+    }
+
+    /**
+     * @dataProvider testRegexifyDataProvider
+     *
+     * @param $expectedRegex
+     * @param $input
+     */
+    public function testRegexify($expectedRegex, $input)
+    {
+        $this->assertRegExp($expectedRegex, BaseProvider::regexify($input));
+    }
+
+    public function testRegexifyDataProvider()
+    {
+        return array(
+            'regex parenthesis should be removed' => array(
+                'expected' => '/this|that/',
+                'input' => '(this|that)'
+            ),
+            'excaped parenthesis should stay' => array(
+                'expected' => '/\(this|that\)/',
+                'input' => '\(this|that\)'
+            )
+        );
     }
 }
 

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -588,6 +588,54 @@ class BaseTest extends TestCase
             'excaped parenthesis should stay' => array(
                 'expected' => '/\(this|that\)/',
                 'input' => '\(this|that\)'
+            ),
+            'anchors should be removed' => array(
+                'expected' => '//',
+                'input' => '/^$/'
+            ),
+            'curly bracket single quantifies should be converted into two digits' => array(
+                'expected' => '/\{2,2\}/',
+                'input' => '/{2}/'
+            ),
+            'single letter quantifier questionmark should be converted' => array(
+                'expected' => '/\{0,1\}/',
+                'input' => '/?/'
+            ),
+            'single letter quantifier asertisk should be converted' => array(
+                'expected' => '/\{0,\d\}/',
+                'input' => '/*/'
+            ),
+            'single letter quantifier plus should be converted' => array(
+                'expected' => '/\{1,\d\}/',
+                'input' => '/+/'
+            ),
+            'quantified character set should be repeated' => array(
+                'expected' => '/1|11|2|22/',
+                'input' => '/[12]{1,2}/'
+            ),
+            'quantified single character or sequence should be repeated' => array(
+                'expected' => '/\d|\d\d/',
+                'input' => '/\d{1,2}/'
+            ),
+            'character sequence should be written out and reduced to a single random character' => array(
+                'expected' => '/A|B|C|D|E|F/',
+                'input' => '/[A-F]/'
+            ),
+            'replace meta sequence with digit' => array(
+                'expected' => '/\d/',
+                'input' => '/\d/'
+            ),
+            'replace meta sequence with letter' => array(
+                'expected' => '/\w/',
+                'input' => '/\w/'
+            ),
+            'replace meta sequence with ascii' => array(
+                'expected' => '/[[:alnum:]]/',
+                'input' => '/./'
+            ),
+            'superfluous backslashes should be removed' => array(
+                'expected' => '//',
+                'input' => '/\\\\\\\\\/'
             )
         );
     }

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -570,8 +570,8 @@ class BaseTest extends TestCase
     /**
      * @dataProvider testRegexifyDataProvider
      *
-     * @param $expectedRegex
-     * @param $input
+     * @param string $expectedRegex
+     * @param string $input
      */
     public function testRegexify($expectedRegex, $input)
     {

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -578,6 +578,9 @@ class BaseTest extends TestCase
         $this->assertRegExp($expectedRegex, BaseProvider::regexify($input));
     }
 
+    /**
+     * @return array
+     */
     public function testRegexifyDataProvider()
     {
         return array(


### PR DESCRIPTION
Should solve #1523 

This improves the grouped regex matching for regexify.
There is now the possibility for the input regex to contain escaped
parentheses which will stay in the final result.