### PR TITLE
Typo in function's name

### DIFF
--- a/src/Faker/Provider/es_ES/PhoneNumber.php
+++ b/src/Faker/Provider/es_ES/PhoneNumber.php
@@ -40,7 +40,7 @@ class PhoneNumber extends \Faker\Provider\PhoneNumber
         return static::numerify(static::randomElement(static::$mobileFormats));
     }
 
-    public static function tollFreeNumber()
+    public static function tollFreePhoneNumber()
     {
         return static::numerify(static::randomElement(static::$tollFreeFormats));
     }


### PR DESCRIPTION
There is a typo in the functions's name, it should be tollFreePhoneNumber instead of tollFreeNumber