### PR TITLE
Enhancement: Require error level 7

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
     cacheDirectory=".build/psalm"
     errorBaseline="psalm-baseline.xml"
-    errorLevel="8"
+    errorLevel="7"
     resolveFromConfigFile="true"
     totallyTyped="false"
 >


### PR DESCRIPTION
This PR

* [x] requires error level 7 for `vimeo/psalm`

Follows #1897.

💁‍♂ The idea is to raise the error level one by one and fix issues as we encounter them.