### PR TITLE
Multiple values

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -113,6 +113,23 @@ for ($i = 0; $i < 10; $i++) {
   // Ms. Karley Kiehn V
 ```
 
+You can generate multiple fake data in one go by calling pluralized method with the quantity you need like so:
+
+```php
+<?php
+
+$faker->names(5);        // 5 names
+$faker->firstNames(2);   // 2 first names
+$faker->jobTitles(2);    // 2 job titles
+$faker->userNames(3);    // 3 usernames
+$faker->citySuffixes(2); // 2 city suffixes
+$faker->cities(4);       // 4 cities
+$faker->isbn10s(3);      // 3 isbn10
+
+// If you want to pass more args besides the quantity, you can do like so:
+$faker->unixTimes(2, '20 years ago'); // 2 unix timestamps before 20 years (from 1970 of course)
+```
+
 **Tip**: For a quick generation of fake data, you can also use Faker as a command line tool thanks to [faker-cli](https://github.com/bit3/faker-cli).
 
 ## Formatters
@@ -121,23 +138,23 @@ Each of the generator properties (like `name`, `address`, and `lorem`) are calle
 
 ### `Faker\Provider\Base`
 
-    randomDigit             // 7
-    randomDigitNot(5)       // 0, 1, 2, 3, 4, 6, 7, 8, or 9
-    randomDigitNotNull      // 5
-    randomNumber($nbDigits = NULL, $strict = false) // 79907610
-    randomFloat($nbMaxDecimals = NULL, $min = 0, $max = NULL) // 48.8932
-    numberBetween($min = 1000, $max = 9000) // 8567
-    randomLetter            // 'b'
+    randomDigit                                              // 7
+    randomDigitNot(5)                                        // 0, 1, 2, 3, 4, 6, 7, 8, or 9
+    randomDigitNotNull                                       // 5
+    randomNumber($nbDigits = NULL, $strict = false)          // 79907610
+    randomFloat($nbMaxDecimals = NULL, $min = 0, $max = NULL)// 48.8932
+    numberBetween($min = 1000, $max = 9000)                  // 8567
+    randomLetter                                             // 'b'
     // returns randomly ordered subsequence of a provided array
     randomElements($array = array ('a','b','c'), $count = 1) // array('c')
-    randomElement($array = array ('a','b','c')) // 'b'
-    shuffle('hello, world') // 'rlo,h eoldlw'
-    shuffle(array(1, 2, 3)) // array(2, 1, 3)
-    numerify('Hello ###') // 'Hello 609'
-    lexify('Hello ???') // 'Hello wgt'
-    bothify('Hello ##??') // 'Hello 42jz'
-    asciify('Hello ***') // 'Hello R6+'
-    regexify('[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}'); // sm0@y8k96a.ej
+    randomElement($array = array ('a','b','c'))              // 'b'
+    shuffle('hello, world')                                  // 'rlo,h eoldlw'
+    shuffle(array(1, 2, 3))                                  // array(2, 1, 3)
+    numerify('Hello ###')                                    // 'Hello 609'
+    lexify('Hello ???')                                      // 'Hello wgt'
+    bothify('Hello ##??')                                    // 'Hello 42jz'
+    asciify('Hello ***')                                     // 'Hello R6+'
+    regexify('[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}');      // sm0@y8k96a.ej
 
 ### `Faker\Provider\Lorem`
 

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -301,14 +301,18 @@ class Generator
     protected function isPluralized($method, $attributes)
     {
         if (isset($this->singularized[$method])) {
-            return true;
+            return (bool) $this->singularized[$method];
         }
 
         if (!isset($attributes[0]) || !is_int($attributes[0])) {
             return false;
         }
 
-        return $this->maybeSingular($method);
+        if (false === $flag = $this->maybeSingular($method)) {
+            $this->singularized[$method] = false;
+        }
+
+        return $flag;
     }
 
     protected function maybeSingular($method)

--- a/test/Faker/GeneratorTest.php
+++ b/test/Faker/GeneratorTest.php
@@ -106,6 +106,43 @@ final class GeneratorTest extends TestCase
         $this->assertEquals('bazfoo', $generator->fooFormatterWithArguments('foo'));
     }
 
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testPluralizedMagicCalls()
+    {
+        $generator = new Generator;
+        $provider = new FooProvider();
+        $generator->addProvider($provider);
+
+        $tests = $generator->tests(3, 'arg');
+        $fishes = $generator->fishes(2, 'L');
+        $cat = $generator->cat(1);
+        $cats = $generator->cats(2, 2);
+        $nums = $generator->nums();
+
+        $this->assertInternalType('array', $tests);
+        $this->assertCount(3, $tests);
+        $this->assertSame(array('test arg', 'test arg', 'test arg'), $tests);
+
+        $this->assertCount(2, $fishes);
+        $this->assertSame(array('fish (L)', 'fish (L)'), $fishes);
+
+        $this->assertInternalType('string', $cat);
+        $this->assertSame('cat 1', $cat);
+
+        $this->assertCount(2, $cats);
+        $this->assertSame(array('cat 2', 'cat 2'), $cats);
+
+        $this->assertInternalType('string', $nums);
+        $this->assertSame('foo::nums', $nums);
+
+        $this->assertCount(1, $generator->fishes(-1, 'S'));
+        $this->assertCount(1, $generator->fishes(0, 'M'));
+
+        $generator->logs(4);
+    }
+
     public function testSeed()
     {
         $generator = new Generator;
@@ -136,6 +173,26 @@ final class FooProvider
     public function fooFormatterWithArguments($value = '')
     {
         return 'baz' . $value;
+    }
+
+    public function nums()
+    {
+        return 'foo::nums';
+    }
+
+    public function test($arg = null)
+    {
+        return "test $arg";
+    }
+
+    public function fish($size = 'M')
+    {
+        return "fish ($size)";
+    }
+
+    public function cat($n)
+    {
+        return "cat $n";
     }
 }
 


### PR DESCRIPTION
Allows retrieving multiple values using pluralized magic calls in single go.

```php
$faker->names(5);        // 5 names
$faker->firstNames(2);   // 2 first names
$faker->jobTitles(2);    // 2 job titles
$faker->userNames(3);    // 3 usernames
$faker->citySuffixes(2); // 2 city suffixes
$faker->cities(4);       // 4 cities
$faker->isbn10s(3);      // 3 isbn10

// If you want to pass more args besides the quantity, you can do like so:
$faker->unixTimes(2, '20 years ago'); // 2 unix timestamps before 20 years (from 1970 of course)
```