### PR TITLE
Reword/Feature: Better naming of dateTime relative methods

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -187,10 +187,18 @@ Each of the generator properties (like `name`, `address`, and `lorem`) are calle
     time($format = 'H:i:s', $max = 'now') // '20:49:42'
     dateTimeBetween($startDate = '-30 years', $endDate = 'now', $timezone = null) // DateTime('2003-03-15 02:00:49', 'Africa/Lagos')
     dateTimeInInterval($startDate = '-30 years', $interval = '+ 5 days', $timezone = null) // DateTime('2003-03-15 02:00:49', 'Antartica/Vostok')
-    dateTimeThisCentury($max = 'now', $timezone = null)     // DateTime('1915-05-30 19:28:21', 'UTC')
-    dateTimeThisDecade($max = 'now', $timezone = null)      // DateTime('2007-05-29 22:30:48', 'Europe/Paris')
-    dateTimeThisYear($max = 'now', $timezone = null)        // DateTime('2011-02-27 20:52:14', 'Africa/Lagos')
-    dateTimeThisMonth($max = 'now', $timezone = null)       // DateTime('2011-10-23 13:46:23', 'Antarctica/Vostok')
+    dateTimePastCentury($max = 'now', $timezone = null)     // DateTime('1915-05-30 19:28:21', 'UTC')
+    dateTimePastDecade($max = 'now', $timezone = null)      // DateTime('2007-05-29 22:30:48', 'Europe/Paris')
+    dateTimePastYear($max = 'now', $timezone = null)        // DateTime('2011-02-27 20:52:14', 'Africa/Lagos')
+    dateTimePastMonth($max = 'now', $timezone = null)       // DateTime('2011-10-23 13:46:23', 'Antarctica/Vostok')
+    dateTimeCurrentCentury($max = 'now', $timezone = null)  // DateTime('2000-02-21 12:14:23', 'UTC')
+    dateTimeCurrentDecade($max = 'now', $timezone = null)   // DateTime('2010-03-02 12:14:23', 'Europe/Paris')
+    dateTimeCurrentYear($max = 'now', $timezone = null)     // DateTime('2019-05-30 12:14:23', 'Africa/Lagos')
+    dateTimeCurrentMonth($max = 'now', $timezone = null)    // DateTime('2019-09-01 12:14:23', 'Antarctica/Vostok')
+    dateTimeLastCentury($max = 'now', $timezone = null)     // DateTime('1900-02-21 12:14:23', 'UTC')
+    dateTimeLastDecade($max = 'now', $timezone = null)      // DateTime('2000-03-02 12:14:23', 'Europe/Paris')
+    dateTimeLastYear($max = 'now', $timezone = null)        // DateTime('2018-05-30 12:14:23', 'Africa/Lagos')
+    dateTimeLastMonth($max = 'now', $timezone = null)       // DateTime('2019-08-01 12:14:23', 'Antarctica/Vostok')
     amPm($max = 'now')                    // 'pm'
     dayOfMonth($max = 'now')              // '04'
     dayOfWeek($max = 'now')               // 'Friday'
@@ -199,8 +207,26 @@ Each of the generator properties (like `name`, `address`, and `lorem`) are calle
     year($max = 'now')                    // '1993'
     century                               // 'VI'
     timezone                              // 'Europe/Paris'
-
+    
 Methods accepting a `$timezone` argument default to `date_default_timezone_get()`. You can pass a custom timezone string to each method, or define a custom timezone for all time methods at once using `$faker::setDefaultTimezone($timezone)`.
