### PR TITLE
Override Factory base Generator class without touching create-method

### DIFF
--- a/src/Faker/Factory.php
+++ b/src/Faker/Factory.php
@@ -16,13 +16,21 @@ class Factory
      */
     public static function create($locale = self::DEFAULT_LOCALE)
     {
-        $generator = new Generator();
+        $generator = static::createGeneratorInstance();
         foreach (static::$defaultProviders as $provider) {
             $providerClassName = self::getProviderClassname($provider, $locale);
             $generator->addProvider(new $providerClassName($generator));
         }
 
         return $generator;
+    }
+
+    /**
+     * @return Generator
+     */
+    protected static function createGeneratorInstance()
+    {
+        return new Generator();
     }
 
     /**

--- a/test/Faker/FactoryTest.php
+++ b/test/Faker/FactoryTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Faker\Test;
+
+use Faker\Factory;
+use Faker\Generator;
+use PHPUnit\Framework\TestCase;
+
+class FactoryTest extends TestCase
+{
+    public function testDeveloperCanOverrideFactoryGenerator()
+    {
+        $generator = FooBarFactory::create();
+        $this->assertInstanceOf('\Faker\Test\FooBarGenerator', $generator);
+    }
+}
+
+final class FooBarGenerator extends Generator
+{
+}
+
+final class FooBarFactory extends Factory
+{
+    protected static function createGeneratorInstance()
+    {
+        return new FooBarGenerator();
+    }
+}


### PR DESCRIPTION
Added possibility to override Factory base Generator class without rewriting the whole create-method.

In my Laravel project I have custom Generator like this:
```php
<?php

namespace App\Faker;

/**
 * @see PictureProvider
 * @method string pictureUrl(int $width = 640, int $height = 480, $randomize = true, $gray = false)
 *
 * @see UniversityProvider
 * @method string gender()
 * @method string cyrillicFirstName(string $gender = null)
 * @method string cyrillicLastName(string $gender = null)
 * @method string facultyName()
 * @method string programName()
 * @method string groupName()
 * @method string subject()
 */
class Generator extends \Faker\Generator
{
    public function __construct()
    {
        $this->addProvider(new PictureProvider($this));
        $this->addProvider(new UniversityProvider($this));
    }
}
```

The class provides a single place to manage Generator providers and more over - I have IDE suggestions because of class annotations.

So to replace the base Generator-class everywhere in the project i should override Generator-instantiating ():

```php
$this->app->singleton(FakerGenerator::class, function (Application $app, array $parameters) {
    return FakerFactory::create($parameters['locale'] ?? $app['config']->get('app.faker_locale', 'en_US'));
});
```
But I don't want to replace the logic of setting up the generator (because it can be changed in the future):

```php
foreach (static::$defaultProviders as $provider) {
    $providerClassName = self::getProviderClassname($provider, $locale);
    $generator->addProvider(new $providerClassName($generator));
}
});
```

So moving creating the new Generator instance in the separate protected-method do the trick:

```php
$generator = static::createGeneratorInstance();
...
protected static function createGeneratorInstance()
{
    return new Generator();
}
```

What do you think?