### PR TITLE
ro_RO Person: fixed generating first and last day of year

### DIFF
--- a/src/Faker/Provider/ro_RO/Person.php
+++ b/src/Faker/Provider/ro_RO/Person.php
@@ -153,7 +153,7 @@ class Person extends \Faker\Provider\Person
         } else {
             $dateOfBirthParts = explode('-', $dateOfBirth);
         }
-        $baseDate = \Faker\Provider\DateTime::dateTimeBetween("first day of {$dateOfBirthParts[0]}", "last day of {$dateOfBirthParts[0]}");
+        $baseDate = \Faker\Provider\DateTime::dateTimeBetween("first day of January {$dateOfBirthParts[0]}", "last day of December {$dateOfBirthParts[0]}");
 
         switch (count($dateOfBirthParts)) {
             case 1:
@@ -169,7 +169,7 @@ class Person extends \Faker\Provider\Person
         }
 
         if ($dateOfBirthParts[0] < 1800 || $dateOfBirthParts[0] > 2099) {
-            throw new \InvalidArgumentException("Invalid date of birth - year must be between 1900 and 2099, '{$dateOfBirthParts[0]}' received");
+            throw new \InvalidArgumentException("Invalid date of birth - year must be between 1800 and 2099, '{$dateOfBirthParts[0]}' received");
         }
 
         $dateOfBirthFinal = implode('-', $dateOfBirthParts);


### PR DESCRIPTION
I've noticed in Febuary tests in all PRs fail because of Romanian Person provider.
I found out it was because the first and last day of the year was generated incorrectly. 
This made the provider in one of the tests to generate non-existing date `1983-02-29` which was then compared against `1983-03-01`
PHP function `strtotime()` assumes that when no month name is given, the first day of current month in the specified year is generated.

The tests are likely to pass in the following months without this update.