### PR TITLE
Fix: Configure preferred installation method via composer.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,4 @@ test: vendor/autoload.php ## Runs tests with phpunit
 	vendor/bin/phpunit --verbose
 
 vendor/autoload.php:
-	composer install --no-interaction --prefer-dist
+	composer install --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         }
     },
     "config": {
+        "preferred-install": "dist",
         "sort-packages": true
     }
 }


### PR DESCRIPTION
This PR

* [x] configures the preferred installation method via `composer.json` instead of specifying the corresponding option in `Makefile`