+    
+#### Naming of relative dateTime methods
+In current state we have `dateTimeThisXXX` which is a misleading name. One would assume that this methods
+will return a calendar accurate datetime but rather it will return a random datetime in the "past" month (`$now - 1 month`).
+
+Assuming the current date is `2019-09-02`. Here is a full list of methods and what you can expect from them:
+- `dateTimePastCentury` datetime between `1919-09-02` and `2019-09-02`
+- `dateTimePastDecade` datetime between `2009-09-02` and `2019-09-02`
+- `dateTimePastYear` datetime between `2018-09-02` and `2019-09-02`
+- `dateTimePastMonth` datetime between `2019-08-02` and `2019-09-02`
+- `dateTimeLastCentury` datetime between `1900-01-01` and `1999-12-31`
+- `dateTimeLastDecade` datetime between `2000-01-01` and `2009-12-31`
+- `dateTimeLastYear` datetime between `2018-01-01` and `2018-12-31`
+- `dateTimeLastMonth` datetime between `2019-08-01` and `2018-08-31`
+- `dateTimeCurrentCentury` datetime between `2000-01-01` and `2019-12-31` (with `$now` as maximum)
+- `dateTimeCurrentDecade` datetime between `2010-01-01` and `2019-12-31` (with `$now` as maximum)
+- `dateTimeCurrentYear` datetime between `2019-01-01` and `2019-12-31` (with `$now` as maximum)
+- `dateTimeCurrentMonth` datetime between `2019-09-01` and `2019-09-30` (with `$now` as maximum)
 
 ### `Faker\Provider\Internet`
 
@@ -571,7 +597,7 @@ $faker = Faker\Factory::create();
   <contact firstName="<?php echo $faker->firstName ?>" lastName="<?php echo $faker->lastName ?>" email="<?php echo $faker->email ?>">
     <phone number="<?php echo $faker->phoneNumber ?>"/>
 <?php if ($faker->boolean(25)): ?>
-    <birth date="<?php echo $faker->dateTimeThisCentury->format('Y-m-d') ?>" place="<?php echo $faker->city ?>"/>
+    <birth date="<?php echo $faker->dateTimePastCentury->format('Y-m-d') ?>" place="<?php echo $faker->city ?>"/>
 <?php endif; ?>
     <address>
       <street><?php echo $faker->streetAddress ?></street>

--- a/readme.md
+++ b/readme.md
@@ -191,14 +191,6 @@ Each of the generator properties (like `name`, `address`, and `lorem`) are calle
     dateTimePastDecade($max = 'now', $timezone = null)      // DateTime('2007-05-29 22:30:48', 'Europe/Paris')
     dateTimePastYear($max = 'now', $timezone = null)        // DateTime('2011-02-27 20:52:14', 'Africa/Lagos')
     dateTimePastMonth($max = 'now', $timezone = null)       // DateTime('2011-10-23 13:46:23', 'Antarctica/Vostok')
-    dateTimeCurrentCentury($max = 'now', $timezone = null)  // DateTime('2000-02-21 12:14:23', 'UTC')
-    dateTimeCurrentDecade($max = 'now', $timezone = null)   // DateTime('2010-03-02 12:14:23', 'Europe/Paris')
-    dateTimeCurrentYear($max = 'now', $timezone = null)     // DateTime('2019-05-30 12:14:23', 'Africa/Lagos')
-    dateTimeCurrentMonth($max = 'now', $timezone = null)    // DateTime('2019-09-01 12:14:23', 'Antarctica/Vostok')
-    dateTimeLastCentury($max = 'now', $timezone = null)     // DateTime('1900-02-21 12:14:23', 'UTC')
-    dateTimeLastDecade($max = 'now', $timezone = null)      // DateTime('2000-03-02 12:14:23', 'Europe/Paris')
-    dateTimeLastYear($max = 'now', $timezone = null)        // DateTime('2018-05-30 12:14:23', 'Africa/Lagos')
-    dateTimeLastMonth($max = 'now', $timezone = null)       // DateTime('2019-08-01 12:14:23', 'Antarctica/Vostok')
     amPm($max = 'now')                    // 'pm'
     dayOfMonth($max = 'now')              // '04'
     dayOfWeek($max = 'now')               // 'Friday'

