### PR TITLE
Enhancement: Require phpunit/phpunit:^8.5.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-vendor
+.build/
+vendor/
 composer.lock

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "ext-intl": "*",
-        "phpunit/phpunit": "^4.8.35 || ^5.7",
+        "phpunit/phpunit": "^8.5.2",
         "squizlabs/php_codesniffer": "^3.5.4"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,6 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
     bootstrap="vendor/autoload.php"
+    cacheResultFile=".build/phpunit/result.cache"
     colors="true"
 >
     <testsuites>

--- a/test/Faker/Calculator/LuhnTest.php
+++ b/test/Faker/Calculator/LuhnTest.php
@@ -31,7 +31,7 @@ class LuhnTest extends TestCase
      */
     public function testComputeCheckDigit($partialNumber, $checkDigit)
     {
-        $this->assertInternalType('string', $checkDigit);
+        $this->assertIsString($checkDigit);
         $this->assertEquals($checkDigit, Luhn::computeCheckDigit($partialNumber));
     }
 
@@ -61,12 +61,12 @@ class LuhnTest extends TestCase
         $this->assertEquals($isValid, Luhn::isValid($number));
     }
 
-    /**
-     * @expectedException        InvalidArgumentException
-     * @expectedExceptionMessage Argument should be an integer.
-     */
+    
     public function testGenerateLuhnNumberWithInvalidPrefix()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Argument should be an integer.');
+
         Luhn::generateLuhnNumber('abc');
     }
 }

--- a/test/Faker/GeneratorTest.php
+++ b/test/Faker/GeneratorTest.php
@@ -20,7 +20,7 @@ class GeneratorTest extends TestCase
         $generator = new Generator;
         $provider = new FooProvider();
         $generator->addProvider($provider);
-        $this->assertInternalType('callable', $generator->getFormatter('fooFormatter'));
+        $this->assertIsCallable($generator->getFormatter('fooFormatter'));
     }
 
     public function testGetFormatterReturnsCorrectFormatter()
@@ -32,20 +32,20 @@ class GeneratorTest extends TestCase
         $this->assertEquals($expected, $generator->getFormatter('fooFormatter'));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
+    
     public function testGetFormatterThrowsExceptionOnIncorrectProvider()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $generator = new Generator;
         $generator->getFormatter('fooFormatter');
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
+    
     public function testGetFormatterThrowsExceptionOnIncorrectFormatter()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $generator = new Generator;
         $provider = new FooProvider();
         $generator->addProvider($provider);

--- a/test/Faker/Provider/AddressTest.php
+++ b/test/Faker/Provider/AddressTest.php
@@ -10,7 +10,7 @@ class AddressTest extends TestCase
 {
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Address($faker));
@@ -20,7 +20,7 @@ class AddressTest extends TestCase
     public function testLatitude()
     {
         $latitude = $this->faker->latitude();
-        $this->assertInternalType('float', $latitude);
+        $this->assertIsFloat($latitude);
         $this->assertGreaterThanOrEqual(-90, $latitude);
         $this->assertLessThanOrEqual(90, $latitude);
     }
@@ -28,7 +28,7 @@ class AddressTest extends TestCase
     public function testLongitude()
     {
         $longitude = $this->faker->longitude();
-        $this->assertInternalType('float', $longitude);
+        $this->assertIsFloat($longitude);
         $this->assertGreaterThanOrEqual(-180, $longitude);
         $this->assertLessThanOrEqual(180, $longitude);
     }
@@ -36,11 +36,11 @@ class AddressTest extends TestCase
     public function testCoordinate()
     {
         $coordinate = $this->faker->localCoordinates();
-        $this->assertInternalType('array', $coordinate);
-        $this->assertInternalType('float', $coordinate['latitude']);
+        $this->assertIsArray($coordinate);
+        $this->assertIsFloat($coordinate['latitude']);
         $this->assertGreaterThanOrEqual(-90, $coordinate['latitude']);
         $this->assertLessThanOrEqual(90, $coordinate['latitude']);
-        $this->assertInternalType('float', $coordinate['longitude']);
+        $this->assertIsFloat($coordinate['longitude']);
         $this->assertGreaterThanOrEqual(-180, $coordinate['longitude']);
         $this->assertLessThanOrEqual(180, $coordinate['longitude']);
     }

--- a/test/Faker/Provider/BarcodeTest.php
+++ b/test/Faker/Provider/BarcodeTest.php
@@ -10,7 +10,7 @@ class BarcodeTest extends TestCase
 {
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Barcode($faker));

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -10,7 +10,7 @@ class BaseTest extends TestCase
 {
     public function testRandomDigitReturnsInteger()
     {
-        $this->assertInternalType('integer', BaseProvider::randomDigit());
+        $this->assertIsInt(BaseProvider::randomDigit());
     }
 
     public function testRandomDigitReturnsDigit()
@@ -35,26 +35,26 @@ class BaseTest extends TestCase
         }
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
+    
     public function testRandomNumberThrowsExceptionWhenCalledWithAMax()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         BaseProvider::randomNumber(5, 200);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
+    
     public function testRandomNumberThrowsExceptionWhenCalledWithATooHighNumberOfDigits()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         BaseProvider::randomNumber(10);
     }
 
     public function testRandomNumberReturnsInteger()
     {
-        $this->assertInternalType('integer', BaseProvider::randomNumber());
-        $this->assertInternalType('integer', BaseProvider::randomNumber(5, false));
+        $this->assertIsInt(BaseProvider::randomNumber());
+        $this->assertIsInt(BaseProvider::randomNumber(5, false));
     }
 
     public function testRandomNumberReturnsDigit()
@@ -92,7 +92,7 @@ class BaseTest extends TestCase
 
         $parts = explode('.', $result);
 
-        $this->assertInternalType('float', $result);
+        $this->assertIsFloat($result);
         $this->assertGreaterThanOrEqual($min, $result);
         $this->assertLessThanOrEqual($max, $result);
         $this->assertLessThanOrEqual($nbMaxDecimals, strlen($parts[1]));
@@ -100,7 +100,7 @@ class BaseTest extends TestCase
 
     public function testRandomLetterReturnsString()
     {
-        $this->assertInternalType('string', BaseProvider::randomLetter());
+        $this->assertIsString(BaseProvider::randomLetter());
     }
 
     public function testRandomLetterReturnsSingleLetter()
@@ -116,7 +116,7 @@ class BaseTest extends TestCase
 
     public function testRandomAsciiReturnsString()
     {
-        $this->assertInternalType('string', BaseProvider::randomAscii());
+        $this->assertIsString(BaseProvider::randomAscii());
     }
 
     public function testRandomAsciiReturnsSingleCharacter()
