### PR TITLE
Added script to run tests using local PhpUnit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,9 @@
             "Faker\\Test\\": "test/Faker/"
         }
     },
+    "scripts": {
+      "test": "phpunit"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "1.9-dev"


### PR DESCRIPTION
Just added a *Composer* script to the project  to run tests using project's PhpUnit dependency . A nice turnarround for those who have incompatible PhpUnit versions installed globally.

Just run `composer run test` in terminal.