### PR TITLE
Run unit tests without PHP memory limit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ sniff: vendor/autoload.php ## Detects code style issues with phpcs
 	vendor/bin/phpcs --standard=PSR2 src -n
 
 test: vendor/autoload.php ## Runs tests with phpunit
-	vendor/bin/phpunit
+	vendor/bin/phpunit -d memory_limit=-1
 
 vendor/autoload.php:
 	composer install --no-interaction --prefer-dist


### PR DESCRIPTION
Changed command line for run phpunit

In default settings tests failed with Fatal Error.