### PR TITLE
Fix bug issue #1873 - French phone numbers invalid

### DIFF
--- a/src/Faker/Provider/fr_FR/PhoneNumber.php
+++ b/src/Faker/Provider/fr_FR/PhoneNumber.php
@@ -7,16 +7,6 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     // Phone numbers can't start by 00 in France
     // 01 is the most common prefix
     protected static $formats = array(
-        '+33 (0)1 ## ## ## ##',
-        '+33 (0)1 ## ## ## ##',
-        '+33 (0)2 ## ## ## ##',
-        '+33 (0)3 ## ## ## ##',
-        '+33 (0)4 ## ## ## ##',
-        '+33 (0)5 ## ## ## ##',
-        '+33 (0)6 ## ## ## ##',
-        '+33 (0)7 {{phoneNumber07WithSeparator}}',
-        '+33 (0)8 {{phoneNumber08WithSeparator}}',
-        '+33 (0)9 ## ## ## ##',
         '+33 1 ## ## ## ##',
         '+33 1 ## ## ## ##',
         '+33 2 ## ## ## ##',
@@ -52,9 +42,6 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     // Mobile phone numbers start by 06 and 07
     // 06 is the most common prefix
     protected static $mobileFormats  = array(
-        '+33 (0)6 ## ## ## ##',
-        '+33 6 ## ## ## ##',
-        '+33 (0)7 {{phoneNumber07WithSeparator}}',
         '+33 7 {{phoneNumber07WithSeparator}}',
         '06########',
         '07{{phoneNumber07}}',
@@ -63,7 +50,6 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
     );
 
     protected static $serviceFormats = array(
-        '+33 (0)8 {{phoneNumber08WithSeparator}}',
         '+33 8 {{phoneNumber08WithSeparator}}',
         '08 {{phoneNumber08WithSeparator}}',
         '08{{phoneNumber08}}',


### PR DESCRIPTION
I checked this issue and fixed it changing this file :
Faker/src/Faker/Provider/fr_FR/PhoneNumber.php
Faker didn't generate numbers like +33 (0)4 06 21 24 41 anymore for french phone numbers.

https://github.com/fzaninotto/Faker/issues/1873