@@ -160,19 +160,19 @@ class BaseTest extends TestCase
 
     public function testShuffleReturnsStringWhenPassedAStringArgument()
     {
-        $this->assertInternalType('string', BaseProvider::shuffle('foo'));
+        $this->assertIsString(BaseProvider::shuffle('foo'));
     }
 
     public function testShuffleReturnsArrayWhenPassedAnArrayArgument()
     {
-        $this->assertInternalType('array', BaseProvider::shuffle(array(1, 2, 3)));
+        $this->assertIsArray(BaseProvider::shuffle(array(1, 2, 3)));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
+    
     public function testShuffleThrowsExceptionWhenPassedAnInvalidArgument()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         BaseProvider::shuffle(false);
     }
 
@@ -227,11 +227,11 @@ class BaseTest extends TestCase
     {
         $string = 'acegi';
         $shuffleString = BaseProvider::shuffleString($string);
-        $this->assertContains('a', $shuffleString);
-        $this->assertContains('c', $shuffleString);
-        $this->assertContains('e', $shuffleString);
-        $this->assertContains('g', $shuffleString);
-        $this->assertContains('i', $shuffleString);
+        $this->assertStringContainsString('a', $shuffleString);
+        $this->assertStringContainsString('c', $shuffleString);
+        $this->assertStringContainsString('e', $shuffleString);
+        $this->assertStringContainsString('g', $shuffleString);
+        $this->assertStringContainsString('i', $shuffleString);
     }
 
     public function testShuffleStringReturnsADifferentStringThanTheOriginal()
@@ -456,11 +456,11 @@ class BaseTest extends TestCase
         $this->assertEquals(array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9), $values);
     }
 
-    /**
-     * @expectedException OverflowException
-     */
+    
     public function testUniqueThrowsExceptionWhenNoUniqueValueCanBeGenerated()
     {
+        $this->expectException(\OverflowException::class);
+
         $faker = new \Faker\Generator();
         $faker->addProvider(new \Faker\Provider\Base($faker));
         for ($i=0; $i < 11; $i++) {
@@ -514,11 +514,11 @@ class BaseTest extends TestCase
         $this->assertEquals(array(0, 2, 4, 6, 8), $uniqueValues);
     }
 
-    /**
-     * @expectedException OverflowException
-     */
+    
     public function testValidThrowsExceptionWhenNoValidValueCanBeGenerated()
     {
+        $this->expectException(\OverflowException::class);
+
         $faker = new \Faker\Generator();
         $faker->addProvider(new \Faker\Provider\Base($faker));
         $evenValidator = function($digit) {
@@ -529,22 +529,22 @@ class BaseTest extends TestCase
         }
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
+    
     public function testValidThrowsExceptionWhenParameterIsNotCollable()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $faker = new \Faker\Generator();
         $faker->addProvider(new \Faker\Provider\Base($faker));
         $faker->valid(12)->randomElement(array(1, 3, 5, 7, 9));
     }
 
-    /**
-     * @expectedException LengthException
-     * @expectedExceptionMessage Cannot get 2 elements, only 1 in array
-     */
+    
     public function testRandomElementsThrowsWhenRequestingTooManyKeys()
     {
+        $this->expectException(\LengthException::class);
+        $this->expectExceptionMessage('Cannot get 2 elements, only 1 in array');
+
         BaseProvider::randomElements(array('foo'), 2);
     }
 
@@ -553,7 +553,7 @@ class BaseTest extends TestCase
         $this->assertCount(1, BaseProvider::randomElements(), 'Should work without any input');
 
         $empty = BaseProvider::randomElements(array(), 0);
-        $this->assertInternalType('array', $empty);
+        $this->assertIsArray($empty);
         $this->assertCount(0, $empty);
 
         $shuffled = BaseProvider::randomElements(array('foo', 'bar', 'baz'), 3);

--- a/test/Faker/Provider/BiasedTest.php
+++ b/test/Faker/Provider/BiasedTest.php
@@ -12,7 +12,7 @@ class BiasedTest extends TestCase
     protected $generator;
     protected $results = array();
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->generator = new Generator();
         $this->generator->addProvider(new Biased($this->generator));

--- a/test/Faker/Provider/CompanyTest.php
+++ b/test/Faker/Provider/CompanyTest.php
@@ -14,7 +14,7 @@ class CompanyTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Company($faker));

--- a/test/Faker/Provider/DateTimeTest.php
+++ b/test/Faker/Provider/DateTimeTest.php
@@ -7,13 +7,13 @@ use PHPUnit\Framework\TestCase;
 
 class DateTimeTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->defaultTz = 'UTC';
         DateTimeProvider::setDefaultTimezone($this->defaultTz);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         DateTimeProvider::setDefaultTimezone();
     }
@@ -71,7 +71,7 @@ class DateTimeTest extends TestCase
     public function testUnixTime()
     {
         $timestamp = DateTimeProvider::unixTime();
-        $this->assertInternalType('int', $timestamp);
+        $this->assertIsInt($timestamp);
         $this->assertGreaterThanOrEqual(0, $timestamp);
         $this->assertLessThanOrEqual(time(), $timestamp);
     }

--- a/test/Faker/Provider/ImageTest.php
+++ b/test/Faker/Provider/ImageTest.php
@@ -64,11 +64,11 @@ class ImageTest extends TestCase
         $this->assertRegexp('#\d{5}#', $splitUrl[1]);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
+    
     public function testUrlWithDimensionsAndBadCategory()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         Image::imageUrl(800, 400, 'bullhonky');
     }
 

--- a/test/Faker/Provider/InternetTest.php
+++ b/test/Faker/Provider/InternetTest.php
@@ -16,7 +16,7 @@ class InternetTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Lorem($faker));

--- a/test/Faker/Provider/LoremTest.php
+++ b/test/Faker/Provider/LoremTest.php
@@ -7,11 +7,11 @@ use PHPUnit\Framework\TestCase;
 
 class LoremTest extends TestCase
 {
-    /**
-     * @expectedException \InvalidArgumentException
-     */
+    
     public function testTextThrowsExceptionWhenAskedTextSizeLessThan5()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         Lorem::text(4);
     }
 

--- a/test/Faker/Provider/PaymentTest.php
+++ b/test/Faker/Provider/PaymentTest.php
@@ -164,7 +164,11 @@ class PaymentTest extends TestCase
         $countryCode = array_pop($parts);
 
         if (!isset($this->ibanFormats[$countryCode])) {
-            // No IBAN format available
+            $this->markTestSkipped(sprintf(
+                'An IBAN format has not been configured for country with country code "%s".',
+                $countryCode
+            ));
+            
             return;
         }
 

