### PR TITLE
Fix dateTimeThisYear method

### DIFF
--- a/src/Faker/Provider/DateTime.php
+++ b/src/Faker/Provider/DateTime.php
@@ -202,7 +202,7 @@ class DateTime extends Base
      */
     public static function dateTimeThisYear($max = 'now', $timezone = null)
     {
-        return static::dateTimeBetween('-1 year', $max, $timezone);
+        return static::dateTimeBetween('first day of january this year', $max, $timezone);
     }
 
     /**

--- a/test/Faker/Provider/DateTimeTest.php
+++ b/test/Faker/Provider/DateTimeTest.php
@@ -122,7 +122,7 @@ final class DateTimeTest extends TestCase
     {
         $date = DateTimeProvider::dateTimeThisYear();
         $this->assertInstanceOf('\DateTime', $date);
-        $this->assertGreaterThanOrEqual(new \DateTime('-1 year'), $date);
+        $this->assertGreaterThanOrEqual(new \DateTime('first day of january this year'), $date);
         $this->assertLessThanOrEqual(new \DateTime(), $date);
         $this->assertEquals(new \DateTimeZone($this->defaultTz), $date->getTimezone());
     }


### PR DESCRIPTION
Fix dateTimeThisYear method in issue #2027

I referred to this document.
https://www.php.net/manual/en/datetime.formats.relative.php#122278

Thank you.