### PR TITLE
Fix: Reduce visibility of setUp() and tearDown()

### DIFF
--- a/test/Faker/Provider/AddressTest.php
+++ b/test/Faker/Provider/AddressTest.php
@@ -10,7 +10,7 @@ class AddressTest extends TestCase
 {
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Address($faker));

--- a/test/Faker/Provider/BarcodeTest.php
+++ b/test/Faker/Provider/BarcodeTest.php
@@ -10,7 +10,7 @@ class BarcodeTest extends TestCase
 {
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Barcode($faker));

--- a/test/Faker/Provider/CompanyTest.php
+++ b/test/Faker/Provider/CompanyTest.php
@@ -14,7 +14,7 @@ class CompanyTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Company($faker));

--- a/test/Faker/Provider/DateTimeTest.php
+++ b/test/Faker/Provider/DateTimeTest.php
@@ -7,13 +7,13 @@ use PHPUnit\Framework\TestCase;
 
 class DateTimeTest extends TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->defaultTz = 'UTC';
         DateTimeProvider::setDefaultTimezone($this->defaultTz);
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         DateTimeProvider::setDefaultTimezone();
     }

--- a/test/Faker/Provider/InternetTest.php
+++ b/test/Faker/Provider/InternetTest.php
@@ -16,7 +16,7 @@ class InternetTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Lorem($faker));

--- a/test/Faker/Provider/PaymentTest.php
+++ b/test/Faker/Provider/PaymentTest.php
@@ -15,7 +15,7 @@ class PaymentTest extends TestCase
 {
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new BaseProvider($faker));

--- a/test/Faker/Provider/PhoneNumberTest.php
+++ b/test/Faker/Provider/PhoneNumberTest.php
@@ -15,7 +15,7 @@ class PhoneNumberTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new PhoneNumber($faker));

--- a/test/Faker/Provider/ar_JO/InternetTest.php
+++ b/test/Faker/Provider/ar_JO/InternetTest.php
@@ -16,7 +16,7 @@ class InternetTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/ar_SA/InternetTest.php
+++ b/test/Faker/Provider/ar_SA/InternetTest.php
@@ -16,7 +16,7 @@ class InternetTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/at_AT/PaymentTest.php
+++ b/test/Faker/Provider/at_AT/PaymentTest.php
@@ -14,7 +14,7 @@ class PaymentTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Payment($faker));

--- a/test/Faker/Provider/bg_BG/PaymentTest.php
+++ b/test/Faker/Provider/bg_BG/PaymentTest.php
@@ -14,7 +14,7 @@ class PaymentTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Payment($faker));

--- a/test/Faker/Provider/bn_BD/PersonTest.php
+++ b/test/Faker/Provider/bn_BD/PersonTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class PersonTest extends TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/da_DK/InternetTest.php
+++ b/test/Faker/Provider/da_DK/InternetTest.php
@@ -16,7 +16,7 @@ class InternetTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/de_AT/InternetTest.php
+++ b/test/Faker/Provider/de_AT/InternetTest.php
@@ -16,7 +16,7 @@ class InternetTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/de_AT/PhoneNumberTest.php
+++ b/test/Faker/Provider/de_AT/PhoneNumberTest.php
@@ -14,7 +14,7 @@ class PhoneNumberTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new PhoneNumber($faker));

--- a/test/Faker/Provider/de_CH/AddressTest.php
+++ b/test/Faker/Provider/de_CH/AddressTest.php
@@ -15,7 +15,7 @@ class AddressTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Address($faker));

--- a/test/Faker/Provider/de_CH/InternetTest.php
+++ b/test/Faker/Provider/de_CH/InternetTest.php
@@ -16,7 +16,7 @@ class InternetTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/de_CH/PersonTest.php
+++ b/test/Faker/Provider/de_CH/PersonTest.php
@@ -11,7 +11,7 @@ class PersonTest extends TestCase
 {
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/de_CH/PhoneNumberTest.php
+++ b/test/Faker/Provider/de_CH/PhoneNumberTest.php
@@ -14,7 +14,7 @@ class PhoneNumberTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new PhoneNumber($faker));

