### PR TITLE
Fix: use last name values instead of first name values

### DIFF
--- a/src/Faker/Provider/lt_LT/Person.php
+++ b/src/Faker/Provider/lt_LT/Person.php
@@ -14,8 +14,8 @@ class Person extends \Faker\Provider\Person
     );
 
     protected static $lastNameFormat = array(
-        '{{firstNameMale}}',
-        '{{firstNameFemale}}',
+        '{{lastNameMale}}',
+        '{{lastNameFemale}}',
     );
 
     protected static $titleMale = array('p.', 'ponas');


### PR DESCRIPTION
It was using first name values when generating random gender last name