### PR TITLE
Show supported version of UUID (version 3)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -292,6 +292,8 @@ Methods accepting a `$timezone` argument default to `date_default_timezone_get()
 
 ### `Faker\Provider\Uuid`
 
+Faker currently supports UUID version 3.
+
     uuid                   // '7e57d004-2b97-0e7a-b45f-5387367791cd'
 
 ### `Faker\Provider\Barcode`


### PR DESCRIPTION
Update readme to show supported version of UUID (version 3).

This got me recently where I assumed it was version 4 and I couldn't get the Faker generated UUID to validate. I wanted to ensure no-one else made the wrong assumption I made too by having it clearly in the readme!