--- a/test/Faker/Provider/de_DE/InternetTest.php
+++ b/test/Faker/Provider/de_DE/InternetTest.php
@@ -16,7 +16,7 @@ class InternetTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/el_GR/TextTest.php
+++ b/test/Faker/Provider/el_GR/TextTest.php
@@ -8,7 +8,7 @@ class TextTest extends TestCase
 {
     private $textClass;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->textClass = new \ReflectionClass('Faker\Provider\el_GR\Text');
     }

--- a/test/Faker/Provider/en_AU/AddressTest.php
+++ b/test/Faker/Provider/en_AU/AddressTest.php
@@ -14,7 +14,7 @@ class AddressTest extends TestCase
    */
   private $faker;
 
-  public function setUp()
+  protected function setUp()
   {
     $faker = new Generator();
     $faker->addProvider(new Address($faker));

--- a/test/Faker/Provider/en_CA/AddressTest.php
+++ b/test/Faker/Provider/en_CA/AddressTest.php
@@ -14,7 +14,7 @@ class AddressTest extends TestCase
    */
   private $faker;
 
-  public function setUp()
+  protected function setUp()
   {
     $faker = new Generator();
     $faker->addProvider(new Address($faker));

--- a/test/Faker/Provider/en_GB/AddressTest.php
+++ b/test/Faker/Provider/en_GB/AddressTest.php
@@ -13,7 +13,7 @@ class AddressTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Address($faker));

--- a/test/Faker/Provider/en_IN/AddressTest.php
+++ b/test/Faker/Provider/en_IN/AddressTest.php
@@ -14,7 +14,7 @@ class AddressTest extends TestCase
    */
   private $faker;
 
-  public function setUp()
+  protected function setUp()
   {
     $faker = new Generator();
     $faker->addProvider(new Address($faker));

--- a/test/Faker/Provider/en_NG/AddressTest.php
+++ b/test/Faker/Provider/en_NG/AddressTest.php
@@ -14,7 +14,7 @@ class AddressTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Address($faker));

--- a/test/Faker/Provider/en_NG/InternetTest.php
+++ b/test/Faker/Provider/en_NG/InternetTest.php
@@ -15,7 +15,7 @@ class InternetTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/en_NG/PersonTest.php
+++ b/test/Faker/Provider/en_NG/PersonTest.php
@@ -13,7 +13,7 @@ class PersonTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/en_NG/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_NG/PhoneNumberTest.php
@@ -14,7 +14,7 @@ class PhoneNumberTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new PhoneNumber($faker));

--- a/test/Faker/Provider/en_NZ/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_NZ/PhoneNumberTest.php
@@ -14,7 +14,7 @@ class PhoneNumberTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new PhoneNumber($faker));

--- a/test/Faker/Provider/en_PH/AddressTest.php
+++ b/test/Faker/Provider/en_PH/AddressTest.php
@@ -14,7 +14,7 @@ class AddressTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
       $faker = new Generator();
       $faker->addProvider(new Address($faker));

--- a/test/Faker/Provider/en_SG/AddressTest.php
+++ b/test/Faker/Provider/en_SG/AddressTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class AddressTest extends TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $faker = Factory::create('en_SG');
         $faker->addProvider(new Address($faker));

--- a/test/Faker/Provider/en_SG/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_SG/PhoneNumberTest.php
@@ -10,7 +10,7 @@ class PhoneNumberTest extends TestCase
 {
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->faker = Factory::create('en_SG');
         $this->faker->seed(1);

--- a/test/Faker/Provider/en_UG/AddressTest.php
+++ b/test/Faker/Provider/en_UG/AddressTest.php
@@ -14,7 +14,7 @@ class AddressTest extends TestCase
  */
   private $faker;
 
-  public function setUp()
+  protected function setUp()
   {
       $faker = new Generator();
       $faker->addProvider(new Address($faker));

--- a/test/Faker/Provider/en_US/CompanyTest.php
+++ b/test/Faker/Provider/en_US/CompanyTest.php
@@ -14,7 +14,7 @@ class CompanyTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Company($faker));

--- a/test/Faker/Provider/en_US/PaymentTest.php
+++ b/test/Faker/Provider/en_US/PaymentTest.php
@@ -13,7 +13,7 @@ class PaymentTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Payment($faker));