--- a/test/Faker/Provider/PaymentTest.php
+++ b/test/Faker/Provider/PaymentTest.php
@@ -15,7 +15,7 @@ class PaymentTest extends TestCase
 {
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new BaseProvider($faker));

--- a/test/Faker/Provider/PhoneNumberTest.php
+++ b/test/Faker/Provider/PhoneNumberTest.php
@@ -15,7 +15,7 @@ class PhoneNumberTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new PhoneNumber($faker));

--- a/test/Faker/Provider/TextTest.php
+++ b/test/Faker/Provider/TextTest.php
@@ -42,7 +42,7 @@ class TextTest extends TestCase
 
     public function testTextMaxIndex()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
 
         $this->generator->realText(200, 11);
 
@@ -51,7 +51,7 @@ class TextTest extends TestCase
 
     public function testTextMinIndex()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
 
         $this->generator->realText(200, 0);
 
@@ -60,7 +60,7 @@ class TextTest extends TestCase
 
     public function testTextMinLength()
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
 
         $this->generator->realText(9);
 

--- a/test/Faker/Provider/UserAgentTest.php
+++ b/test/Faker/Provider/UserAgentTest.php
@@ -14,12 +14,12 @@ class UserAgentTest extends TestCase
 
     public function testFirefoxUserAgent()
     {
-        $this->stringContains(' Firefox/', UserAgent::firefox());
+        $this->assertStringContainsString(' Firefox/', UserAgent::firefox());
     }
 
     public function testSafariUserAgent()
     {
-        $this->stringContains('Safari/', UserAgent::safari());
+        $this->assertStringContainsString('Safari/', UserAgent::safari());
     }
 
     public function testInternetExplorerUserAgent()
@@ -34,6 +34,6 @@ class UserAgentTest extends TestCase
 
     public function testChromeUserAgent()
     {
-        $this->stringContains('(KHTML, like Gecko) Chrome/', UserAgent::chrome());
+        $this->assertStringContainsString('(KHTML, like Gecko) Chrome/', UserAgent::chrome());
     }
 }

--- a/test/Faker/Provider/ar_JO/InternetTest.php
+++ b/test/Faker/Provider/ar_JO/InternetTest.php
@@ -16,7 +16,7 @@ class InternetTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/ar_SA/InternetTest.php
+++ b/test/Faker/Provider/ar_SA/InternetTest.php
@@ -16,7 +16,7 @@ class InternetTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/at_AT/PaymentTest.php
+++ b/test/Faker/Provider/at_AT/PaymentTest.php
@@ -14,7 +14,7 @@ class PaymentTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Payment($faker));

--- a/test/Faker/Provider/bg_BG/PaymentTest.php
+++ b/test/Faker/Provider/bg_BG/PaymentTest.php
@@ -14,7 +14,7 @@ class PaymentTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Payment($faker));

--- a/test/Faker/Provider/bn_BD/PersonTest.php
+++ b/test/Faker/Provider/bn_BD/PersonTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class PersonTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/da_DK/InternetTest.php
+++ b/test/Faker/Provider/da_DK/InternetTest.php
@@ -16,7 +16,7 @@ class InternetTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/de_AT/AddressTest.php
+++ b/test/Faker/Provider/de_AT/AddressTest.php
@@ -14,7 +14,7 @@ class AddressTest extends TestCase
      */
     private $faker;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $faker = new Generator();
 

--- a/test/Faker/Provider/de_AT/InternetTest.php
+++ b/test/Faker/Provider/de_AT/InternetTest.php
@@ -16,7 +16,7 @@ class InternetTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/de_AT/PhoneNumberTest.php
+++ b/test/Faker/Provider/de_AT/PhoneNumberTest.php
@@ -14,7 +14,7 @@ class PhoneNumberTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new PhoneNumber($faker));

--- a/test/Faker/Provider/de_CH/AddressTest.php
+++ b/test/Faker/Provider/de_CH/AddressTest.php
@@ -15,7 +15,7 @@ class AddressTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Address($faker));
@@ -29,13 +29,13 @@ class AddressTest extends TestCase
     public function canton ()
     {
         $canton = $this->faker->canton();
-        $this->assertInternalType('array', $canton);
+        $this->assertIsArray($canton);
         $this->assertCount(1, $canton);
 
         foreach ($canton as $cantonShort => $cantonName){
-            $this->assertInternalType('string', $cantonShort);
+            $this->assertIsString($cantonShort);
             $this->assertEquals(2, strlen($cantonShort));
-            $this->assertInternalType('string', $cantonName);
+            $this->assertIsString($cantonName);
             $this->assertGreaterThan(2, strlen($cantonName));
         }
     }
@@ -46,7 +46,7 @@ class AddressTest extends TestCase
     public function cantonName ()
     {
         $cantonName = $this->faker->cantonName();
-        $this->assertInternalType('string', $cantonName);
+        $this->assertIsString($cantonName);
         $this->assertGreaterThan(2, strlen($cantonName));
     }
 
@@ -56,7 +56,7 @@ class AddressTest extends TestCase
     public function cantonShort ()
     {
         $cantonShort = $this->faker->cantonShort();
-        $this->assertInternalType('string', $cantonShort);
+        $this->assertIsString($cantonShort);
         $this->assertEquals(2, strlen($cantonShort));
     }
 
@@ -65,6 +65,6 @@ class AddressTest extends TestCase
      */
     public function address (){
         $address = $this->faker->address();
-        $this->assertInternalType('string', $address);
+        $this->assertIsString($address);
     }
 }

--- a/test/Faker/Provider/de_CH/InternetTest.php
+++ b/test/Faker/Provider/de_CH/InternetTest.php
@@ -16,7 +16,7 @@ class InternetTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/de_CH/PersonTest.php
+++ b/test/Faker/Provider/de_CH/PersonTest.php
@@ -11,7 +11,7 @@ class PersonTest extends TestCase
 {
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/de_CH/PhoneNumberTest.php
+++ b/test/Faker/Provider/de_CH/PhoneNumberTest.php
@@ -14,7 +14,7 @@ class PhoneNumberTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new PhoneNumber($faker));

--- a/test/Faker/Provider/de_DE/InternetTest.php
+++ b/test/Faker/Provider/de_DE/InternetTest.php
@@ -16,7 +16,7 @@ class InternetTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/el_GR/TextTest.php
+++ b/test/Faker/Provider/el_GR/TextTest.php
@@ -8,7 +8,7 @@ class TextTest extends TestCase
 {
     private $textClass;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->textClass = new \ReflectionClass('Faker\Provider\el_GR\Text');
     }

