### PR TITLE
Create en_GB specific e164 phone numbers

### DIFF
--- a/src/Faker/Provider/en_GB/PhoneNumber.php
+++ b/src/Faker/Provider/en_GB/PhoneNumber.php
@@ -40,4 +40,14 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     {
         return static::numerify(static::randomElement(static::$mobileFormats));
     }
+    
+    /**
+     * Return a en_GB fixed line number in e164 format
+     * @return string
+     */
+    public function e164PhoneNumber()
+    {
+        $formats = array('+441#########', '+442#########', '+443#########');
+        return static::numerify($this->generator->parse(static::randomElement($formats)));
+    }
 }


### PR DESCRIPTION
Currently when generating e164 phone numbers, all the digits are randomised however if you are validating that the number is a UK number, it needs to start `+44[1|2|3]` so this PR creates the en_GB specific override to do that.