### PR TITLE
Improve en_US area code generation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -119,6 +119,7 @@ Each of the generator properties (like `name`, `address`, and `lorem`) are calle
 
     randomDigit             // 7
     randomDigitNot(5)       // 0, 1, 2, 3, 4, 6, 7, 8, or 9
+    randomDigitNotIn(array(0, 2, 4, 6, 8)) // 1, 3, 5, 7 or 9
     randomDigitNotNull      // 5
     randomNumber($nbDigits = NULL, $strict = false) // 79907610
     randomFloat($nbMaxDecimals = NULL, $min = 0, $max = NULL) // 48.8932

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -137,6 +137,7 @@ namespace Faker;
  *
  * @property int    $randomDigit
  * @property int    $randomDigitNot
+ * @property int    $randomDigitNotIn
  * @property int    $randomDigitNotNull
  * @property string $randomLetter
  * @property string $randomAscii

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -63,6 +63,24 @@ class Base
     }
 
     /**
+     * Generates a random digit, which cannot be in $except
+     *
+     * @param array|int $except
+     * @return int
+     */
+    public static function randomDigitNotIn($except)
+    {
+        $digits = array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+        $pool = array_diff($digits, (array) $except);
+        if (!$pool) {
+            throw new \InvalidArgumentException('The argument is inclusive of the digits 0 to 9. A digit cannot be returned.');
+        }
+        $key = array_rand($pool);
+
+        return $pool[$key];
+    }
+
+    /**
      * Returns a random integer with 0 to $nbDigits digits.
      *
      * The maximum value returned is mt_getrandmax()

--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -75,7 +75,7 @@ class Base
         if (!$pool) {
             throw new \InvalidArgumentException('The argument is inclusive of the digits 0 to 9. A digit cannot be returned.');
         }
-        $key = array_rand($pool);
+        $key = self::randomElement($pool);
 
         return $pool[$key];
     }

--- a/src/Faker/Provider/en_US/PhoneNumber.php
+++ b/src/Faker/Provider/en_US/PhoneNumber.php
@@ -72,17 +72,23 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     /**
      * NPA-format area code
      *
-     * @see https://en.wikipedia.org/wiki/North_American_Numbering_Plan#Numbering_system
+     * @see https://www.nationalnanpa.com/area_codes/index.html
      *
      * @return string
      */
     public static function areaCode()
     {
         $digits[] = self::numberBetween(2, 9);
-        $digits[] = self::randomDigit();
+        $digits[] = self::randomDigitNot(9);
+        if ($digits[0] === 3) {
+            $digits[1] = self::randomDigitNotIn(array(7, 9));
+        }
+        if ($digits[0] === 9) {
+            $digits[1] = self::randomDigitNotIn(array(6, 9));
+        }
         $digits[] = self::randomDigitNot($digits[1]);
 
-        return join('', $digits);
+        return implode('', $digits);
     }
 
     /**

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -35,6 +35,41 @@ class BaseTest extends TestCase
         }
     }
 
+    public function testRandomDigitNotInReturnsValidDigit()
+    {
+        for ($i = 0; $i <= 9; $i++) {
+            $this->assertGreaterThanOrEqual(0, BaseProvider::randomDigitNotIn($i));
+            $this->assertLessThan(10, BaseProvider::randomDigitNotIn($i));
+            $this->assertNotSame(BaseProvider::randomDigitNotIn($i), $i);
+        }
+
+        $array = array();
+        $this->assertGreaterThanOrEqual(0, BaseProvider::randomDigitNotIn($array));
+        $this->assertLessThan(10, BaseProvider::randomDigitNotIn($array));
+
+        $array = array(1, 3, 5, 7, 9);
+        $this->assertNotEquals(1, BaseProvider::randomDigitNotIn($array));
+        $this->assertNotEquals(3, BaseProvider::randomDigitNotIn($array));
+        $this->assertNotEquals(5, BaseProvider::randomDigitNotIn($array));
+        $this->assertNotEquals(7, BaseProvider::randomDigitNotIn($array));
+        $this->assertNotEquals(9, BaseProvider::randomDigitNotIn($array));
+
+        $array = array(0, 2, 4, 6, 8);
+        $this->assertNotEquals(0, BaseProvider::randomDigitNotIn($array));
+        $this->assertNotEquals(2, BaseProvider::randomDigitNotIn($array));
+        $this->assertNotEquals(4, BaseProvider::randomDigitNotIn($array));
+        $this->assertNotEquals(6, BaseProvider::randomDigitNotIn($array));
+        $this->assertNotEquals(8, BaseProvider::randomDigitNotIn($array));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testRandomDigitNotInThrowsExceptionWhenCalledWithInclusiveArray()
+    {
+        BaseProvider::randomDigitNotIn(array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9));
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      */

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -38,28 +38,29 @@ class BaseTest extends TestCase
     public function testRandomDigitNotInReturnsValidDigit()
     {
         for ($i = 0; $i <= 9; $i++) {
-            $this->assertGreaterThanOrEqual(0, BaseProvider::randomDigitNotIn($i));
-            $this->assertLessThan(10, BaseProvider::randomDigitNotIn($i));
-            $this->assertNotSame(BaseProvider::randomDigitNotIn($i), $i);
+            $digit = BaseProvider::randomDigitNotIn($i);
+            $this->assertGreaterThanOrEqual(0, $digit);
+            $this->assertLessThan(10, $digit);
+            $this->assertNotSame($digit, $i);
         }
 
         $array = array();
         $this->assertGreaterThanOrEqual(0, BaseProvider::randomDigitNotIn($array));
         $this->assertLessThan(10, BaseProvider::randomDigitNotIn($array));
 
-        $array = array(1, 3, 5, 7, 9);
-        $this->assertNotEquals(1, BaseProvider::randomDigitNotIn($array));
-        $this->assertNotEquals(3, BaseProvider::randomDigitNotIn($array));
-        $this->assertNotEquals(5, BaseProvider::randomDigitNotIn($array));
-        $this->assertNotEquals(7, BaseProvider::randomDigitNotIn($array));
-        $this->assertNotEquals(9, BaseProvider::randomDigitNotIn($array));
+        $digit = BaseProvider::randomDigitNotIn(array(1, 3, 5, 7, 9));
+        $this->assertNotEquals(1, $digit);
+        $this->assertNotEquals(3, $digit);
+        $this->assertNotEquals(5, $digit);
+        $this->assertNotEquals(7, $digit);
+        $this->assertNotEquals(9, $digit);
 
-        $array = array(0, 2, 4, 6, 8);
-        $this->assertNotEquals(0, BaseProvider::randomDigitNotIn($array));
-        $this->assertNotEquals(2, BaseProvider::randomDigitNotIn($array));
-        $this->assertNotEquals(4, BaseProvider::randomDigitNotIn($array));
-        $this->assertNotEquals(6, BaseProvider::randomDigitNotIn($array));
-        $this->assertNotEquals(8, BaseProvider::randomDigitNotIn($array));
+        $digit = BaseProvider::randomDigitNotIn(array(0, 2, 4, 6, 8));
+        $this->assertNotEquals(0, $digit);
+        $this->assertNotEquals(2, $digit);
+        $this->assertNotEquals(4, $digit);
+        $this->assertNotEquals(6, $digit);
+        $this->assertNotEquals(8, $digit);
     }
 
     /**

--- a/test/Faker/Provider/en_US/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_US/PhoneNumberTest.php
@@ -40,6 +40,15 @@ class PhoneNumberTest extends TestCase
             // Last two digits of area code cannot be identical
             $this->assertNotEquals($digits[1], $digits[2]);
 
+            // Second digit of area code cannot be 9
+            $this->assertNotEquals($digits[1], 9);
+
+            // First two digits of area code cannot be 37
+            $this->assertNotEquals(implode('', array($digits[0], $digits[1])), 37);
+
+            // First two digits of area code cannot be 96
+            $this->assertNotEquals(implode('', array($digits[0], $digits[1])), 96);
+
             // Last two digits of exchange code cannot be 1
             if ($digits[4] === 1) {
                 $this->assertNotEquals($digits[4], $digits[5]);


### PR DESCRIPTION
The existing PhoneNumber provider does not fully implement the [NANP rules for area codes](https://www.nationalnanpa.com/area_codes/index.html). This can be problematic when running generated phone numbers against validation.

In concert with implementing the full NANP rules, this PR adds a new formatter: randomDigitNotIn(). The formatter is used here because the first and second digits of the area code cannot be 37 or 96. Since the formatter accepts an integer or array, it's convenient to pass [3, 7] or [9, 6] to get a digit exclusive of the passed digits.

This is a resubmission of https://github.com/fzaninotto/Faker/pull/1473 which I closed asmy rebase did not not go smoothly. Sorry. 