--- a/test/Faker/Provider/en_AU/AddressTest.php
+++ b/test/Faker/Provider/en_AU/AddressTest.php
@@ -14,7 +14,7 @@ class AddressTest extends TestCase
    */
   private $faker;
 
-  public function setUp()
+  public function setUp(): void
   {
     $faker = new Generator();
     $faker->addProvider(new Address($faker));
@@ -25,7 +25,7 @@ class AddressTest extends TestCase
   {
     $cityPrefix = $this->faker->cityPrefix();
     $this->assertNotEmpty($cityPrefix);
-    $this->assertInternalType('string', $cityPrefix);
+    $this->assertIsString($cityPrefix);
     $this->assertRegExp('/[A-Z][a-z]+/', $cityPrefix);
   }
 
@@ -33,7 +33,7 @@ class AddressTest extends TestCase
   {
     $streetSuffix = $this->faker->streetSuffix();
     $this->assertNotEmpty($streetSuffix);
-    $this->assertInternalType('string', $streetSuffix);
+    $this->assertIsString($streetSuffix);
     $this->assertRegExp('/[A-Z][a-z]+/', $streetSuffix);
   }
 
@@ -41,7 +41,7 @@ class AddressTest extends TestCase
   {
     $state = $this->faker->state();
     $this->assertNotEmpty($state);
-    $this->assertInternalType('string', $state);
+    $this->assertIsString($state);
     $this->assertRegExp('/[A-Z][a-z]+/', $state);
   }
 }

--- a/test/Faker/Provider/en_CA/AddressTest.php
+++ b/test/Faker/Provider/en_CA/AddressTest.php
@@ -14,7 +14,7 @@ class AddressTest extends TestCase
    */
   private $faker;
 
-  public function setUp()
+  public function setUp(): void
   {
     $faker = new Generator();
     $faker->addProvider(new Address($faker));
@@ -28,7 +28,7 @@ class AddressTest extends TestCase
   {
     $province = $this->faker->province();
     $this->assertNotEmpty($province);
-    $this->assertInternalType('string', $province);
+    $this->assertIsString($province);
     $this->assertRegExp('/[A-Z][a-z]+/', $province);
   }
 
@@ -39,7 +39,7 @@ class AddressTest extends TestCase
   {
     $provinceAbbr = $this->faker->provinceAbbr();
     $this->assertNotEmpty($provinceAbbr);
-    $this->assertInternalType('string', $provinceAbbr);
+    $this->assertIsString($provinceAbbr);
     $this->assertRegExp('/^[A-Z]{2}$/', $provinceAbbr);
   }
 
@@ -50,7 +50,7 @@ class AddressTest extends TestCase
   {
     $postcodeLetter = $this->faker->randomPostcodeLetter();
     $this->assertNotEmpty($postcodeLetter);
-    $this->assertInternalType('string', $postcodeLetter);
+    $this->assertIsString($postcodeLetter);
     $this->assertRegExp('/^[A-Z]{1}$/', $postcodeLetter);
   }
 
@@ -61,7 +61,7 @@ class AddressTest extends TestCase
   {
     $postcode = $this->faker->postcode();
     $this->assertNotEmpty($postcode);
-    $this->assertInternalType('string', $postcode);
+    $this->assertIsString($postcode);
     $this->assertRegExp('/^[A-Za-z]\d[A-Za-z][ -]?\d[A-Za-z]\d$/', $postcode);
   }
 }

--- a/test/Faker/Provider/en_GB/AddressTest.php
+++ b/test/Faker/Provider/en_GB/AddressTest.php
@@ -13,22 +13,20 @@ class AddressTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Address($faker));
         $this->faker = $faker;
     }
 
-    /**
-     *
-     */
+    
     public function testPostcode()
     {
 
         $postcode = $this->faker->postcode();
         $this->assertNotEmpty($postcode);
-        $this->assertInternalType('string', $postcode);
+        $this->assertIsString($postcode);
         $this->assertRegExp('@^(GIR ?0AA|[A-PR-UWYZ]([0-9]{1,2}|([A-HK-Y][0-9]([0-9ABEHMNPRV-Y])?)|[0-9][A-HJKPS-UW]) ?[0-9][ABD-HJLNP-UW-Z]{2})$@i', $postcode);
 
     }

--- a/test/Faker/Provider/en_IN/AddressTest.php
+++ b/test/Faker/Provider/en_IN/AddressTest.php
@@ -14,7 +14,7 @@ class AddressTest extends TestCase
    */
   private $faker;
 
-  public function setUp()
+  public function setUp(): void
   {
     $faker = new Generator();
     $faker->addProvider(new Address($faker));
@@ -25,7 +25,7 @@ class AddressTest extends TestCase
   {
     $city = $this->faker->city();
     $this->assertNotEmpty($city);
-    $this->assertInternalType('string', $city);
+    $this->assertIsString($city);
     $this->assertRegExp('/[A-Z][a-z]+/', $city);
   }
 
@@ -33,7 +33,7 @@ class AddressTest extends TestCase
   {
     $country = $this->faker->country();
     $this->assertNotEmpty($country);
-    $this->assertInternalType('string', $country);
+    $this->assertIsString($country);
     $this->assertRegExp('/[A-Z][a-z]+/', $country);
   }
 
@@ -41,7 +41,7 @@ class AddressTest extends TestCase
   {
     $localityName = $this->faker->localityName();
     $this->assertNotEmpty($localityName);
-    $this->assertInternalType('string', $localityName);
+    $this->assertIsString($localityName);
     $this->assertRegExp('/[A-Z][a-z]+/', $localityName);
   }
 
@@ -49,7 +49,7 @@ class AddressTest extends TestCase
   {
     $areaSuffix = $this->faker->areaSuffix();
     $this->assertNotEmpty($areaSuffix);
-    $this->assertInternalType('string', $areaSuffix);
+    $this->assertIsString($areaSuffix);
     $this->assertRegExp('/[A-Z][a-z]+/', $areaSuffix);
   }
 }

--- a/test/Faker/Provider/en_NG/AddressTest.php
+++ b/test/Faker/Provider/en_NG/AddressTest.php
@@ -14,22 +14,20 @@ class AddressTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Address($faker));
         $this->faker = $faker;
     }
 
