### PR TITLE
Allow to prevent seed break on destruct

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -519,6 +519,9 @@ echo $faker->name; // 'Jess Mraz I';
 > // good
 > $faker->realText($faker->numberBetween(10,20));
 > ```
+> 
+> **Tip**: When the faker object is destroyed, the seed is restored to generate unpredictable values (default behavior for mt_rand that is used internally). But you can't guess when the php garbage collector is going to collect the faker object. It can occur during a values generation sequence from another instance of faker (like in a test suite). In this case it will break your predictable values suite. To prevent this kind of problem, when you've finished to generate values, you should use `restoreSeed` on your faker instance to control the seed restore instant.
+> 
 
 
 

--- a/src/Faker/Generator.php
+++ b/src/Faker/Generator.php
@@ -199,6 +199,7 @@ class Generator
 {
     protected $providers = array();
     protected $formatters = array();
+    protected $seedRestored = false;
 
     public function addProvider($provider)
     {
@@ -221,6 +222,16 @@ class Generator
                 mt_srand((int) $seed, MT_RAND_PHP);
             }
         }
+    }
+
+    public function restoreSeed()
+    {
+        if ($this->seedRestored) {
+            return;
+        }
+
+        $this->seed();
+        $this->seedRestored = true;
     }
 
     public function format($formatter, $arguments = array())
@@ -287,6 +298,6 @@ class Generator
 
     public function __destruct()
     {
-        $this->seed();
+        $this->restoreSeed();
     }
 }

--- a/test/Faker/GeneratorTest.php
+++ b/test/Faker/GeneratorTest.php
@@ -124,6 +124,32 @@ final class GeneratorTest extends TestCase
         $generator->seed('10');
         $this->assertTrue(true, 'seeding with a non int value doesn\'t throw an exception');
     }
+
+    public function testRestoreSeedPreventSeedBreak()
+    {
+        $generator1 = new Generator;
+        $generator1->seed(0);
+
+        $generated1 = array();
+        for ($i=0; $i<5; $i++) {
+            $generated1[] = mt_rand(1, 10);
+        }
+        $generator1->restoreSeed();
+        $this->assertEquals(array(5, 6, 8, 2, 7), $generated1);
+
+        $generator2 = new Generator;
+        $generator2->seed(0);
+
+        $generated2 = array();
+        for ($i=0; $i<5; $i++) {
+            if ($i == 2) {
+                $generator1->__destruct();
+            }
+            $generated2[] = mt_rand(1, 10);
+        }
+        $generator2->restoreSeed();
+        $this->assertEquals(array(5, 6, 8, 2, 7), $generated2);
+    }
 }
 
 final class FooProvider


### PR DESCRIPTION
When using faker on several classes (in a non-static way; in a test suite for instance), `Generator` instances can be garbage-collected at any-time. But if it occurs during values generation from another Generator instance, seed previously set for `mt_rand` is canceled and the predictable value suite is broken.

This PR provides a `restoreSeed` method to control `mt_rand` seed restoration instant. 