### PR TITLE
Added batch inserts for doctrine orm populate

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -409,6 +409,9 @@ Faker provides adapters for Object-Relational and Object-Document Mappers (curre
 
 To populate entities, create a new populator class (using a generator instance as parameter), then list the class and number of all the entities that must be generated. To launch the actual data population, call the `execute()` method.
 
+Note that some of the `populators` could require additional parameters. As example the `doctrine` populator has an option to specify
+its batchSize on how often it will flush the UnitOfWork to the database.
+
 Here is an example showing how to populate 5 `Author` and 10 `Book` objects:
 
 ```php

--- a/readme.md
+++ b/readme.md
@@ -452,6 +452,8 @@ print_r($insertedPKs);
 // )
 ```
 
+**Note:** Due to the fact that `Faker` returns all the primary keys inserted, the memory consumption will go up drastically when you do batch inserts due to the big list of data.
+
 In the previous example, the `Book` and `Author` models share a relationship. Since `Author` entities are populated first, Faker is smart enough to relate the populated `Book` entities to one of the populated `Author` entities.
 
 Lastly, if you want to execute an arbitrary function on an entity before insertion, use the fourth argument of the `addEntity()` method:

--- a/src/Faker/ORM/Doctrine/Populator.php
+++ b/src/Faker/ORM/Doctrine/Populator.php
@@ -3,6 +3,7 @@
 namespace Faker\ORM\Doctrine;
 
 use Doctrine\Common\Persistence\ObjectManager;
+use Faker\Generator;
 
 /**
  * Service class for populating a database using the Doctrine ORM or ODM.
@@ -10,20 +11,35 @@ use Doctrine\Common\Persistence\ObjectManager;
  */
 class Populator
 {
+    /** @var int  */
+    protected $batchSize;
+
+    /** @var Generator  */
     protected $generator;
+
+    /** @var ObjectManager|null  */
     protected $manager;
+
+    /** @var array  */
     protected $entities = array();
+
+    /** @var array  */
     protected $quantities = array();
+
+    /** @var array  */
     protected $generateId = array();
 
     /**
-     * @param \Faker\Generator $generator
+     * Populator constructor.
+     * @param Generator $generator
      * @param ObjectManager|null $manager
+     * @param int $batchSize
      */
-    public function __construct(\Faker\Generator $generator, ObjectManager $manager = null)
+    public function __construct(Generator $generator, ObjectManager $manager = null, $batchSize = 1000)
     {
         $this->generator = $generator;
         $this->manager = $manager;
+        $this->batchSize = $batchSize;
     }
 
     /**
@@ -55,6 +71,9 @@ class Populator
     /**
      * Populate the database using all the Entity classes previously added.
      *
+     * Please note that large amounts of data will result in more memory usage since the the Populator will return
+     * all newly created primary keys after executing.
+     *
      * @param null|EntityManager $entityManager A Doctrine connection object
      *
      * @return array A list of the inserted PKs
@@ -72,9 +91,18 @@ class Populator
         foreach ($this->quantities as $class => $number) {
             $generateId = $this->generateId[$class];
             for ($i=0; $i < $number; $i++) {
-                $insertedEntities[$class][]= $this->entities[$class]->execute($entityManager, $insertedEntities, $generateId);
+                $insertedEntities[$class][]= $this->entities[$class]->execute(
+                    $entityManager,
+                    $insertedEntities,
+                    $generateId
+                );
+                if (count($insertedEntities) % $this->batchSize === 0) {
+                    $entityManager->flush();
+                    $entityManager->clear($class);
+                }
             }
             $entityManager->flush();
+            $entityManager->clear($class);
         }
 
         return $insertedEntities;


### PR DESCRIPTION
Added a counter a batch size to insert in batches instead of all at once on which doctrine orm will block itself due the fact it holds all in memory.

Works fine and it reduces the memory consumption a lot. The smaller the batches the less memory it will consume but will be less fast as well.

Only problem that still remains is the return of the PKs inserted though. I don't think there is a real solution for that when you want to keep track of so much data. Did a test with 100k records for this though meaning it holds 100k PKs in an array.