-    /**
-     *
-     */
+    
     public function testPostcodeIsNotEmptyAndIsValid()
     {
         $postcode = $this->faker->postcode();
 
         $this->assertNotEmpty($postcode);
-        $this->assertInternalType('string', $postcode);
+        $this->assertIsString($postcode);
     }
 
     /**
@@ -40,7 +38,7 @@ class AddressTest extends TestCase
         $county = $this->faker->county;
 
         $this->assertNotEmpty($county);
-        $this->assertInternalType('string', $county);
+        $this->assertIsString($county);
     }
 
     /**
@@ -51,7 +49,7 @@ class AddressTest extends TestCase
         $region = $this->faker->region;
 
         $this->assertNotEmpty($region);
-        $this->assertInternalType('string', $region);
+        $this->assertIsString($region);
     }
 
 }

--- a/test/Faker/Provider/en_NG/InternetTest.php
+++ b/test/Faker/Provider/en_NG/InternetTest.php
@@ -15,7 +15,7 @@ class InternetTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));
@@ -28,6 +28,6 @@ class InternetTest extends TestCase
         $email = $this->faker->email();
         $this->assertNotFalse(filter_var($email, FILTER_VALIDATE_EMAIL));
         $this->assertNotEmpty($email);
-        $this->assertInternalType('string', $email);
+        $this->assertIsString($email);
     }
 }

--- a/test/Faker/Provider/en_NG/PersonTest.php
+++ b/test/Faker/Provider/en_NG/PersonTest.php
@@ -13,7 +13,7 @@ class PersonTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));
@@ -25,6 +25,6 @@ class PersonTest extends TestCase
         $name = $this->faker->name;
 
         $this->assertNotEmpty($name);
-        $this->assertInternalType('string', $name);
+        $this->assertIsString($name);
     }
 }

--- a/test/Faker/Provider/en_NG/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_NG/PhoneNumberTest.php
@@ -14,7 +14,7 @@ class PhoneNumberTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new PhoneNumber($faker));
@@ -26,7 +26,7 @@ class PhoneNumberTest extends TestCase
         $phoneNumber = $this->faker->phoneNumber();
 
         $this->assertNotEmpty($phoneNumber);
-        $this->assertInternalType('string', $phoneNumber);
+        $this->assertIsString($phoneNumber);
         $this->assertRegExp('/^(0|(\+234))\s?[789][01]\d\s?(\d{3}\s?\d{4})/', $phoneNumber);
     }
 }

--- a/test/Faker/Provider/en_NZ/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_NZ/PhoneNumberTest.php
@@ -14,7 +14,7 @@ class PhoneNumberTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new PhoneNumber($faker));

--- a/test/Faker/Provider/en_PH/AddressTest.php
+++ b/test/Faker/Provider/en_PH/AddressTest.php
@@ -14,7 +14,7 @@ class AddressTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
       $faker = new Generator();
       $faker->addProvider(new Address($faker));
@@ -25,26 +25,26 @@ class AddressTest extends TestCase
     {
       $province = $this->faker->province();
       $this->assertNotEmpty($province);
-      $this->assertInternalType('string', $province);
+      $this->assertIsString($province);
     }
 
     public function testCity()
     {
       $city = $this->faker->city();
       $this->assertNotEmpty($city);
-      $this->assertInternalType('string', $city);
+      $this->assertIsString($city);
     }
 
     public function testMunicipality()
     {
       $municipality = $this->faker->municipality();
       $this->assertNotEmpty($municipality);
-      $this->assertInternalType('string', $municipality);
+      $this->assertIsString($municipality);
     }
 
     public function testBarangay()
     {
       $barangay = $this->faker->barangay();
-      $this->assertInternalType('string', $barangay);
+      $this->assertIsString($barangay);
     }
 }

--- a/test/Faker/Provider/en_SG/AddressTest.php
+++ b/test/Faker/Provider/en_SG/AddressTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class AddressTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $faker = Factory::create('en_SG');
         $faker->addProvider(new Address($faker));

--- a/test/Faker/Provider/en_SG/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_SG/PhoneNumberTest.php
@@ -10,7 +10,7 @@ class PhoneNumberTest extends TestCase
 {
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->faker = Factory::create('en_SG');
         $this->faker->seed(1);

--- a/test/Faker/Provider/en_UG/AddressTest.php
+++ b/test/Faker/Provider/en_UG/AddressTest.php
@@ -14,7 +14,7 @@ class AddressTest extends TestCase
  */
   private $faker;
 
-  public function setUp()
+  public function setUp(): void
   {
       $faker = new Generator();
       $faker->addProvider(new Address($faker));
@@ -25,20 +25,20 @@ class AddressTest extends TestCase
   {
     $city = $this->faker->cityName();
     $this->assertNotEmpty($city);
-    $this->assertInternalType('string', $city);
+    $this->assertIsString($city);
   }
 
   public function testDistrict()
   {
     $district = $this->faker->district();
     $this->assertNotEmpty($district);
-    $this->assertInternalType('string', $district);
+    $this->assertIsString($district);
   }
 
   public function testRegion()
   {
     $region = $this->faker->region();
     $this->assertNotEmpty($region);
-    $this->assertInternaltype('string', $region);
+    $this->assertIsString($region);
   }
 }

--- a/test/Faker/Provider/en_US/CompanyTest.php
+++ b/test/Faker/Provider/en_US/CompanyTest.php
@@ -14,7 +14,7 @@ class CompanyTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Company($faker));

--- a/test/Faker/Provider/en_US/PaymentTest.php
+++ b/test/Faker/Provider/en_US/PaymentTest.php
@@ -13,7 +13,7 @@ class PaymentTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Payment($faker));

--- a/test/Faker/Provider/en_US/PersonTest.php
+++ b/test/Faker/Provider/en_US/PersonTest.php
@@ -14,7 +14,7 @@ class PersonTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/en_US/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_US/PhoneNumberTest.php
@@ -14,7 +14,7 @@ class PhoneNumberTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new PhoneNumber($faker));

--- a/test/Faker/Provider/en_ZA/CompanyTest.php
+++ b/test/Faker/Provider/en_ZA/CompanyTest.php
@@ -10,7 +10,7 @@ class CompanyTest extends TestCase
 {
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Company($faker));

--- a/test/Faker/Provider/en_ZA/InternetTest.php
+++ b/test/Faker/Provider/en_ZA/InternetTest.php
@@ -16,7 +16,7 @@ class InternetTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/en_ZA/PersonTest.php
+++ b/test/Faker/Provider/en_ZA/PersonTest.php
@@ -11,7 +11,7 @@ class PersonTest extends TestCase
 {
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));
@@ -25,7 +25,7 @@ class PersonTest extends TestCase
 
         $this->assertEquals(13, strlen($idNumber));
         $this->assertRegExp('#^\d{13}$#', $idNumber);
-        $this->assertInternalType('string', $idNumber);
+        $this->assertIsString($idNumber);
     }
 
     public function testIdNumberForMales()