--- a/test/Faker/Provider/en_US/PersonTest.php
+++ b/test/Faker/Provider/en_US/PersonTest.php
@@ -14,7 +14,7 @@ class PersonTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/en_US/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_US/PhoneNumberTest.php
@@ -14,7 +14,7 @@ class PhoneNumberTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new PhoneNumber($faker));

--- a/test/Faker/Provider/en_ZA/CompanyTest.php
+++ b/test/Faker/Provider/en_ZA/CompanyTest.php
@@ -10,7 +10,7 @@ class CompanyTest extends TestCase
 {
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Company($faker));

--- a/test/Faker/Provider/en_ZA/InternetTest.php
+++ b/test/Faker/Provider/en_ZA/InternetTest.php
@@ -16,7 +16,7 @@ class InternetTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/en_ZA/PersonTest.php
+++ b/test/Faker/Provider/en_ZA/PersonTest.php
@@ -11,7 +11,7 @@ class PersonTest extends TestCase
 {
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/en_ZA/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_ZA/PhoneNumberTest.php
@@ -10,7 +10,7 @@ class PhoneNumberTest extends TestCase
 {
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new PhoneNumber($faker));

--- a/test/Faker/Provider/es_ES/PaymentTest.php
+++ b/test/Faker/Provider/es_ES/PaymentTest.php
@@ -13,7 +13,7 @@ class PaymentTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Payment($faker));

--- a/test/Faker/Provider/es_ES/PersonTest.php
+++ b/test/Faker/Provider/es_ES/PersonTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class PersonTest extends TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->seed(1);

--- a/test/Faker/Provider/es_ES/PhoneNumberTest.php
+++ b/test/Faker/Provider/es_ES/PhoneNumberTest.php
@@ -7,7 +7,7 @@ use Faker\Provider\es_ES\PhoneNumber;
 
 class PhoneNumberTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new PhoneNumber($faker));

--- a/test/Faker/Provider/es_ES/TextTest.php
+++ b/test/Faker/Provider/es_ES/TextTest.php
@@ -13,7 +13,7 @@ class TextTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Text($faker));

--- a/test/Faker/Provider/es_PE/PersonTest.php
+++ b/test/Faker/Provider/es_PE/PersonTest.php
@@ -13,7 +13,7 @@ class PersonTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->seed(1);

--- a/test/Faker/Provider/es_VE/CompanyTest.php
+++ b/test/Faker/Provider/es_VE/CompanyTest.php
@@ -18,7 +18,7 @@ class CompanyTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->seed(1);

--- a/test/Faker/Provider/es_VE/PersonTest.php
+++ b/test/Faker/Provider/es_VE/PersonTest.php
@@ -19,7 +19,7 @@ class PersonTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->seed(1);

--- a/test/Faker/Provider/fa_IR/PersonTest.php
+++ b/test/Faker/Provider/fa_IR/PersonTest.php
@@ -14,7 +14,7 @@ class PersonTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/fi_FI/InternetTest.php
+++ b/test/Faker/Provider/fi_FI/InternetTest.php
@@ -16,7 +16,7 @@ class InternetTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/fi_FI/PersonTest.php
+++ b/test/Faker/Provider/fi_FI/PersonTest.php
@@ -12,7 +12,7 @@ class PersonTest extends TestCase
     /** @var Generator */
     protected $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new DateTime($faker));

--- a/test/Faker/Provider/fr_BE/PaymentTest.php
+++ b/test/Faker/Provider/fr_BE/PaymentTest.php
@@ -13,7 +13,7 @@ class PaymentTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Payment($faker));