--- a/src/Faker/Provider/DateTime.php
+++ b/src/Faker/Provider/DateTime.php
@@ -236,7 +236,7 @@ class DateTime extends Base
      * @example DateTime('1964-04-04 11:02:02')
      * @return \DateTime
      */
-    public static function dateTImePastCentury($max = 'now', $timezone = null)
+    public static function dateTimePastCentury($max = 'now', $timezone = null)
     {
         return static::dateTimeBetween('-100 year', $max, $timezone);
     }

--- a/src/Faker/Provider/DateTime.php
+++ b/src/Faker/Provider/DateTime.php
@@ -177,10 +177,13 @@ class DateTime extends Base
      * @param string|null $timezone time zone in which the date time should be set, default to DateTime::$defaultTimezone, if set, otherwise the result of `date_default_timezone_get`
      * @example DateTime('1964-04-04 11:02:02')
      * @return \DateTime
+     *
+     * @deprecated use dateTimePastCentury - The naming of this method is misleading since "this century" does not
+     *             point to the past century but rather to a random between 100 years ago and $now.
      */
     public static function dateTimeThisCentury($max = 'now', $timezone = null)
     {
-        return static::dateTimeBetween('-100 year', $max, $timezone);
+        return static::dateTImePastCentury($max, $timezone);
     }
 
     /**
@@ -188,10 +191,13 @@ class DateTime extends Base
      * @param string|null $timezone time zone in which the date time should be set, default to DateTime::$defaultTimezone, if set, otherwise the result of `date_default_timezone_get`
      * @example DateTime('2010-03-10 05:18:58')
      * @return \DateTime
+     *
+     * @deprecated use dateTimePastDecade - The naming of this method is misleading since "this decade" does not
+     *             point to the past decade but rather to a random between 10 years ago and $now.
      */
     public static function dateTimeThisDecade($max = 'now', $timezone = null)
     {
-        return static::dateTimeBetween('-10 year', $max, $timezone);
+        return static::dateTimePastDecade($max, $timezone);
     }
 
     /**
@@ -199,10 +205,13 @@ class DateTime extends Base
      * @param string|null $timezone time zone in which the date time should be set, default to DateTime::$defaultTimezone, if set, otherwise the result of `date_default_timezone_get`
      * @example DateTime('2011-09-19 09:24:37')
      * @return \DateTime
+     *
+     * @deprecated use dateTimePastYear - The naming of this method is misleading since "this year" does not point
+     *             on current calendar year but rather to a random between 1 year ago and $now.
      */
     public static function dateTimeThisYear($max = 'now', $timezone = null)
     {
-        return static::dateTimeBetween('-1 year', $max, $timezone);
+        return static::dateTimePastYear($max, $timezone);
     }
 
     /**
@@ -210,8 +219,63 @@ class DateTime extends Base
      * @param string|null $timezone time zone in which the date time should be set, default to DateTime::$defaultTimezone, if set, otherwise the result of `date_default_timezone_get`
      * @example DateTime('2011-10-05 12:51:46')
      * @return \DateTime
+     *
+     * @deprecated use dateTimePastMonth - The naming of this method is misleading since "this month" does not point
+     *             on current calendar month but rather to a random between 1 month ago and $now.
      */
     public static function dateTimeThisMonth($max = 'now', $timezone = null)
