### PR TITLE
Fix: Consistently indent YML files with 2 spaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,19 +3,19 @@ language: php
 dist: precise
 
 php:
-    - 5.3
-    - 5.4
-    - 5.5
-    - 5.6
-    - 7.0
-    - 7.1
-    - 7.2
-    - 7.3
-    - nightly
+  - 5.3
+  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
+  - nightly
 
 matrix:
-    allow_failures:
-        - nightly
+  allow_failures:
+    - nightly
 
 cache:
   directories:
@@ -25,6 +25,6 @@ before_install:
   - phpenv config-rm xdebug.ini || true
 
 before_script:
-    - travis_retry composer install --no-interaction --prefer-dist
+  - travis_retry composer install --no-interaction --prefer-dist
 
 script: make sniff test


### PR DESCRIPTION
This PR

* [x] consistently indents `.travis.yml` with 2 spaces

💁‍♂ Probably not needed when we decide to go with #1826.