--- a/test/Faker/Provider/fr_CH/AddressTest.php
+++ b/test/Faker/Provider/fr_CH/AddressTest.php
@@ -15,7 +15,7 @@ class AddressTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Address($faker));

--- a/test/Faker/Provider/fr_CH/InternetTest.php
+++ b/test/Faker/Provider/fr_CH/InternetTest.php
@@ -16,7 +16,7 @@ class InternetTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/fr_CH/PersonTest.php
+++ b/test/Faker/Provider/fr_CH/PersonTest.php
@@ -11,7 +11,7 @@ class PersonTest extends TestCase
 {
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/fr_CH/PhoneNumberTest.php
+++ b/test/Faker/Provider/fr_CH/PhoneNumberTest.php
@@ -14,7 +14,7 @@ class PhoneNumberTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new PhoneNumber($faker));

--- a/test/Faker/Provider/fr_FR/AddressTest.php
+++ b/test/Faker/Provider/fr_FR/AddressTest.php
@@ -14,7 +14,7 @@ class AddressTest extends TestCase
  */
   private $faker;
 
-  public function setUp()
+  protected function setUp()
   {
       $faker = new Generator();
       $faker->addProvider(new Address($faker));

--- a/test/Faker/Provider/fr_FR/CompanyTest.php
+++ b/test/Faker/Provider/fr_FR/CompanyTest.php
@@ -11,7 +11,7 @@ class CompanyTest extends TestCase
 {
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Company($faker));

--- a/test/Faker/Provider/fr_FR/PaymentTest.php
+++ b/test/Faker/Provider/fr_FR/PaymentTest.php
@@ -11,7 +11,7 @@ class PaymentTest extends TestCase
 {
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Payment($faker));

--- a/test/Faker/Provider/fr_FR/PersonTest.php
+++ b/test/Faker/Provider/fr_FR/PersonTest.php
@@ -10,7 +10,7 @@ class PersonTest extends TestCase
 {
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/fr_FR/PhoneNumberTest.php
+++ b/test/Faker/Provider/fr_FR/PhoneNumberTest.php
@@ -13,7 +13,7 @@ class PhoneNumberTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new PhoneNumber($faker));

--- a/test/Faker/Provider/fr_FR/TextTest.php
+++ b/test/Faker/Provider/fr_FR/TextTest.php
@@ -8,7 +8,7 @@ class TextTest extends TestCase
 {
     private $textClass;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->textClass = new \ReflectionClass('Faker\Provider\fr_FR\Text');
     }

--- a/test/Faker/Provider/id_ID/PersonTest.php
+++ b/test/Faker/Provider/id_ID/PersonTest.php
@@ -47,7 +47,7 @@ class PersonTest extends TestCase
         '9171', '9201', '9202', '9203', '9204', '9205', '9206', '9207', '9208', '9209', '9210', '9211', '9212', '9271',
     );
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/it_CH/AddressTest.php
+++ b/test/Faker/Provider/it_CH/AddressTest.php
@@ -15,7 +15,7 @@ class AddressTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Address($faker));

--- a/test/Faker/Provider/it_CH/InternetTest.php
+++ b/test/Faker/Provider/it_CH/InternetTest.php
@@ -16,7 +16,7 @@ class InternetTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/it_CH/PersonTest.php
+++ b/test/Faker/Provider/it_CH/PersonTest.php
@@ -11,7 +11,7 @@ class PersonTest extends TestCase
 {
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/it_CH/PhoneNumberTest.php
+++ b/test/Faker/Provider/it_CH/PhoneNumberTest.php
@@ -14,7 +14,7 @@ class PhoneNumberTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new PhoneNumber($faker));

--- a/test/Faker/Provider/it_IT/CompanyTest.php
+++ b/test/Faker/Provider/it_IT/CompanyTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class CompanyTest extends TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Company($faker));

