### PR TITLE
Fix letter 'a' in female lastname generation (ru_RU)

### DIFF
--- a/src/Faker/Provider/ru_RU/Person.php
+++ b/src/Faker/Provider/ru_RU/Person.php
@@ -105,7 +105,7 @@ class Person extends \Faker\Provider\Person
         'Меркушев', 'Лыткин', 'Туров',
     );
 
-    protected static $lastNameSuffix = array('a', '');
+    protected static $lastNameSuffix = array('а', '');
 
     /**
      * Return male middle name
@@ -169,7 +169,7 @@ class Person extends \Faker\Provider\Person
         $lastName = static::randomElement(static::$lastName);
 
         if (static::GENDER_FEMALE === $gender) {
-            return $lastName . 'a';
+            return $lastName . 'а';
         } elseif (static::GENDER_MALE === $gender) {
             return $lastName;
         }

--- a/test/Faker/Provider/ru_RU/PersonTest.php
+++ b/test/Faker/Provider/ru_RU/PersonTest.php
@@ -22,12 +22,12 @@ final class PersonTest extends TestCase
 
     public function testLastNameFemale()
     {
-        $this->assertEquals("a", substr($this->faker->lastName('female'), -1));
+        $this->assertEquals("а", substr($this->faker->lastName('female'), -2, 2));
     }
 
     public function testLastNameMale()
     {
-        $this->assertNotEquals("a", substr($this->faker->lastName('male'), -1));
+        $this->assertNotEquals("а", substr($this->faker->lastName('male'), -2, 2));
     }
 
     public function testLastNameRandom()


### PR DESCRIPTION
Now female lastname generated from male lastname (in cyrillic) and adding latin letter 'a', so female lastname contains as cyrillic as latin letters. It cause errors in validating rules, for example. 
This fix just changes latin 'a' to cyrillic 'а'