+    {
+        return static::dateTimePastMonth($max, $timezone);
+    }
+
+    /**
+     * Generate a random datetime from up to a hundred years ago
+     *
+     * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
+     * @param string|null $timezone time zone in which the date time should be set, default to DateTime::$defaultTimezone, if set, otherwise the result of `date_default_timezone_get`
+     * @example DateTime('1964-04-04 11:02:02')
+     * @return \DateTime
+     */
+    public static function dateTImePastCentury($max = 'now', $timezone = null)
+    {
+        return static::dateTimeBetween('-100 year', $max, $timezone);
+    }
+
+    /**
+     * Generate a random datetime from up to ten years ago
+     *
+     * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
+     * @param string|null $timezone time zone in which the date time should be set, default to DateTime::$defaultTimezone, if set, otherwise the result of `date_default_timezone_get`
+     * @example DateTime('2010-03-10 05:18:58')
+     * @return \DateTime
+     */
+    public static function dateTimePastDecade($max = 'now', $timezone = null)
+    {
+        return static::dateTimeBetween('-10 year', $max, $timezone);
+    }
+
+    /**
+     * Generate a random datetime from up to one year ago
+     *
+     * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
+     * @param string|null $timezone time zone in which the date time should be set, default to DateTime::$defaultTimezone, if set, otherwise the result of `date_default_timezone_get`
+     * @example DateTime('2011-09-19 09:24:37')
+     * @return \DateTime
+     */
+    public static function dateTimePastYear($max = 'now', $timezone = null)
+    {
+        return static::dateTimeBetween('-1 year', $max, $timezone);
+    }
+
+    /**
+     * Generate a random datetime from up to one month ago
+     *
+     * @param \DateTime|int|string $max maximum timestamp used as random end limit, default to "now"
+     * @param string|null $timezone time zone in which the date time should be set, default to DateTime::$defaultTimezone, if set, otherwise the result of `date_default_timezone_get`
+     * @example DateTime('2011-10-05 12:51:46')
+     * @return \DateTime
+     */
+    public static function dateTimePastMonth($max = 'now', $timezone = null)
     {
         return static::dateTimeBetween('-1 month', $max, $timezone);
     }

