### PR TITLE
Enhancement: Use colors when running phpcbf or phpcs

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -13,5 +13,6 @@
 
     <rule ref="Generic.Arrays.DisallowLongArraySyntax" />
 
+    <arg name="colors" />
     <arg value="np" />
 </ruleset>


### PR DESCRIPTION
This PR

* [x] uses colors when running `phpcbf` or `phpcs`

Follows #1896.