### PR TITLE
added protected method Generator::findFormatter

### DIFF
--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -238,11 +238,20 @@ class Generator
         if (isset($this->formatters[$formatter])) {
             return $this->formatters[$formatter];
         }
+        $this->formatters[$formatter] = $this->findFormatter($formatter);
+        return $this->formatters[$formatter];
+    }
+    
+    /**
+     * @param string $formatter
+     *
+     * @return Callable
+     */
+    protected function findFormatter($formatter)
+    {
         foreach ($this->providers as $provider) {
             if (method_exists($provider, $formatter)) {
-                $this->formatters[$formatter] = array($provider, $formatter);
-
-                return $this->formatters[$formatter];
+                return array($provider, $formatter);
             }
         }
         throw new \InvalidArgumentException(sprintf('Unknown formatter "%s"', $formatter));


### PR DESCRIPTION
Hi,

This PR adds a protected method ``Generator::findFormatter`` that can get a formatter without use of cache.

The reason I propose it is that we need to define custom way to find a formatter by overiding ``Generator::getFormater`` but we cannot do it efficiently as the method makes use of cache internally. We would like to be able to keep the native cache feature of the method and just overide the way the formatter callable is found. 

In other words with this change then we will be able to overide the method ``findFormatter`` without messing with the cache implementation

Thanks