--- a/src/Faker/Provider/DateTime.php
+++ b/src/Faker/Provider/DateTime.php
@@ -183,7 +183,7 @@ class DateTime extends Base
      */
     public static function dateTimeThisCentury($max = 'now', $timezone = null)
     {
-        return static::dateTImePastCentury($max, $timezone);
+        return static::dateTimePastCentury($max, $timezone);
     }
 
     /**

--- a/test/Faker/Provider/DateTimeTest.php
+++ b/test/Faker/Provider/DateTimeTest.php
@@ -100,63 +100,63 @@ class DateTimeTest extends TestCase
         $this->assertEquals(new \DateTimeZone($this->defaultTz), $date->getTimezone());
     }
 
-    public function testDateTimeThisCentury()
+    public function testDateTimePastCentury()
     {
-        $date = DateTimeProvider::dateTimeThisCentury();
+        $date = DateTimeProvider::dateTimePastCentury();
         $this->assertInstanceOf('\DateTime', $date);
         $this->assertGreaterThanOrEqual(new \DateTime('-100 year'), $date);
         $this->assertLessThanOrEqual(new \DateTime(), $date);
         $this->assertEquals(new \DateTimeZone($this->defaultTz), $date->getTimezone());
     }
 
-    public function testDateTimeThisDecade()
+    public function testDateTimePastDecade()
     {
-        $date = DateTimeProvider::dateTimeThisDecade();
+        $date = DateTimeProvider::dateTimePastDecade();
         $this->assertInstanceOf('\DateTime', $date);
         $this->assertGreaterThanOrEqual(new \DateTime('-10 year'), $date);
         $this->assertLessThanOrEqual(new \DateTime(), $date);
         $this->assertEquals(new \DateTimeZone($this->defaultTz), $date->getTimezone());
     }
 
-    public function testDateTimeThisYear()
+    public function testDateTimePastYear()
     {
-        $date = DateTimeProvider::dateTimeThisYear();
+        $date = DateTimeProvider::dateTimePastYear();
         $this->assertInstanceOf('\DateTime', $date);
         $this->assertGreaterThanOrEqual(new \DateTime('-1 year'), $date);
         $this->assertLessThanOrEqual(new \DateTime(), $date);
         $this->assertEquals(new \DateTimeZone($this->defaultTz), $date->getTimezone());
     }
 
-    public function testDateTimeThisMonth()
+    public function testDateTimePastMonth()
     {
-        $date = DateTimeProvider::dateTimeThisMonth();
+        $date = DateTimeProvider::dateTimePastMonth();
         $this->assertInstanceOf('\DateTime', $date);
         $this->assertGreaterThanOrEqual(new \DateTime('-1 month'), $date);
         $this->assertLessThanOrEqual(new \DateTime(), $date);
         $this->assertEquals(new \DateTimeZone($this->defaultTz), $date->getTimezone());
     }
 
-    public function testDateTimeThisCenturyWithTimezone()
+    public function testDateTimePastCenturyWithTimezone()
     {
-        $date = DateTimeProvider::dateTimeThisCentury('now', 'America/New_York');
+        $date = DateTimeProvider::dateTimePastCentury('now', 'America/New_York');
         $this->assertEquals($date->getTimezone(), new \DateTimeZone('America/New_York'));
     }
 
-    public function testDateTimeThisDecadeWithTimezone()
+    public function testDateTimePastDecadeWithTimezone()
     {
-        $date = DateTimeProvider::dateTimeThisDecade('now', 'America/New_York');
+        $date = DateTimeProvider::dateTimePastDecade('now', 'America/New_York');
         $this->assertEquals($date->getTimezone(), new \DateTimeZone('America/New_York'));
     }
 
-    public function testDateTimeThisYearWithTimezone()
+    public function testDateTimePastYearWithTimezone()
     {
-        $date = DateTimeProvider::dateTimeThisYear('now', 'America/New_York');
+        $date = DateTimeProvider::dateTimePastYear('now', 'America/New_York');
         $this->assertEquals($date->getTimezone(), new \DateTimeZone('America/New_York'));
     }
 
-    public function testDateTimeThisMonthWithTimezone()
+    public function testDateTimePastMonthWithTimezone()
     {
-        $date = DateTimeProvider::dateTimeThisMonth('now', 'America/New_York');
+        $date = DateTimeProvider::dateTimePastMonth('now', 'America/New_York');
         $this->assertEquals($date->getTimezone(), new \DateTimeZone('America/New_York'));
     }
 


### PR DESCRIPTION
This PR will address #1165 where we want to address a better naming for dateTime relative methods.

`dateTimeThisMonth` (and sorts) seems misleading as it pretends to return a value from *the current month* which is does not. With these changes we want to clarify by which method the user can expect the correct return value.

### Open discussion
This PR should also be used as an open discussion if we even should add the new methods, or simply clarify the naming of the old ones. This is why this PR does not yet contain the implementation of the new methods. If we agree upon adding the new methods I will add the implementation.

### The full feature list

Assuming the current date is `2019-09-02`. Here is a full list of methods and what you can expect from them:
- `dateTimePastCentury` datetime between `1919-09-02` and `2019-09-02`
- `dateTimePastDecade` datetime between `2009-09-02` and `2019-09-02`
- `dateTimePastYear` datetime between `2018-09-02` and `2019-09-02`
- `dateTimePastMonth` datetime between `2019-08-02` and `2019-09-02`
- `dateTimeLastCentury` datetime between `1900-01-01` and `1999-12-31`
- `dateTimeLastDecade` datetime between `2000-01-01` and `2009-12-31`
- `dateTimeLastYear` datetime between `2018-01-01` and `2018-12-31`
- `dateTimeLastMonth` datetime between `2019-08-01` and `2018-08-31`
- `dateTimeCurrentCentury` datetime between `2000-01-01` and `2019-12-31` (with `$now` as maximum)
- `dateTimeCurrentDecade` datetime between `2010-01-01` and `2019-12-31` (with `$now` as maximum)
- `dateTimeCurrentYear` datetime between `2019-01-01` and `2019-12-31` (with `$now` as maximum)
- `dateTimeCurrentMonth` datetime between `2019-09-01` and `2019-09-30` (with `$now` as maximum)