### PR TITLE
Trim randomHtml

### DIFF
--- a/src/Faker/Provider/HtmlLorem.php
+++ b/src/Faker/Provider/HtmlLorem.php
@@ -63,7 +63,7 @@ class HtmlLorem extends Base
         $html->appendChild($body);
 
         $document->appendChild($html);
-        return $document->saveHTML();
+        return trim($document->saveHTML());
     }
 
     private function addRandomSubTree(\DOMElement $root, $maxDepth, $maxWidth)

--- a/test/Faker/Provider/HtmlLoremTest.php
+++ b/test/Faker/Provider/HtmlLoremTest.php
@@ -15,7 +15,7 @@ class HtmlLoremTest extends TestCase
         $faker->addProvider(new HtmlLorem($faker));
         $node = $faker->randomHtml(6, 10);
         $this->assertStringStartsWith("<html>", $node);
-        $this->assertStringEndsWith("</html>\n", $node);
+        $this->assertStringEndsWith("</html>", $node);
     }
 
     public function testRandomHtmlReturnsValidHTMLString(){


### PR DESCRIPTION
I've been getting some failing tests recently when using `randomHtml()`.  Tracked it down to the fact that `(new \DomDocument)->saveHTML()` **always** ends the output with a newline character.

Laravel (and I'm guessing other frameworks) will automatically trim all input. Therefore if I'm running a test my database value is `<html></html>` while my expected value is `<html></html>\n`, resulting in a failure.

This seems like odd behavior to me to append this newline.  This PR trims the resulting HTML, and updates the test.

I realize I may have a very narrow scope of the use case, so interested to start the discussion and see if this is this simple of a fix.