### PR TITLE
Enhancement: Reference schema for phpcs configuration

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0"?>
-<ruleset name="fzaninotto/faker">
+<ruleset
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd"
+    name="fzaninotto/faker"
+>
     <description>Coding standard for fzaninotto/faker</description>
 
     <file>src/</file>


### PR DESCRIPTION
This PR

* [x] references `phpcs.xsd` as installed with `composer` in `phpcs.xml`

Follows #1896.

💁‍♂ Helps with auto-completion!