--- a/test/Faker/Provider/en_ZA/PhoneNumberTest.php
+++ b/test/Faker/Provider/en_ZA/PhoneNumberTest.php
@@ -10,7 +10,7 @@ class PhoneNumberTest extends TestCase
 {
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new PhoneNumber($faker));

--- a/test/Faker/Provider/es_ES/PaymentTest.php
+++ b/test/Faker/Provider/es_ES/PaymentTest.php
@@ -13,7 +13,7 @@ class PaymentTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Payment($faker));

--- a/test/Faker/Provider/es_ES/PersonTest.php
+++ b/test/Faker/Provider/es_ES/PersonTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class PersonTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->seed(1);

--- a/test/Faker/Provider/es_ES/PhoneNumberTest.php
+++ b/test/Faker/Provider/es_ES/PhoneNumberTest.php
@@ -5,9 +5,9 @@ namespace Faker\Test\Provider\es_ES;
 use Faker\Generator;
 use Faker\Provider\es_ES\PhoneNumber;
 
-class PhoneNumberTest extends \PHPUnit_Framework_TestCase
+class PhoneNumberTest extends \PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new PhoneNumber($faker));

--- a/test/Faker/Provider/es_ES/TextTest.php
+++ b/test/Faker/Provider/es_ES/TextTest.php
@@ -13,7 +13,7 @@ class TextTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Text($faker));

--- a/test/Faker/Provider/es_PE/PersonTest.php
+++ b/test/Faker/Provider/es_PE/PersonTest.php
@@ -13,7 +13,7 @@ class PersonTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->seed(1);

--- a/test/Faker/Provider/es_VE/CompanyTest.php
+++ b/test/Faker/Provider/es_VE/CompanyTest.php
@@ -18,7 +18,7 @@ class CompanyTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->seed(1);

--- a/test/Faker/Provider/es_VE/PersonTest.php
+++ b/test/Faker/Provider/es_VE/PersonTest.php
@@ -19,7 +19,7 @@ class PersonTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->seed(1);

--- a/test/Faker/Provider/fa_IR/PersonTest.php
+++ b/test/Faker/Provider/fa_IR/PersonTest.php
@@ -14,7 +14,7 @@ class PersonTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/fi_FI/InternetTest.php
+++ b/test/Faker/Provider/fi_FI/InternetTest.php
@@ -16,7 +16,7 @@ class InternetTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/fi_FI/PersonTest.php
+++ b/test/Faker/Provider/fi_FI/PersonTest.php
@@ -12,7 +12,7 @@ class PersonTest extends TestCase
     /** @var Generator */
     protected $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new DateTime($faker));

--- a/test/Faker/Provider/fr_BE/PaymentTest.php
+++ b/test/Faker/Provider/fr_BE/PaymentTest.php
@@ -13,7 +13,7 @@ class PaymentTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Payment($faker));

--- a/test/Faker/Provider/fr_CH/AddressTest.php
+++ b/test/Faker/Provider/fr_CH/AddressTest.php
@@ -15,7 +15,7 @@ class AddressTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Address($faker));
@@ -29,13 +29,13 @@ class AddressTest extends TestCase
     public function canton ()
     {
         $canton = $this->faker->canton();
-        $this->assertInternalType('array', $canton);
+        $this->assertIsArray($canton);
         $this->assertCount(1, $canton);
 
         foreach ($canton as $cantonShort => $cantonName){
-            $this->assertInternalType('string', $cantonShort);
+            $this->assertIsString($cantonShort);
             $this->assertEquals(2, strlen($cantonShort));
-            $this->assertInternalType('string', $cantonName);
+            $this->assertIsString($cantonName);
             $this->assertGreaterThan(2, strlen($cantonName));
         }
     }
@@ -46,7 +46,7 @@ class AddressTest extends TestCase
     public function cantonName ()
     {
         $cantonName = $this->faker->cantonName();
-        $this->assertInternalType('string', $cantonName);
+        $this->assertIsString($cantonName);
         $this->assertGreaterThan(2, strlen($cantonName));
     }
 
@@ -56,7 +56,7 @@ class AddressTest extends TestCase
     public function cantonShort ()
     {
         $cantonShort = $this->faker->cantonShort();
-        $this->assertInternalType('string', $cantonShort);
+        $this->assertIsString($cantonShort);
         $this->assertEquals(2, strlen($cantonShort));
     }
 
@@ -65,6 +65,6 @@ class AddressTest extends TestCase
      */
     public function address (){
         $address = $this->faker->address();
-        $this->assertInternalType('string', $address);
+        $this->assertIsString($address);
     }
 }

--- a/test/Faker/Provider/fr_CH/InternetTest.php
+++ b/test/Faker/Provider/fr_CH/InternetTest.php
@@ -16,7 +16,7 @@ class InternetTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/fr_CH/PersonTest.php
+++ b/test/Faker/Provider/fr_CH/PersonTest.php
@@ -11,7 +11,7 @@ class PersonTest extends TestCase
 {
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/fr_CH/PhoneNumberTest.php
+++ b/test/Faker/Provider/fr_CH/PhoneNumberTest.php
@@ -14,7 +14,7 @@ class PhoneNumberTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new PhoneNumber($faker));

--- a/test/Faker/Provider/fr_FR/AddressTest.php
+++ b/test/Faker/Provider/fr_FR/AddressTest.php
@@ -14,7 +14,7 @@ class AddressTest extends TestCase
  */
   private $faker;
 
-  public function setUp()
+  public function setUp(): void
   {
       $faker = new Generator();
       $faker->addProvider(new Address($faker));
@@ -25,6 +25,6 @@ class AddressTest extends TestCase
   {
     $secondaryAdress = $this->faker->secondaryAddress();
     $this->assertNotEmpty($secondaryAdress);
-    $this->assertInternalType('string', $secondaryAdress);
+    $this->assertIsString($secondaryAdress);
   }
 }

--- a/test/Faker/Provider/fr_FR/CompanyTest.php
+++ b/test/Faker/Provider/fr_FR/CompanyTest.php
@@ -11,7 +11,7 @@ class CompanyTest extends TestCase
 {
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Company($faker));

--- a/test/Faker/Provider/fr_FR/PaymentTest.php
+++ b/test/Faker/Provider/fr_FR/PaymentTest.php
@@ -11,7 +11,7 @@ class PaymentTest extends TestCase
 {
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Payment($faker));

