### PR TITLE
FIx: Avoid deprecation warning in newer CakePHP version

### DIFF
--- a/src/Faker/ORM/CakePHP/ColumnTypeGuesser.php
+++ b/src/Faker/ORM/CakePHP/ColumnTypeGuesser.php
@@ -42,7 +42,11 @@ class ColumnTypeGuesser
                     return $generator->uuid();
                 };
             case 'string':
-                $columnData = $schema->column($column);
+                if (method_exists($schema, 'getColumn')) {
+                    $columnData = $schema->getColumn($column);
+                } else {
+                    $columnData = $schema->column($column);
+                }
                 $length = $columnData['length'];
                 return function () use ($generator, $length) {
                     return $generator->text($length);


### PR DESCRIPTION
This will avoid deprecation warnings by accessing `getColumn` if the method exists. Otherwise access the old `column` method.

Solve #1616