--- a/test/Faker/Provider/it_IT/PersonTest.php
+++ b/test/Faker/Provider/it_IT/PersonTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class PersonTest extends TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/ka_GE/TextTest.php
+++ b/test/Faker/Provider/ka_GE/TextTest.php
@@ -8,7 +8,7 @@ class TextTest extends TestCase
 {
     private $textClass;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->textClass = new \ReflectionClass('Faker\Provider\el_GR\Text');
     }

--- a/test/Faker/Provider/kk_KZ/CompanyTest.php
+++ b/test/Faker/Provider/kk_KZ/CompanyTest.php
@@ -11,7 +11,7 @@ class CompanyTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->faker = new Generator();
 

--- a/test/Faker/Provider/kk_KZ/PersonTest.php
+++ b/test/Faker/Provider/kk_KZ/PersonTest.php
@@ -12,7 +12,7 @@ class PersonTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->faker = new Generator();
 

--- a/test/Faker/Provider/kk_KZ/TextTest.php
+++ b/test/Faker/Provider/kk_KZ/TextTest.php
@@ -8,7 +8,7 @@ class TextTest extends TestCase
 {
     private $textClass;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->textClass = new \ReflectionClass('Faker\Provider\kk_KZ\Text');
     }

--- a/test/Faker/Provider/ko_KR/TextTest.php
+++ b/test/Faker/Provider/ko_KR/TextTest.php
@@ -8,7 +8,7 @@ class TextTest extends TestCase
 {
     private $textClass;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->textClass = new \ReflectionClass('Faker\Provider\el_GR\Text');
     }

--- a/test/Faker/Provider/ms_MY/PersonTest.php
+++ b/test/Faker/Provider/ms_MY/PersonTest.php
@@ -13,7 +13,7 @@ class PersonTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/nb_NO/PhoneNumberTest.php
+++ b/test/Faker/Provider/nb_NO/PhoneNumberTest.php
@@ -10,7 +10,7 @@ class PhoneNumberTest extends TestCase
 {
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new PhoneNumber($faker));

--- a/test/Faker/Provider/nl_BE/PaymentTest.php
+++ b/test/Faker/Provider/nl_BE/PaymentTest.php
@@ -13,7 +13,7 @@ class PaymentTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Payment($faker));

--- a/test/Faker/Provider/nl_BE/PersonTest.php
+++ b/test/Faker/Provider/nl_BE/PersonTest.php
@@ -17,7 +17,7 @@ class PersonTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/nl_NL/CompanyTest.php
+++ b/test/Faker/Provider/nl_NL/CompanyTest.php
@@ -10,7 +10,7 @@ class CompanyTest extends TestCase
 {
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Company($faker));

--- a/test/Faker/Provider/nl_NL/PersonTest.php
+++ b/test/Faker/Provider/nl_NL/PersonTest.php
@@ -10,7 +10,7 @@ class PersonTest extends TestCase
 {
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/pl_PL/AddressTest.php
+++ b/test/Faker/Provider/pl_PL/AddressTest.php
@@ -12,7 +12,7 @@ class AddressTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Address($faker));

--- a/test/Faker/Provider/pl_PL/PersonTest.php
+++ b/test/Faker/Provider/pl_PL/PersonTest.php
@@ -13,7 +13,7 @@ class PersonTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/pt_BR/CompanyTest.php
+++ b/test/Faker/Provider/pt_BR/CompanyTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 class CompanyTest extends TestCase
 {
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Company($faker));

--- a/test/Faker/Provider/pt_BR/PersonTest.php
+++ b/test/Faker/Provider/pt_BR/PersonTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 class PersonTest extends TestCase
 {
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/pt_PT/AddressTest.php
+++ b/test/Faker/Provider/pt_PT/AddressTest.php
@@ -15,7 +15,7 @@ class AddressTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Address($faker));

--- a/test/Faker/Provider/pt_PT/PersonTest.php
+++ b/test/Faker/Provider/pt_PT/PersonTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 class PersonTest extends TestCase
 {
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/pt_PT/PhoneNumberTest.php
+++ b/test/Faker/Provider/pt_PT/PhoneNumberTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class PhoneNumberTest extends TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new PhoneNumber($faker));