--- a/test/Faker/Provider/fr_FR/PersonTest.php
+++ b/test/Faker/Provider/fr_FR/PersonTest.php
@@ -10,7 +10,7 @@ class PersonTest extends TestCase
 {
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/fr_FR/PhoneNumberTest.php
+++ b/test/Faker/Provider/fr_FR/PhoneNumberTest.php
@@ -13,7 +13,7 @@ class PhoneNumberTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new PhoneNumber($faker));

--- a/test/Faker/Provider/fr_FR/TextTest.php
+++ b/test/Faker/Provider/fr_FR/TextTest.php
@@ -8,7 +8,7 @@ class TextTest extends TestCase
 {
     private $textClass;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->textClass = new \ReflectionClass('Faker\Provider\fr_FR\Text');
     }

--- a/test/Faker/Provider/id_ID/PersonTest.php
+++ b/test/Faker/Provider/id_ID/PersonTest.php
@@ -47,7 +47,7 @@ class PersonTest extends TestCase
         '9171', '9201', '9202', '9203', '9204', '9205', '9206', '9207', '9208', '9209', '9210', '9211', '9212', '9271',
     );
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/it_CH/AddressTest.php
+++ b/test/Faker/Provider/it_CH/AddressTest.php
@@ -15,7 +15,7 @@ class AddressTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Address($faker));
@@ -29,13 +29,13 @@ class AddressTest extends TestCase
     public function canton ()
     {
         $canton = $this->faker->canton();
-        $this->assertInternalType('array', $canton);
+        $this->assertIsArray($canton);
         $this->assertCount(1, $canton);
 
         foreach ($canton as $cantonShort => $cantonName){
-            $this->assertInternalType('string', $cantonShort);
+            $this->assertIsString($cantonShort);
             $this->assertEquals(2, strlen($cantonShort));
-            $this->assertInternalType('string', $cantonName);
+            $this->assertIsString($cantonName);
             $this->assertGreaterThan(2, strlen($cantonName));
         }
     }
@@ -46,7 +46,7 @@ class AddressTest extends TestCase
     public function cantonName ()
     {
         $cantonName = $this->faker->cantonName();
-        $this->assertInternalType('string', $cantonName);
+        $this->assertIsString($cantonName);
         $this->assertGreaterThan(2, strlen($cantonName));
     }
 
@@ -56,7 +56,7 @@ class AddressTest extends TestCase
     public function cantonShort ()
     {
         $cantonShort = $this->faker->cantonShort();
-        $this->assertInternalType('string', $cantonShort);
+        $this->assertIsString($cantonShort);
         $this->assertEquals(2, strlen($cantonShort));
     }
 
@@ -65,6 +65,6 @@ class AddressTest extends TestCase
      */
     public function address (){
         $address = $this->faker->address();
-        $this->assertInternalType('string', $address);
+        $this->assertIsString($address);
     }
 }

--- a/test/Faker/Provider/it_CH/InternetTest.php
+++ b/test/Faker/Provider/it_CH/InternetTest.php
@@ -16,7 +16,7 @@ class InternetTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/it_CH/PersonTest.php
+++ b/test/Faker/Provider/it_CH/PersonTest.php
@@ -11,7 +11,7 @@ class PersonTest extends TestCase
 {
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/it_CH/PhoneNumberTest.php
+++ b/test/Faker/Provider/it_CH/PhoneNumberTest.php
@@ -14,7 +14,7 @@ class PhoneNumberTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new PhoneNumber($faker));

--- a/test/Faker/Provider/it_IT/CompanyTest.php
+++ b/test/Faker/Provider/it_IT/CompanyTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class CompanyTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Company($faker));

--- a/test/Faker/Provider/it_IT/PersonTest.php
+++ b/test/Faker/Provider/it_IT/PersonTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class PersonTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/ka_GE/TextTest.php
+++ b/test/Faker/Provider/ka_GE/TextTest.php
@@ -8,7 +8,7 @@ class TextTest extends TestCase
 {
     private $textClass;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->textClass = new \ReflectionClass('Faker\Provider\el_GR\Text');
     }

--- a/test/Faker/Provider/kk_KZ/CompanyTest.php
+++ b/test/Faker/Provider/kk_KZ/CompanyTest.php
@@ -11,7 +11,7 @@ class CompanyTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->faker = new Generator();
 

--- a/test/Faker/Provider/kk_KZ/PersonTest.php
+++ b/test/Faker/Provider/kk_KZ/PersonTest.php
@@ -12,7 +12,7 @@ class PersonTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->faker = new Generator();
 

--- a/test/Faker/Provider/kk_KZ/TextTest.php
+++ b/test/Faker/Provider/kk_KZ/TextTest.php
@@ -8,7 +8,7 @@ class TextTest extends TestCase
 {
     private $textClass;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->textClass = new \ReflectionClass('Faker\Provider\kk_KZ\Text');
     }

--- a/test/Faker/Provider/ko_KR/TextTest.php
+++ b/test/Faker/Provider/ko_KR/TextTest.php
@@ -8,7 +8,7 @@ class TextTest extends TestCase
 {
     private $textClass;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->textClass = new \ReflectionClass('Faker\Provider\el_GR\Text');
     }

--- a/test/Faker/Provider/ms_MY/PersonTest.php
+++ b/test/Faker/Provider/ms_MY/PersonTest.php
@@ -13,7 +13,7 @@ class PersonTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/nb_NO/PhoneNumberTest.php
+++ b/test/Faker/Provider/nb_NO/PhoneNumberTest.php
@@ -10,7 +10,7 @@ class PhoneNumberTest extends TestCase
 {
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new PhoneNumber($faker));

--- a/test/Faker/Provider/nl_BE/PaymentTest.php
+++ b/test/Faker/Provider/nl_BE/PaymentTest.php
@@ -13,7 +13,7 @@ class PaymentTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Payment($faker));

--- a/test/Faker/Provider/nl_BE/PersonTest.php
+++ b/test/Faker/Provider/nl_BE/PersonTest.php
@@ -17,7 +17,7 @@ class PersonTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/nl_NL/CompanyTest.php
+++ b/test/Faker/Provider/nl_NL/CompanyTest.php
@@ -10,7 +10,7 @@ class CompanyTest extends TestCase
 {
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Company($faker));

--- a/test/Faker/Provider/nl_NL/PersonTest.php
+++ b/test/Faker/Provider/nl_NL/PersonTest.php
@@ -10,7 +10,7 @@ class PersonTest extends TestCase
 {
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/pl_PL/AddressTest.php
+++ b/test/Faker/Provider/pl_PL/AddressTest.php
@@ -12,7 +12,7 @@ class AddressTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Address($faker));
@@ -26,7 +26,7 @@ class AddressTest extends TestCase
     {
         $state = $this->faker->state();
         $this->assertNotEmpty($state);
-        $this->assertInternalType('string', $state);
+        $this->assertIsString($state);
         $this->assertRegExp('/[a-z]+/', $state);
     }
 }

