### PR TITLE
Fix: Run build against PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ jobs:
     - php: 7.1
     - php: 7.2
     - php: 7.3
+    - php: 7.4
+      dist: bionic
       env: WITH_COVERAGE=true
     - php: nightly
 


### PR DESCRIPTION
This PR

* [x] runs builds against PHP 7.4 instead of nightly

Related to #1847.