### PR TITLE
Enhancement: Collect code coverage using pcov

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -101,7 +101,7 @@ jobs:
       - name: "Install PHP with extensions"
         uses: shivammathur/setup-php@v1
         with:
-          coverage: xdebug
+          coverage: pcov
           extensions: "intl"
           php-version: ${{ matrix.php-version }}
 
@@ -119,7 +119,7 @@ jobs:
       - name: "Create build directory"
         run: mkdir -p .build/logs
 
-      - name: "Collect code coverage with Xdebug and phpunit/phpunit"
+      - name: "Collect code coverage with pcov and phpunit/phpunit"
         run: vendor/bin/phpunit --coverage-clover=.build/logs/clover.xml
 
       - name: "Send code coverage report to Codecov.io"


### PR DESCRIPTION
This PR

* [x] uses `pcov` to collect code coverage instead of `Xdebug`

Follows #1890.

💁‍♂ It's a lot faster!