### PR TITLE
fix phplint warnings (7.4)

### DIFF
--- a/src/Faker/Calculator/Luhn.php
+++ b/src/Faker/Calculator/Luhn.php
@@ -24,10 +24,10 @@ class Luhn
         $length = strlen($number);
         $sum = 0;
         for ($i = $length - 1; $i >= 0; $i -= 2) {
-            $sum += $number{$i};
+            $sum += $number[$i];
         }
         for ($i = $length - 2; $i >= 0; $i -= 2) {
-            $sum += array_sum(str_split($number{$i} * 2));
+            $sum += array_sum(str_split($number[$i] * 2));
         }
 
         return $sum % 10;

--- a/test/Faker/Provider/fi_FI/PersonTest.php
+++ b/test/Faker/Provider/fi_FI/PersonTest.php
@@ -71,12 +71,12 @@ class PersonTest extends TestCase
     public function testPersonalIdentityNumberGeneratesOddValuesForMales()
     {
         $pin = $this->faker->personalIdentityNumber(null, 'male');
-        $this->assertEquals(1, $pin{9} % 2);
+        $this->assertEquals(1, $pin[9] % 2);
     }
 
     public function testPersonalIdentityNumberGeneratesEvenValuesForFemales()
     {
         $pin = $this->faker->personalIdentityNumber(null, 'female');
-        $this->assertEquals(0, $pin{9} % 2);
+        $this->assertEquals(0, $pin[9] % 2);
     }
 }

--- a/test/Faker/Provider/sv_SE/PersonTest.php
+++ b/test/Faker/Provider/sv_SE/PersonTest.php
@@ -50,12 +50,12 @@ class PersonTest extends TestCase
     public function testPersonalIdentityNumberGeneratesOddValuesForMales()
     {
         $pin = $this->faker->personalIdentityNumber(null, 'male');
-        $this->assertEquals(1, $pin{9} % 2);
+        $this->assertEquals(1, $pin[9] % 2);
     }
 
     public function testPersonalIdentityNumberGeneratesEvenValuesForFemales()
     {
         $pin = $this->faker->personalIdentityNumber(null, 'female');
-        $this->assertEquals(0, $pin{9} % 2);
+        $this->assertEquals(0, $pin[9] % 2);
     }
 }


### PR DESCRIPTION
Array and string offset access syntax with curly braces is deprecated 