### PR TITLE
Add named unique() "bags"

### DIFF
--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -15,9 +15,9 @@ class Base
     protected $generator;
 
     /**
-     * @var \Faker\UniqueGenerator
+     * @var \Faker\UniqueGenerator[]
      */
-    protected $unique;
+    protected $unique = [];
 
     /**
      * @param \Faker\Generator $generator
@@ -573,13 +573,13 @@ class Base
      *
      * @return UniqueGenerator A proxy class returning only non-existing values
      */
-    public function unique($reset = false, $maxRetries = 10000)
+    public function unique($bag = null, $reset = false, $maxRetries = 10000)
     {
         if ($reset || !$this->unique) {
-            $this->unique = new UniqueGenerator($this->generator, $maxRetries);
+            $this->unique[$bag] = new UniqueGenerator($this->generator, $maxRetries);
         }
 
-        return $this->unique;
+        return $this->unique[$bag];
     }
 
     /**


### PR DESCRIPTION
I want to seed two table columns independently from each other but with the same set of possible values, e.g. `[1, 2, 3, 4, 5, 6, 7, 8]`

My Laravel factory and seeder look like this:
```
// Factory
$factory->define(MyModel::class, function (Faker $faker) {
    return [
        'a' => $faker->unique()->randomElement([1, 2, 3, 4, 5, 6, 7, 8]),
        'b' => $faker->unique()->randomElement([1, 2, 3, 4, 5, 6, 7, 8])
    ];
});
// Seeder
public function run() {
    factory(MyModel::class, 4)->create();
}
```

Currently, the UniqueGenerator will save the existing values only by function name, e.g. `"randomElement"`. Therefore I can only seed up to 4 models and receive no `a` value as a `b` value.

**Solution:**
With this pull request I propose adding a `$bag` parameter to the `unique()` modifier to define independent sets of existing values. The given example factory could then be changed to

```
$factory->define(MyModel::class, function (Faker $faker) {
    return [
        'a' => $faker->unique('a')->randomElement([1, 2, 3, 4, 5, 6, 7, 8]),
        'b' => $faker->unique('b')->randomElement([1, 2, 3, 4, 5, 6, 7, 8])
    ];
});
```

This allows generation of up to 8 models with distinct values per column (`a` and `b`) but same values using the same formatter for different columns.

When used without the `$bag` parameter the behavior will not change.