### PR TITLE
Fix (bug #1862): Do not clear entity manager for doctrine orm populator

### DIFF
--- a/src/Faker/ORM/Doctrine/Populator.php
+++ b/src/Faker/ORM/Doctrine/Populator.php
@@ -98,11 +98,9 @@ class Populator
                 );
                 if (count($insertedEntities) % $this->batchSize === 0) {
                     $entityManager->flush();
-                    $entityManager->clear($class);
                 }
             }
             $entityManager->flush();
-            $entityManager->clear($class);
         }
 
         return $insertedEntities;


### PR DESCRIPTION
Bug: https://github.com/fzaninotto/Faker/issues/1862
Clear specific entities is deprecated and will not be supported in Doctrine 3.0. (https://github.com/doctrine/orm/commit/9ccb8837e7f0bc605117024561c07e487a57eca0)
Bug introduced: c49cd5438655043b487f4d986961746ae58edb3a
Related issue: https://stackoverflow.com/questions/18215975/doctrine-a-new-entity-was-found-through-the-relationship