### PR TITLE
Fix: Mark test classes as final

### DIFF
--- a/test/Faker/Calculator/EanTest.php
+++ b/test/Faker/Calculator/EanTest.php
@@ -7,7 +7,7 @@ namespace Faker\Test\Calculator;
 use Faker\Calculator\Ean;
 use PHPUnit\Framework\TestCase;
 
-class EanTest extends TestCase
+final class EanTest extends TestCase
 {
     public function Ean8checksumProvider()
     {

--- a/test/Faker/Calculator/IbanTest.php
+++ b/test/Faker/Calculator/IbanTest.php
@@ -5,7 +5,7 @@ namespace Faker\Test\Calculator;
 use Faker\Calculator\Iban;
 use PHPUnit\Framework\TestCase;
 
-class IbanTest extends TestCase
+final class IbanTest extends TestCase
 {
 
     public function checksumProvider()

--- a/test/Faker/Calculator/InnTest.php
+++ b/test/Faker/Calculator/InnTest.php
@@ -5,7 +5,7 @@ namespace Faker\Test\Calculator;
 use Faker\Calculator\Inn;
 use PHPUnit\Framework\TestCase;
 
-class InnTest extends TestCase
+final class InnTest extends TestCase
 {
 
     public function checksumProvider()

--- a/test/Faker/Calculator/LuhnTest.php
+++ b/test/Faker/Calculator/LuhnTest.php
@@ -5,7 +5,7 @@ namespace Faker\Test\Calculator;
 use Faker\Calculator\Luhn;
 use PHPUnit\Framework\TestCase;
 
-class LuhnTest extends TestCase
+final class LuhnTest extends TestCase
 {
 
     public function checkDigitProvider()

--- a/test/Faker/Calculator/TCNoTest.php
+++ b/test/Faker/Calculator/TCNoTest.php
@@ -5,7 +5,7 @@ namespace Faker\Test\Calculator;
 use Faker\Calculator\TCNo;
 use PHPUnit\Framework\TestCase;
 
-class TCNoTest extends TestCase
+final class TCNoTest extends TestCase
 {
     public function checksumProvider()
     {

--- a/test/Faker/DefaultGeneratorTest.php
+++ b/test/Faker/DefaultGeneratorTest.php
@@ -5,7 +5,7 @@ namespace Faker\Test;
 use Faker\DefaultGenerator;
 use PHPUnit\Framework\TestCase;
 
-class DefaultGeneratorTest extends TestCase
+final class DefaultGeneratorTest extends TestCase
 {
     public function testGeneratorReturnsNullByDefault()
     {

--- a/test/Faker/GeneratorTest.php
+++ b/test/Faker/GeneratorTest.php
@@ -5,7 +5,7 @@ namespace Faker\Test;
 use Faker\Generator;
 use PHPUnit\Framework\TestCase;
 
-class GeneratorTest extends TestCase
+final class GeneratorTest extends TestCase
 {
     public function testAddProviderGivesPriorityToNewlyAddedProvider()
     {
@@ -126,7 +126,7 @@ class GeneratorTest extends TestCase
     }
 }
 
-class FooProvider
+final class FooProvider
 {
     public function fooFormatter()
     {
@@ -139,7 +139,7 @@ class FooProvider
     }
 }
 
-class BarProvider
+final class BarProvider
 {
     public function fooFormatter()
     {

--- a/test/Faker/Provider/AddressTest.php
+++ b/test/Faker/Provider/AddressTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\Address;
 use PHPUnit\Framework\TestCase;
 
-class AddressTest extends TestCase
+final class AddressTest extends TestCase
 {
     private $faker;
 

--- a/test/Faker/Provider/BarcodeTest.php
+++ b/test/Faker/Provider/BarcodeTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\Barcode;
 use PHPUnit\Framework\TestCase;
 
-class BarcodeTest extends TestCase
+final class BarcodeTest extends TestCase
 {
     private $faker;
 
@@ -37,7 +37,7 @@ class BarcodeTest extends TestCase
     }
 }
 
-class TestableBarcode extends Barcode
+final class TestableBarcode extends Barcode
 {
     public static function eanChecksum($input)
     {

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -6,7 +6,7 @@ use Faker\Provider\Base as BaseProvider;
 use PHPUnit\Framework\TestCase;
 use Traversable;
 
-class BaseTest extends TestCase
+final class BaseTest extends TestCase
 {
     public function testRandomDigitReturnsInteger()
     {
@@ -567,6 +567,6 @@ class BaseTest extends TestCase
     }
 }
 
-class Collection extends \ArrayObject
+final class Collection extends \ArrayObject
 {
 }

--- a/test/Faker/Provider/BiasedTest.php
+++ b/test/Faker/Provider/BiasedTest.php
@@ -5,7 +5,7 @@ use Faker\Provider\Biased;
 use Faker\Generator;
 use PHPUnit\Framework\TestCase;
 
-class BiasedTest extends TestCase
+final class BiasedTest extends TestCase
 {
     const MAX = 10;
     const NUMBERS = 25000;

--- a/test/Faker/Provider/ColorTest.php
+++ b/test/Faker/Provider/ColorTest.php
@@ -5,7 +5,7 @@ namespace Faker\Test\Provider;
 use Faker\Provider\Color;
 use PHPUnit\Framework\TestCase;
 
-class ColorTest extends TestCase
+final class ColorTest extends TestCase
 {
 
     public function testHexColor()

--- a/test/Faker/Provider/CompanyTest.php
+++ b/test/Faker/Provider/CompanyTest.php
@@ -7,7 +7,7 @@ use Faker\Provider\Company;
 use Faker\Provider\Lorem;
 use PHPUnit\Framework\TestCase;
 
-class CompanyTest extends TestCase
+final class CompanyTest extends TestCase
 {
     /**
      * @var Generator

--- a/test/Faker/Provider/DateTimeTest.php
+++ b/test/Faker/Provider/DateTimeTest.php
@@ -5,7 +5,7 @@ namespace Faker\Test\Provider;
 use Faker\Provider\DateTime as DateTimeProvider;
 use PHPUnit\Framework\TestCase;
 
-class DateTimeTest extends TestCase
+final class DateTimeTest extends TestCase
 {
     public function setUp()
     {

--- a/test/Faker/Provider/HtmlLoremTest.php
+++ b/test/Faker/Provider/HtmlLoremTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\HtmlLorem;
 use PHPUnit\Framework\TestCase;
 
-class HtmlLoremTest extends TestCase
+final class HtmlLoremTest extends TestCase
 {
 
     public function testProvider()

--- a/test/Faker/Provider/ImageTest.php
+++ b/test/Faker/Provider/ImageTest.php
@@ -5,7 +5,7 @@ namespace Faker\Test\Provider;
 use Faker\Provider\Image;
 use PHPUnit\Framework\TestCase;
 
-class ImageTest extends TestCase
+final class ImageTest extends TestCase
 {
     public function testImageUrlUses640x680AsTheDefaultSize()
     {

--- a/test/Faker/Provider/InternetTest.php
+++ b/test/Faker/Provider/InternetTest.php
@@ -9,7 +9,7 @@ use Faker\Provider\Lorem;
 use Faker\Provider\Person;
 use PHPUnit\Framework\TestCase;
 
-class InternetTest extends TestCase
+final class InternetTest extends TestCase
 {
     /**
      * @var Generator

--- a/test/Faker/Provider/LocalizationTest.php
+++ b/test/Faker/Provider/LocalizationTest.php
@@ -5,7 +5,7 @@ namespace Faker\Test\Provider;
 use Faker\Factory;
 use PHPUnit\Framework\TestCase;
 
-class LocalizationTest extends TestCase
+final class LocalizationTest extends TestCase
 {
     public function testLocalizedNameProvidersDoNotThrowErrors()
     {

--- a/test/Faker/Provider/LoremTest.php
+++ b/test/Faker/Provider/LoremTest.php
@@ -5,7 +5,7 @@ namespace Faker\Test\Provider;
 use Faker\Provider\Lorem;
 use PHPUnit\Framework\TestCase;
 
-class LoremTest extends TestCase
+final class LoremTest extends TestCase
 {
     /**
      * @expectedException \InvalidArgumentException
@@ -89,7 +89,7 @@ class LoremTest extends TestCase
     }
 }
 
-class TestableLorem extends Lorem
+final class TestableLorem extends Lorem
 {
 
     public static function word()

--- a/test/Faker/Provider/MiscellaneousTest.php
+++ b/test/Faker/Provider/MiscellaneousTest.php
@@ -5,7 +5,7 @@ namespace Faker\Test\Provider;
 use Faker\Provider\Miscellaneous;
 use PHPUnit\Framework\TestCase;
 
-class MiscellaneousTest extends TestCase
+final class MiscellaneousTest extends TestCase
 {
     public function testBoolean()
     {

--- a/test/Faker/Provider/PaymentTest.php
+++ b/test/Faker/Provider/PaymentTest.php
@@ -11,7 +11,7 @@ use Faker\Provider\Payment as PaymentProvider;
 use Faker\Provider\Person as PersonProvider;
 use PHPUnit\Framework\TestCase;
 
-class PaymentTest extends TestCase
+final class PaymentTest extends TestCase
 {
     private $faker;
 

--- a/test/Faker/Provider/PersonTest.php
+++ b/test/Faker/Provider/PersonTest.php
@@ -6,7 +6,7 @@ use Faker\Provider\Person;
 use Faker\Generator;
 use PHPUnit\Framework\TestCase;
 
-class PersonTest extends TestCase
+final class PersonTest extends TestCase
 {
     /**
      * @dataProvider firstNameProvider

--- a/test/Faker/Provider/PhoneNumberTest.php
+++ b/test/Faker/Provider/PhoneNumberTest.php
@@ -7,7 +7,7 @@ use Faker\Calculator\Luhn;
 use Faker\Provider\PhoneNumber;
 use PHPUnit\Framework\TestCase;
 
-class PhoneNumberTest extends TestCase
+final class PhoneNumberTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/ProviderOverrideTest.php
+++ b/test/Faker/Provider/ProviderOverrideTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
  * locale specific provider (can) has specific implementations. The goal of this test is to test the common denominator
  * and to try to catch possible invalid multi-byte sequences.
  */
-class ProviderOverrideTest extends TestCase
+final class ProviderOverrideTest extends TestCase
 {
     /**
      * Constants with regular expression patterns for testing the output.

--- a/test/Faker/Provider/TextTest.php
+++ b/test/Faker/Provider/TextTest.php
@@ -5,7 +5,7 @@ use Faker\Provider\en_US\Text;
 use Faker\Generator;
 use PHPUnit\Framework\TestCase;
 
-class TextTest extends TestCase
+final class TextTest extends TestCase
 {
     /**
      * @var Generator

--- a/test/Faker/Provider/UserAgentTest.php
+++ b/test/Faker/Provider/UserAgentTest.php
@@ -5,7 +5,7 @@ namespace Faker\Test\Provider;
 use Faker\Provider\UserAgent;
 use PHPUnit\Framework\TestCase;
 
-class UserAgentTest extends TestCase
+final class UserAgentTest extends TestCase
 {
     public function testRandomUserAgent()
     {

--- a/test/Faker/Provider/UuidTest.php
+++ b/test/Faker/Provider/UuidTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\Uuid as BaseProvider;
 use PHPUnit\Framework\TestCase;
 
-class UuidTest extends TestCase
+final class UuidTest extends TestCase
 {
     public function testUuidReturnsUuid()
     {

--- a/test/Faker/Provider/ar_JO/InternetTest.php
+++ b/test/Faker/Provider/ar_JO/InternetTest.php
@@ -8,7 +8,7 @@ use Faker\Provider\fi_FI\Internet;
 use Faker\Provider\fi_FI\Company;
 use PHPUnit\Framework\TestCase;
 
-class InternetTest extends TestCase
+final class InternetTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/ar_SA/InternetTest.php
+++ b/test/Faker/Provider/ar_SA/InternetTest.php
@@ -8,7 +8,7 @@ use Faker\Provider\ar_SA\Internet;
 use Faker\Provider\ar_SA\Company;
 use PHPUnit\Framework\TestCase;
 
-class InternetTest extends TestCase
+final class InternetTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/at_AT/PaymentTest.php
+++ b/test/Faker/Provider/at_AT/PaymentTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\at_AT\Payment;
 use PHPUnit\Framework\TestCase;
 
-class PaymentTest extends TestCase
+final class PaymentTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/bg_BG/PaymentTest.php
+++ b/test/Faker/Provider/bg_BG/PaymentTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\bg_BG\Payment;
 use PHPUnit\Framework\TestCase;
 
-class PaymentTest extends TestCase
+final class PaymentTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/bn_BD/PersonTest.php
+++ b/test/Faker/Provider/bn_BD/PersonTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\bn_BD\Person;
 use PHPUnit\Framework\TestCase;
 
-class PersonTest extends TestCase
+final class PersonTest extends TestCase
 {
     public function setUp()
     {

--- a/test/Faker/Provider/cs_CZ/PersonTest.php
+++ b/test/Faker/Provider/cs_CZ/PersonTest.php
@@ -7,7 +7,7 @@ use Faker\Provider\cs_CZ\Person;
 use Faker\Provider\Miscellaneous;
 use PHPUnit\Framework\TestCase;
 
-class PersonTest extends TestCase
+final class PersonTest extends TestCase
 {
     public function testBirthNumber()
     {

--- a/test/Faker/Provider/da_DK/InternetTest.php
+++ b/test/Faker/Provider/da_DK/InternetTest.php
@@ -8,7 +8,7 @@ use Faker\Provider\da_DK\Internet;
 use Faker\Provider\da_DK\Company;
 use PHPUnit\Framework\TestCase;
 
-class InternetTest extends TestCase
+final class InternetTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/de_AT/AddressTest.php
+++ b/test/Faker/Provider/de_AT/AddressTest.php
@@ -7,7 +7,7 @@ use Faker\Generator;
 use Faker\Provider\de_AT\Address;
 use PHPUnit\Framework\TestCase;
 
-class AddressTest extends TestCase
+final class AddressTest extends TestCase
 {
     /**
      * @var Generator

--- a/test/Faker/Provider/de_AT/InternetTest.php
+++ b/test/Faker/Provider/de_AT/InternetTest.php
@@ -8,7 +8,7 @@ use Faker\Provider\de_AT\Internet;
 use Faker\Provider\de_AT\Company;
 use PHPUnit\Framework\TestCase;
 
-class InternetTest extends TestCase
+final class InternetTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/de_AT/PhoneNumberTest.php
+++ b/test/Faker/Provider/de_AT/PhoneNumberTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\de_AT\PhoneNumber;
 use PHPUnit\Framework\TestCase;
 
-class PhoneNumberTest extends TestCase
+final class PhoneNumberTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/de_CH/AddressTest.php
+++ b/test/Faker/Provider/de_CH/AddressTest.php
@@ -7,7 +7,7 @@ use Faker\Provider\de_CH\Address;
 use Faker\Provider\de_CH\Person;
 use PHPUnit\Framework\TestCase;
 
-class AddressTest extends TestCase
+final class AddressTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/de_CH/InternetTest.php
+++ b/test/Faker/Provider/de_CH/InternetTest.php
@@ -8,7 +8,7 @@ use Faker\Provider\de_CH\Internet;
 use Faker\Provider\de_CH\Company;
 use PHPUnit\Framework\TestCase;
 
-class InternetTest extends TestCase
+final class InternetTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/de_CH/PersonTest.php
+++ b/test/Faker/Provider/de_CH/PersonTest.php
@@ -7,7 +7,7 @@ use Faker\Generator;
 use Faker\Provider\de_CH\Person;
 use PHPUnit\Framework\TestCase;
 
-class PersonTest extends TestCase
+final class PersonTest extends TestCase
 {
     private $faker;
 

--- a/test/Faker/Provider/de_CH/PhoneNumberTest.php
+++ b/test/Faker/Provider/de_CH/PhoneNumberTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\de_CH\PhoneNumber;
 use PHPUnit\Framework\TestCase;
 
-class PhoneNumberTest extends TestCase
+final class PhoneNumberTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/de_DE/InternetTest.php
+++ b/test/Faker/Provider/de_DE/InternetTest.php
@@ -8,7 +8,7 @@ use Faker\Provider\de_DE\Internet;
 use Faker\Provider\de_DE\Company;
 use PHPUnit\Framework\TestCase;
 
-class InternetTest extends TestCase
+final class InternetTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/el_GR/TextTest.php
+++ b/test/Faker/Provider/el_GR/TextTest.php
@@ -4,7 +4,7 @@ namespace Faker\Test\Provider\el_GR;
 
 use PHPUnit\Framework\TestCase;
 
-class TextTest extends TestCase
+final class TextTest extends TestCase
 {
     private $textClass;
 

--- a/test/Faker/Provider/en_AU/AddressTest.php
+++ b/test/Faker/Provider/en_AU/AddressTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\en_AU\Address;
 use PHPUnit\Framework\TestCase;
 
-class AddressTest extends TestCase
+final class AddressTest extends TestCase
 {
 
   /**

--- a/test/Faker/Provider/en_CA/AddressTest.php
+++ b/test/Faker/Provider/en_CA/AddressTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\en_CA\Address;
 use PHPUnit\Framework\TestCase;
 
-class AddressTest extends TestCase
+final class AddressTest extends TestCase
 {
 
   /**

--- a/test/Faker/Provider/en_GB/AddressTest.php
+++ b/test/Faker/Provider/en_GB/AddressTest.php
@@ -5,7 +5,7 @@ namespace Faker\Provider\en_GB;
 use Faker\Generator;
 use PHPUnit\Framework\TestCase;
 
-class AddressTest extends TestCase
+final class AddressTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/en_IN/AddressTest.php
+++ b/test/Faker/Provider/en_IN/AddressTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\en_IN\Address;
 use PHPUnit\Framework\TestCase;
 
-class AddressTest extends TestCase
+final class AddressTest extends TestCase
 {
 
   /**

--- a/test/Faker/Provider/en_NG/AddressTest.php
+++ b/test/Faker/Provider/en_NG/AddressTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\en_NG\Address;
 use PHPUnit\Framework\TestCase;
 
-class AddressTest extends TestCase
+final class AddressTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/en_NG/InternetTest.php
+++ b/test/Faker/Provider/en_NG/InternetTest.php
@@ -7,7 +7,7 @@ use Faker\Provider\en_NG\Person;
 use Faker\Provider\en_NG\Internet;
 use PHPUnit\Framework\TestCase;
 
-class InternetTest extends TestCase
+final class InternetTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/en_NG/PersonTest.php
+++ b/test/Faker/Provider/en_NG/PersonTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\en_NG\Person;
 use PHPUnit\Framework\TestCase;
 
-class PersonTest extends TestCase
+final class PersonTest extends TestCase
 {
      /**
      * @var Generator

--- a/test/Faker/Provider/en_NG/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_NG/PhoneNumberTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\en_NG\PhoneNumber;
 use PHPUnit\Framework\TestCase;
 
-class PhoneNumberTest extends TestCase
+final class PhoneNumberTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/en_NZ/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_NZ/PhoneNumberTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\en_NZ\PhoneNumber;
 use PHPUnit\Framework\TestCase;
 
-class PhoneNumberTest extends TestCase
+final class PhoneNumberTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/en_PH/AddressTest.php
+++ b/test/Faker/Provider/en_PH/AddressTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\en_PH\Address;
 use PHPUnit\Framework\TestCase;
 
-class AddressTest extends TestCase
+final class AddressTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/en_SG/AddressTest.php
+++ b/test/Faker/Provider/en_SG/AddressTest.php
@@ -6,7 +6,7 @@ use Faker\Factory;
 use Faker\Provider\en_SG\Address;
 use PHPUnit\Framework\TestCase;
 
-class AddressTest extends TestCase
+final class AddressTest extends TestCase
 {
     public function setUp()
     {

--- a/test/Faker/Provider/en_SG/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_SG/PhoneNumberTest.php
@@ -6,7 +6,7 @@ use Faker\Factory;
 use Faker\Provider\en_SG\PhoneNumber;
 use PHPUnit\Framework\TestCase;
 
-class PhoneNumberTest extends TestCase
+final class PhoneNumberTest extends TestCase
 {
     private $faker;
 

--- a/test/Faker/Provider/en_UG/AddressTest.php
+++ b/test/Faker/Provider/en_UG/AddressTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\en_UG\Address;
 use PHPUnit\Framework\TestCase;
 
-class AddressTest extends TestCase
+final class AddressTest extends TestCase
 {
 
 /**

--- a/test/Faker/Provider/en_US/CompanyTest.php
+++ b/test/Faker/Provider/en_US/CompanyTest.php
@@ -6,7 +6,7 @@ use Faker\Provider\en_US\Company;
 use Faker\Generator;
 use PHPUnit\Framework\TestCase;
 
-class CompanyTest extends TestCase
+final class CompanyTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/en_US/PaymentTest.php
+++ b/test/Faker/Provider/en_US/PaymentTest.php
@@ -6,7 +6,7 @@ namespace Faker\Provider\en_US;
 use Faker\Generator;
 use PHPUnit\Framework\TestCase;
 
-class PaymentTest extends TestCase
+final class PaymentTest extends TestCase
 {
     /**
      * @var Generator

--- a/test/Faker/Provider/en_US/PersonTest.php
+++ b/test/Faker/Provider/en_US/PersonTest.php
@@ -6,7 +6,7 @@ use Faker\Provider\en_US\Person;
 use Faker\Generator;
 use PHPUnit\Framework\TestCase;
 
-class PersonTest extends TestCase
+final class PersonTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/en_US/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_US/PhoneNumberTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\en_US\PhoneNumber;
 use PHPUnit\Framework\TestCase;
 
-class PhoneNumberTest extends TestCase
+final class PhoneNumberTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/en_ZA/CompanyTest.php
+++ b/test/Faker/Provider/en_ZA/CompanyTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\en_ZA\Company;
 use PHPUnit\Framework\TestCase;
 
-class CompanyTest extends TestCase
+final class CompanyTest extends TestCase
 {
     private $faker;
 

--- a/test/Faker/Provider/en_ZA/InternetTest.php
+++ b/test/Faker/Provider/en_ZA/InternetTest.php
@@ -8,7 +8,7 @@ use Faker\Provider\en_ZA\Internet;
 use Faker\Provider\en_ZA\Company;
 use PHPUnit\Framework\TestCase;
 
-class InternetTest extends TestCase
+final class InternetTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/en_ZA/PersonTest.php
+++ b/test/Faker/Provider/en_ZA/PersonTest.php
@@ -7,7 +7,7 @@ use Faker\Provider\en_ZA\Person;
 use Faker\Provider\DateTime;
 use PHPUnit\Framework\TestCase;
 
-class PersonTest extends TestCase
+final class PersonTest extends TestCase
 {
     private $faker;
 

--- a/test/Faker/Provider/en_ZA/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_ZA/PhoneNumberTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\en_ZA\PhoneNumber;
 use PHPUnit\Framework\TestCase;
 
-class PhoneNumberTest extends TestCase
+final class PhoneNumberTest extends TestCase
 {
     private $faker;
 

--- a/test/Faker/Provider/es_ES/PaymentTest.php
+++ b/test/Faker/Provider/es_ES/PaymentTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\es_ES\Payment;
 use PHPUnit\Framework\TestCase;
 
-class PaymentTest extends TestCase
+final class PaymentTest extends TestCase
 {
     /**
      * @var Generator

--- a/test/Faker/Provider/es_ES/PersonTest.php
+++ b/test/Faker/Provider/es_ES/PersonTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\es_ES\Person;
 use PHPUnit\Framework\TestCase;
 
-class PersonTest extends TestCase
+final class PersonTest extends TestCase
 {
     public function setUp()
     {

--- a/test/Faker/Provider/es_ES/PhoneNumberTest.php
+++ b/test/Faker/Provider/es_ES/PhoneNumberTest.php
@@ -5,7 +5,7 @@ namespace Faker\Test\Provider\es_ES;
 use Faker\Generator;
 use Faker\Provider\es_ES\PhoneNumber;
 
-class PhoneNumberTest extends \PHPUnit_Framework_TestCase
+final class PhoneNumberTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {

--- a/test/Faker/Provider/es_ES/TextTest.php
+++ b/test/Faker/Provider/es_ES/TextTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\es_ES\Text;
 use PHPUnit\Framework\TestCase;
 
-class TextTest extends TestCase
+final class TextTest extends TestCase
 {
     /**
      * @var Generator

--- a/test/Faker/Provider/es_PE/PersonTest.php
+++ b/test/Faker/Provider/es_PE/PersonTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\es_PE\Person;
 use PHPUnit\Framework\TestCase;
 
-class PersonTest extends TestCase
+final class PersonTest extends TestCase
 {
     /**
      * @var Generator

--- a/test/Faker/Provider/es_VE/CompanyTest.php
+++ b/test/Faker/Provider/es_VE/CompanyTest.php
@@ -11,7 +11,7 @@ use Faker\Generator;
 use Faker\Provider\es_VE\Company;
 use PHPUnit\Framework\TestCase;
 
-class CompanyTest extends TestCase
+final class CompanyTest extends TestCase
 {
     /**
      * @var Generator

--- a/test/Faker/Provider/es_VE/PersonTest.php
+++ b/test/Faker/Provider/es_VE/PersonTest.php
@@ -11,7 +11,7 @@ use Faker\Generator;
 use Faker\Provider\es_VE\Person;
 use PHPUnit\Framework\TestCase;
 
-class PersonTest extends TestCase
+final class PersonTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/fa_IR/PersonTest.php
+++ b/test/Faker/Provider/fa_IR/PersonTest.php
@@ -6,7 +6,7 @@ use Faker\Provider\fa_IR\Person;
 use Faker\Generator;
 use PHPUnit\Framework\TestCase;
 
-class PersonTest extends TestCase
+final class PersonTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/fi_FI/InternetTest.php
+++ b/test/Faker/Provider/fi_FI/InternetTest.php
@@ -8,7 +8,7 @@ use Faker\Provider\fi_FI\Internet;
 use Faker\Provider\fi_FI\Company;
 use PHPUnit\Framework\TestCase;
 
-class InternetTest extends TestCase
+final class InternetTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/fi_FI/PersonTest.php
+++ b/test/Faker/Provider/fi_FI/PersonTest.php
@@ -7,7 +7,7 @@ use Faker\Provider\DateTime;
 use Faker\Provider\fi_FI\Person;
 use PHPUnit\Framework\TestCase;
 
-class PersonTest extends TestCase
+final class PersonTest extends TestCase
 {
     /** @var Generator */
     protected $faker;

--- a/test/Faker/Provider/fr_BE/PaymentTest.php
+++ b/test/Faker/Provider/fr_BE/PaymentTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\fr_BE\Payment;
 use PHPUnit\Framework\TestCase;
 
-class PaymentTest extends TestCase
+final class PaymentTest extends TestCase
 {
     /**
      * @var Generator

--- a/test/Faker/Provider/fr_CH/AddressTest.php
+++ b/test/Faker/Provider/fr_CH/AddressTest.php
@@ -7,7 +7,7 @@ use Faker\Provider\fr_CH\Address;
 use Faker\Provider\fr_CH\Person;
 use PHPUnit\Framework\TestCase;
 
-class AddressTest extends TestCase
+final class AddressTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/fr_CH/InternetTest.php
+++ b/test/Faker/Provider/fr_CH/InternetTest.php
@@ -8,7 +8,7 @@ use Faker\Provider\fr_CH\Internet;
 use Faker\Provider\fr_CH\Company;
 use PHPUnit\Framework\TestCase;
 
-class InternetTest extends TestCase
+final class InternetTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/fr_CH/PersonTest.php
+++ b/test/Faker/Provider/fr_CH/PersonTest.php
@@ -7,7 +7,7 @@ use Faker\Generator;
 use Faker\Provider\fr_CH\Person;
 use PHPUnit\Framework\TestCase;
 
-class PersonTest extends TestCase
+final class PersonTest extends TestCase
 {
     private $faker;
 

--- a/test/Faker/Provider/fr_CH/PhoneNumberTest.php
+++ b/test/Faker/Provider/fr_CH/PhoneNumberTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\fr_CH\PhoneNumber;
 use PHPUnit\Framework\TestCase;
 
-class PhoneNumberTest extends TestCase
+final class PhoneNumberTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/fr_FR/AddressTest.php
+++ b/test/Faker/Provider/fr_FR/AddressTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\fr_FR\Address;
 use PHPUnit\Framework\TestCase;
 
-class AddressTest extends TestCase
+final class AddressTest extends TestCase
 {
 
 /**

--- a/test/Faker/Provider/fr_FR/CompanyTest.php
+++ b/test/Faker/Provider/fr_FR/CompanyTest.php
@@ -7,7 +7,7 @@ use Faker\Generator;
 use Faker\Provider\fr_FR\Company;
 use PHPUnit\Framework\TestCase;
 
-class CompanyTest extends TestCase
+final class CompanyTest extends TestCase
 {
     private $faker;
 
@@ -66,7 +66,7 @@ class CompanyTest extends TestCase
     }
 }
 
-class TestableCompany extends Company
+final class TestableCompany extends Company
 {
     public static function isCatchPhraseValid($catchPhrase)
     {

--- a/test/Faker/Provider/fr_FR/PaymentTest.php
+++ b/test/Faker/Provider/fr_FR/PaymentTest.php
@@ -7,7 +7,7 @@ use Faker\Generator;
 use Faker\Provider\fr_FR\Payment;
 use PHPUnit\Framework\TestCase;
 
-class PaymentTest extends TestCase
+final class PaymentTest extends TestCase
 {
     private $faker;
 

--- a/test/Faker/Provider/fr_FR/PersonTest.php
+++ b/test/Faker/Provider/fr_FR/PersonTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\fr_FR\Person;
 use PHPUnit\Framework\TestCase;
 
-class PersonTest extends TestCase
+final class PersonTest extends TestCase
 {
     private $faker;
 

--- a/test/Faker/Provider/fr_FR/PhoneNumberTest.php
+++ b/test/Faker/Provider/fr_FR/PhoneNumberTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\fr_FR\PhoneNumber;
 use PHPUnit\Framework\TestCase;
 
-class PhoneNumberTest extends TestCase
+final class PhoneNumberTest extends TestCase
 {
     /**
      * @var Generator

--- a/test/Faker/Provider/fr_FR/TextTest.php
+++ b/test/Faker/Provider/fr_FR/TextTest.php
@@ -4,7 +4,7 @@ namespace Faker\Test\Provider\fr_FR;
 
 use PHPUnit\Framework\TestCase;
 
-class TextTest extends TestCase
+final class TextTest extends TestCase
 {
     private $textClass;
 

--- a/test/Faker/Provider/id_ID/PersonTest.php
+++ b/test/Faker/Provider/id_ID/PersonTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\id_ID\Person;
 use PHPUnit\Framework\TestCase;
 
-class PersonTest extends TestCase
+final class PersonTest extends TestCase
 {
     public function setUp()
     {

--- a/test/Faker/Provider/it_CH/AddressTest.php
+++ b/test/Faker/Provider/it_CH/AddressTest.php
@@ -7,7 +7,7 @@ use Faker\Provider\it_CH\Address;
 use Faker\Provider\it_CH\Person;
 use PHPUnit\Framework\TestCase;
 
-class AddressTest extends TestCase
+final class AddressTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/it_CH/InternetTest.php
+++ b/test/Faker/Provider/it_CH/InternetTest.php
@@ -8,7 +8,7 @@ use Faker\Provider\it_CH\Internet;
 use Faker\Provider\it_CH\Company;
 use PHPUnit\Framework\TestCase;
 
-class InternetTest extends TestCase
+final class InternetTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/it_CH/PersonTest.php
+++ b/test/Faker/Provider/it_CH/PersonTest.php
@@ -7,7 +7,7 @@ use Faker\Generator;
 use Faker\Provider\it_CH\Person;
 use PHPUnit\Framework\TestCase;
 
-class PersonTest extends TestCase
+final class PersonTest extends TestCase
 {
     private $faker;
 

--- a/test/Faker/Provider/it_CH/PhoneNumberTest.php
+++ b/test/Faker/Provider/it_CH/PhoneNumberTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\it_CH\PhoneNumber;
 use PHPUnit\Framework\TestCase;
 
-class PhoneNumberTest extends TestCase
+final class PhoneNumberTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/it_IT/CompanyTest.php
+++ b/test/Faker/Provider/it_IT/CompanyTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\it_IT\Company;
 use PHPUnit\Framework\TestCase;
 
-class CompanyTest extends TestCase
+final class CompanyTest extends TestCase
 {
     public function setUp()
     {

--- a/test/Faker/Provider/it_IT/PersonTest.php
+++ b/test/Faker/Provider/it_IT/PersonTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\it_IT\Person;
 use PHPUnit\Framework\TestCase;
 
-class PersonTest extends TestCase
+final class PersonTest extends TestCase
 {
     public function setUp()
     {

--- a/test/Faker/Provider/ja_JP/InternetTest.php
+++ b/test/Faker/Provider/ja_JP/InternetTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\ja_JP\Internet;
 use PHPUnit\Framework\TestCase;
 
-class InternetTest extends TestCase
+final class InternetTest extends TestCase
 {
     public function testUserName()
     {

--- a/test/Faker/Provider/ja_JP/PersonTest.php
+++ b/test/Faker/Provider/ja_JP/PersonTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\ja_JP\Person;
 use PHPUnit\Framework\TestCase;
 
-class PersonTest extends TestCase
+final class PersonTest extends TestCase
 {
     public function testKanaNameMaleReturns()
     {

--- a/test/Faker/Provider/ja_JP/PhoneNumberTest.php
+++ b/test/Faker/Provider/ja_JP/PhoneNumberTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\ja_JP\PhoneNumber;
 use PHPUnit\Framework\TestCase;
 
-class PhoneNumberTest extends TestCase
+final class PhoneNumberTest extends TestCase
 {
     public function testPhoneNumber()
     {

--- a/test/Faker/Provider/ka_GE/TextTest.php
+++ b/test/Faker/Provider/ka_GE/TextTest.php
@@ -4,7 +4,7 @@ namespace Faker\Test\Provider\ka_GE;
 
 use PHPUnit\Framework\TestCase;
 
-class TextTest extends TestCase
+final class TextTest extends TestCase
 {
     private $textClass;
 

--- a/test/Faker/Provider/kk_KZ/CompanyTest.php
+++ b/test/Faker/Provider/kk_KZ/CompanyTest.php
@@ -5,7 +5,7 @@ use Faker\Generator;
 use Faker\Provider\kk_KZ\Company;
 use PHPUnit\Framework\TestCase;
 
-class CompanyTest extends TestCase
+final class CompanyTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/kk_KZ/PersonTest.php
+++ b/test/Faker/Provider/kk_KZ/PersonTest.php
@@ -6,7 +6,7 @@ use Faker\Provider\DateTime;
 use Faker\Provider\kk_KZ\Person;
 use PHPUnit\Framework\TestCase;
 
-class PersonTest extends TestCase
+final class PersonTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/kk_KZ/TextTest.php
+++ b/test/Faker/Provider/kk_KZ/TextTest.php
@@ -4,7 +4,7 @@ namespace Faker\Test\Provider\kk_KZ;
 
 use PHPUnit\Framework\TestCase;
 
-class TextTest extends TestCase
+final class TextTest extends TestCase
 {
     private $textClass;
 

--- a/test/Faker/Provider/ko_KR/TextTest.php
+++ b/test/Faker/Provider/ko_KR/TextTest.php
@@ -4,7 +4,7 @@ namespace Faker\Test\Provider\ko_KR;
 
 use PHPUnit\Framework\TestCase;
 
-class TextTest extends TestCase
+final class TextTest extends TestCase
 {
     private $textClass;
 

--- a/test/Faker/Provider/mn_MN/PersonTest.php
+++ b/test/Faker/Provider/mn_MN/PersonTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\mn_MN\Person;
 use PHPUnit\Framework\TestCase;
 
-class PersonTest extends TestCase
+final class PersonTest extends TestCase
 {
     public function testName()
     {

--- a/test/Faker/Provider/ms_MY/PersonTest.php
+++ b/test/Faker/Provider/ms_MY/PersonTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\ms_MY\Person;
 use PHPUnit\Framework\TestCase;
 
-class PersonTest extends TestCase
+final class PersonTest extends TestCase
 {
     /**
      * @var Generator

--- a/test/Faker/Provider/nb_NO/PhoneNumberTest.php
+++ b/test/Faker/Provider/nb_NO/PhoneNumberTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\nb_NO\PhoneNumber;
 use PHPUnit\Framework\TestCase;
 
-class PhoneNumberTest extends TestCase
+final class PhoneNumberTest extends TestCase
 {
     private $faker;
 

--- a/test/Faker/Provider/nl_BE/PaymentTest.php
+++ b/test/Faker/Provider/nl_BE/PaymentTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\nl_BE\Payment;
 use PHPUnit\Framework\TestCase;
 
-class PaymentTest extends TestCase
+final class PaymentTest extends TestCase
 {
     /**
      * @var Generator

--- a/test/Faker/Provider/nl_BE/PersonTest.php
+++ b/test/Faker/Provider/nl_BE/PersonTest.php
@@ -10,7 +10,7 @@ use Datetime;
 /**
  * @group Person
  */
-class PersonTest extends TestCase
+final class PersonTest extends TestCase
 {
     /**
      * @var Generator

--- a/test/Faker/Provider/nl_NL/CompanyTest.php
+++ b/test/Faker/Provider/nl_NL/CompanyTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\nl_NL\Company;
 use PHPUnit\Framework\TestCase;
 
-class CompanyTest extends TestCase
+final class CompanyTest extends TestCase
 {
     private $faker;
 

--- a/test/Faker/Provider/nl_NL/PersonTest.php
+++ b/test/Faker/Provider/nl_NL/PersonTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\nl_NL\Person;
 use PHPUnit\Framework\TestCase;
 
-class PersonTest extends TestCase
+final class PersonTest extends TestCase
 {
     private $faker;
 

--- a/test/Faker/Provider/pl_PL/AddressTest.php
+++ b/test/Faker/Provider/pl_PL/AddressTest.php
@@ -5,7 +5,7 @@ namespace Faker\Provider\pl_PL;
 use Faker\Generator;
 use PHPUnit\Framework\TestCase;
 
-class AddressTest extends TestCase
+final class AddressTest extends TestCase
 {
     /**
      * @var Generator

--- a/test/Faker/Provider/pl_PL/PersonTest.php
+++ b/test/Faker/Provider/pl_PL/PersonTest.php
@@ -6,7 +6,7 @@ use DateTime;
 use Faker\Generator;
 use PHPUnit\Framework\TestCase;
 
-class PersonTest extends TestCase
+final class PersonTest extends TestCase
 {
     /**
      * @var Generator

--- a/test/Faker/Provider/pt_BR/CompanyTest.php
+++ b/test/Faker/Provider/pt_BR/CompanyTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\pt_BR\Company;
 use PHPUnit\Framework\TestCase;
 
-class CompanyTest extends TestCase
+final class CompanyTest extends TestCase
 {
 
     public function setUp()

--- a/test/Faker/Provider/pt_BR/PersonTest.php
+++ b/test/Faker/Provider/pt_BR/PersonTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\pt_BR\Person;
 use PHPUnit\Framework\TestCase;
 
-class PersonTest extends TestCase
+final class PersonTest extends TestCase
 {
 
     public function setUp()

--- a/test/Faker/Provider/pt_PT/AddressTest.php
+++ b/test/Faker/Provider/pt_PT/AddressTest.php
@@ -7,7 +7,7 @@ use Faker\Provider\pt_PT\Address;
 use Faker\Provider\pt_PT\Person;
 use PHPUnit\Framework\TestCase;
 
-class AddressTest extends TestCase
+final class AddressTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/pt_PT/PersonTest.php
+++ b/test/Faker/Provider/pt_PT/PersonTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\pt_PT\Person;
 use PHPUnit\Framework\TestCase;
 
-class PersonTest extends TestCase
+final class PersonTest extends TestCase
 {
 
     public function setUp()

--- a/test/Faker/Provider/pt_PT/PhoneNumberTest.php
+++ b/test/Faker/Provider/pt_PT/PhoneNumberTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\pt_PT\PhoneNumber;
 use PHPUnit\Framework\TestCase;
 
-class PhoneNumberTest extends TestCase
+final class PhoneNumberTest extends TestCase
 {
     public function setUp()
     {

--- a/test/Faker/Provider/ro_RO/PersonTest.php
+++ b/test/Faker/Provider/ro_RO/PersonTest.php
@@ -7,7 +7,7 @@ use Faker\Provider\DateTime;
 use Faker\Provider\ro_RO\Person;
 use PHPUnit\Framework\TestCase;
 
-class PersonTest extends TestCase
+final class PersonTest extends TestCase
 {
     const TEST_CNP_REGEX = '/^[1-9][0-9]{2}(?:0[1-9]|1[012])(?:0[1-9]|[12][0-9]|3[01])(?:0[1-9]|[123][0-9]|4[0-6]|5[12])[0-9]{3}[0-9]$/';
 

--- a/test/Faker/Provider/ro_RO/PhoneNumberTest.php
+++ b/test/Faker/Provider/ro_RO/PhoneNumberTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\ro_RO\PhoneNumber;
 use PHPUnit\Framework\TestCase;
 
-class PhoneNumberTest extends TestCase
+final class PhoneNumberTest extends TestCase
 {
     public function setUp()
     {

--- a/test/Faker/Provider/ru_RU/CompanyTest.php
+++ b/test/Faker/Provider/ru_RU/CompanyTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\ru_RU\Company;
 use PHPUnit\Framework\TestCase;
 
-class CompanyTest extends TestCase
+final class CompanyTest extends TestCase
 {
     /**
      * @var Generator

--- a/test/Faker/Provider/ru_RU/PersonTest.php
+++ b/test/Faker/Provider/ru_RU/PersonTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\ru_RU\Person;
 use PHPUnit\Framework\TestCase;
 
-class PersonTest extends TestCase
+final class PersonTest extends TestCase
 {
     /**
      * @var Generator

--- a/test/Faker/Provider/ru_RU/TextTest.php
+++ b/test/Faker/Provider/ru_RU/TextTest.php
@@ -4,7 +4,7 @@ namespace Faker\Test\Provider\ru_RU;
 
 use PHPUnit\Framework\TestCase;
 
-class TextTest extends TestCase
+final class TextTest extends TestCase
 {
     private $textClass;
 

--- a/test/Faker/Provider/sv_SE/PersonTest.php
+++ b/test/Faker/Provider/sv_SE/PersonTest.php
@@ -7,7 +7,7 @@ use Faker\Generator;
 use Faker\Provider\sv_SE\Person;
 use PHPUnit\Framework\TestCase;
 
-class PersonTest extends TestCase
+final class PersonTest extends TestCase
 {
     /** @var Generator */
     protected $faker;

--- a/test/Faker/Provider/tr_TR/CompanyTest.php
+++ b/test/Faker/Provider/tr_TR/CompanyTest.php
@@ -6,7 +6,7 @@ use Faker\Provider\tr_TR\Company;
 use Faker\Generator;
 use PHPUnit\Framework\TestCase;
 
-class CompanyTest extends TestCase
+final class CompanyTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/tr_TR/PaymentTest.php
+++ b/test/Faker/Provider/tr_TR/PaymentTest.php
@@ -6,7 +6,7 @@ namespace Faker\Provider\tr_TR;
 use Faker\Generator;
 use PHPUnit\Framework\TestCase;
 
-class PaymentTest extends TestCase
+final class PaymentTest extends TestCase
 {
     /**
      * @var Generator

--- a/test/Faker/Provider/tr_TR/PersonTest.php
+++ b/test/Faker/Provider/tr_TR/PersonTest.php
@@ -7,7 +7,7 @@ use Faker\Provider\tr_TR\Person;
 use Faker\Generator;
 use PHPUnit\Framework\TestCase;
 
-class PersonTest extends TestCase
+final class PersonTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/tr_TR/PhoneNumberTest.php
+++ b/test/Faker/Provider/tr_TR/PhoneNumberTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\tr_TR\PhoneNumber;
 use PHPUnit\Framework\TestCase;
 
-class PhoneNumberTest extends TestCase
+final class PhoneNumberTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/uk_UA/AddressTest.php
+++ b/test/Faker/Provider/uk_UA/AddressTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\uk_UA\Address;
 use PHPUnit\Framework\TestCase;
 
-class AddressTest extends TestCase
+final class AddressTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/uk_UA/PersonTest.php
+++ b/test/Faker/Provider/uk_UA/PersonTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\uk_UA\Person;
 use PHPUnit\Framework\TestCase;
 
-class PersonTest extends TestCase
+final class PersonTest extends TestCase
 {
     public function testFirstNameMaleReturns()
     {

--- a/test/Faker/Provider/uk_UA/PhoneNumberTest.php
+++ b/test/Faker/Provider/uk_UA/PhoneNumberTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\uk_UA\PhoneNumber;
 use PHPUnit\Framework\TestCase;
 
-class PhoneNumberTest extends TestCase
+final class PhoneNumberTest extends TestCase
 {
 
     /**

--- a/test/Faker/Provider/zh_TW/CompanyTest.php
+++ b/test/Faker/Provider/zh_TW/CompanyTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\zh_TW\Company;
 use PHPUnit\Framework\TestCase;
 
-class CompanyTest extends TestCase
+final class CompanyTest extends TestCase
 {
     /**
      * @var Generator

--- a/test/Faker/Provider/zh_TW/PersonTest.php
+++ b/test/Faker/Provider/zh_TW/PersonTest.php
@@ -6,7 +6,7 @@ use Faker\Generator;
 use Faker\Provider\zh_TW\Person;
 use PHPUnit\Framework\TestCase;
 
-class PersonTest extends TestCase
+final class PersonTest extends TestCase
 {
     /**
      * @var Generator

--- a/test/Faker/Provider/zh_TW/TextTest.php
+++ b/test/Faker/Provider/zh_TW/TextTest.php
@@ -4,7 +4,7 @@ namespace Faker\Test\Provider\zh_TW;
 
 use PHPUnit\Framework\TestCase;
 
-class TextTest extends TestCase
+final class TextTest extends TestCase
 {
     private $textClass;
 


### PR DESCRIPTION
This PR

* [x] marks test classes as `final`

💁‍♂ There's probably no reason to extend from them.