--- a/test/Faker/Provider/ro_RO/PersonTest.php
+++ b/test/Faker/Provider/ro_RO/PersonTest.php
@@ -17,7 +17,7 @@ class PersonTest extends TestCase
      */
     protected $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new DateTime($faker));
@@ -26,7 +26,7 @@ class PersonTest extends TestCase
         $this->faker = $faker;
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         $this->faker->setDefaultTimezone();
     }

--- a/test/Faker/Provider/ro_RO/PhoneNumberTest.php
+++ b/test/Faker/Provider/ro_RO/PhoneNumberTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class PhoneNumberTest extends TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new PhoneNumber($faker));

--- a/test/Faker/Provider/ru_RU/CompanyTest.php
+++ b/test/Faker/Provider/ru_RU/CompanyTest.php
@@ -13,7 +13,7 @@ class CompanyTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Company($faker));

--- a/test/Faker/Provider/ru_RU/PersonTest.php
+++ b/test/Faker/Provider/ru_RU/PersonTest.php
@@ -13,7 +13,7 @@ class PersonTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/ru_RU/TextTest.php
+++ b/test/Faker/Provider/ru_RU/TextTest.php
@@ -8,7 +8,7 @@ class TextTest extends TestCase
 {
     private $textClass;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->textClass = new \ReflectionClass('Faker\Provider\ru_RU\Text');
     }

--- a/test/Faker/Provider/sv_SE/PersonTest.php
+++ b/test/Faker/Provider/sv_SE/PersonTest.php
@@ -12,7 +12,7 @@ class PersonTest extends TestCase
     /** @var Generator */
     protected $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/tr_TR/CompanyTest.php
+++ b/test/Faker/Provider/tr_TR/CompanyTest.php
@@ -14,7 +14,7 @@ class CompanyTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Company($faker));

--- a/test/Faker/Provider/tr_TR/PaymentTest.php
+++ b/test/Faker/Provider/tr_TR/PaymentTest.php
@@ -13,7 +13,7 @@ class PaymentTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Payment($faker));

--- a/test/Faker/Provider/tr_TR/PersonTest.php
+++ b/test/Faker/Provider/tr_TR/PersonTest.php
@@ -15,7 +15,7 @@ class PersonTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/tr_TR/PhoneNumberTest.php
+++ b/test/Faker/Provider/tr_TR/PhoneNumberTest.php
@@ -14,7 +14,7 @@ class PhoneNumberTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new PhoneNumber($faker));

--- a/test/Faker/Provider/uk_UA/AddressTest.php
+++ b/test/Faker/Provider/uk_UA/AddressTest.php
@@ -14,7 +14,7 @@ class AddressTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Address($faker));

--- a/test/Faker/Provider/uk_UA/PhoneNumberTest.php
+++ b/test/Faker/Provider/uk_UA/PhoneNumberTest.php
@@ -14,7 +14,7 @@ class PhoneNumberTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new PhoneNumber($faker));

--- a/test/Faker/Provider/zh_TW/CompanyTest.php
+++ b/test/Faker/Provider/zh_TW/CompanyTest.php
@@ -13,7 +13,7 @@ class CompanyTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Company($faker));

--- a/test/Faker/Provider/zh_TW/PersonTest.php
+++ b/test/Faker/Provider/zh_TW/PersonTest.php
@@ -13,7 +13,7 @@ class PersonTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    protected function setUp()
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/zh_TW/TextTest.php
+++ b/test/Faker/Provider/zh_TW/TextTest.php
@@ -8,7 +8,7 @@ class TextTest extends TestCase
 {
     private $textClass;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->textClass = new \ReflectionClass('Faker\Provider\zh_TW\Text');
     }


### PR DESCRIPTION
This PR

* [x] reduces the visibility of `setUp()` and `tearDown()` from `public` to `protected`

💁‍♂ This is the visibility as declared on `PHPUnit\Framework\TestCase`, and there's probably no need to increase it.