--- a/test/Faker/Provider/pl_PL/PersonTest.php
+++ b/test/Faker/Provider/pl_PL/PersonTest.php
@@ -13,7 +13,7 @@ class PersonTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/pt_BR/CompanyTest.php
+++ b/test/Faker/Provider/pt_BR/CompanyTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 class CompanyTest extends TestCase
 {
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Company($faker));

--- a/test/Faker/Provider/pt_BR/PersonTest.php
+++ b/test/Faker/Provider/pt_BR/PersonTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 class PersonTest extends TestCase
 {
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/pt_PT/AddressTest.php
+++ b/test/Faker/Provider/pt_PT/AddressTest.php
@@ -15,7 +15,7 @@ class AddressTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Address($faker));

--- a/test/Faker/Provider/pt_PT/PersonTest.php
+++ b/test/Faker/Provider/pt_PT/PersonTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 class PersonTest extends TestCase
 {
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/pt_PT/PhoneNumberTest.php
+++ b/test/Faker/Provider/pt_PT/PhoneNumberTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class PhoneNumberTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new PhoneNumber($faker));

--- a/test/Faker/Provider/ro_RO/PersonTest.php
+++ b/test/Faker/Provider/ro_RO/PersonTest.php
@@ -17,7 +17,7 @@ class PersonTest extends TestCase
      */
     protected $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new DateTime($faker));
@@ -26,7 +26,7 @@ class PersonTest extends TestCase
         $this->faker = $faker;
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->faker->setDefaultTimezone();
     }
@@ -93,9 +93,7 @@ class PersonTest extends TestCase
             array(Person::GENDER_FEMALE, '1981-06-16','B2', false, '981061642'),
         );
     }
-    /**
-     *
-     */
+    
     public function test_allRandom_returnsValidCnp()
     {
         $cnp = $this->faker->cnp;
@@ -105,9 +103,7 @@ class PersonTest extends TestCase
         );
     }
 
-    /**
-     *
-     */
+    
     public function test_validGender_returnsValidCnp()
     {
         $cnp = $this->faker->cnp(Person::GENDER_MALE);
@@ -130,7 +126,7 @@ class PersonTest extends TestCase
      */
     public function test_invalidGender_throwsException($value)
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         $this->faker->cnp($value);
     }
 
@@ -155,7 +151,7 @@ class PersonTest extends TestCase
      */
     public function test_invalidYear_throwsException($value)
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         $this->faker->cnp(null, $value);
     }
 
@@ -178,13 +174,11 @@ class PersonTest extends TestCase
      */
     public function test_invalidCountyCode_throwsException($value)
     {
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         $this->faker->cnp(null, null, $value);
     }
 
-    /**
-     *
-     */
+    
     public function test_nonResident_returnsValidCnp()
     {
         $cnp = $this->faker->cnp(null, null, null, false);

--- a/test/Faker/Provider/ro_RO/PhoneNumberTest.php
+++ b/test/Faker/Provider/ro_RO/PhoneNumberTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class PhoneNumberTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new PhoneNumber($faker));

--- a/test/Faker/Provider/ru_RU/CompanyTest.php
+++ b/test/Faker/Provider/ru_RU/CompanyTest.php
@@ -13,7 +13,7 @@ class CompanyTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Company($faker));

--- a/test/Faker/Provider/ru_RU/PersonTest.php
+++ b/test/Faker/Provider/ru_RU/PersonTest.php
@@ -13,7 +13,7 @@ class PersonTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/ru_RU/TextTest.php
+++ b/test/Faker/Provider/ru_RU/TextTest.php
@@ -8,7 +8,7 @@ class TextTest extends TestCase
 {
     private $textClass;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->textClass = new \ReflectionClass('Faker\Provider\ru_RU\Text');
     }

--- a/test/Faker/Provider/sv_SE/PersonTest.php
+++ b/test/Faker/Provider/sv_SE/PersonTest.php
@@ -12,7 +12,7 @@ class PersonTest extends TestCase
     /** @var Generator */
     protected $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/tr_TR/CompanyTest.php
+++ b/test/Faker/Provider/tr_TR/CompanyTest.php
@@ -14,7 +14,7 @@ class CompanyTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Company($faker));

--- a/test/Faker/Provider/tr_TR/PaymentTest.php
+++ b/test/Faker/Provider/tr_TR/PaymentTest.php
@@ -13,7 +13,7 @@ class PaymentTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Payment($faker));

--- a/test/Faker/Provider/tr_TR/PersonTest.php
+++ b/test/Faker/Provider/tr_TR/PersonTest.php
@@ -15,7 +15,7 @@ class PersonTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/tr_TR/PhoneNumberTest.php
+++ b/test/Faker/Provider/tr_TR/PhoneNumberTest.php
@@ -14,7 +14,7 @@ class PhoneNumberTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new PhoneNumber($faker));

--- a/test/Faker/Provider/uk_UA/AddressTest.php
+++ b/test/Faker/Provider/uk_UA/AddressTest.php
@@ -14,7 +14,7 @@ class AddressTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Address($faker));

--- a/test/Faker/Provider/uk_UA/PhoneNumberTest.php
+++ b/test/Faker/Provider/uk_UA/PhoneNumberTest.php
@@ -14,7 +14,7 @@ class PhoneNumberTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new PhoneNumber($faker));

--- a/test/Faker/Provider/zh_TW/CompanyTest.php
+++ b/test/Faker/Provider/zh_TW/CompanyTest.php
@@ -13,7 +13,7 @@ class CompanyTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Company($faker));

--- a/test/Faker/Provider/zh_TW/PersonTest.php
+++ b/test/Faker/Provider/zh_TW/PersonTest.php
@@ -13,7 +13,7 @@ class PersonTest extends TestCase
      */
     private $faker;
 
-    public function setUp()
+    public function setUp(): void
     {
         $faker = new Generator();
         $faker->addProvider(new Person($faker));

--- a/test/Faker/Provider/zh_TW/TextTest.php
+++ b/test/Faker/Provider/zh_TW/TextTest.php
@@ -8,7 +8,7 @@ class TextTest extends TestCase
 {
     private $textClass;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->textClass = new \ReflectionClass('Faker\Provider\zh_TW\Text');
     }


### PR DESCRIPTION
This PR

* [x] requires `phpunit/phpunit:^8.5.2`
* [x] migrates tests
* [x] fixes risky tests

💁‍♂ Since we require PHP 7.2, we can also use `phpunit/phpunit:^8.5.2`.