### PR TITLE
Fix: Add type and return type declarations to seed()

### DIFF
--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -210,15 +210,15 @@ class Generator
         return $this->providers;
     }
 
-    public function seed($seed = null)
+    public function seed(int $seed = null): void
     {
         if ($seed === null) {
             mt_srand();
         } else {
             if (PHP_VERSION_ID < 70100) {
-                mt_srand((int) $seed);
+                mt_srand($seed);
             } else {
-                mt_srand((int) $seed, MT_RAND_PHP);
+                mt_srand($seed, MT_RAND_PHP);
             }
         }
     }

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -215,11 +215,7 @@ class Generator
         if ($seed === null) {
             mt_srand();
         } else {
-            if (PHP_VERSION_ID < 70100) {
-                mt_srand($seed);
-            } else {
-                mt_srand($seed, MT_RAND_PHP);
-            }
+            mt_srand($seed, MT_RAND_PHP);
         }
     }
 

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -214,9 +214,11 @@ class Generator
     {
         if ($seed === null) {
             mt_srand();
-        } else {
-            mt_srand($seed, MT_RAND_PHP);
+
+            return;
         }
+
+        mt_srand($seed, MT_RAND_PHP);
     }
 
     public function format($formatter, $arguments = array())


### PR DESCRIPTION
This PR

* [x] adds type and return type declarations to `Faker\Generator::seed()`
* [x] cleans up underlying code

Fixes #1934.