### PR TITLE
Fix: Mark `$unique` property as nullable

### DIFF
--- a/src/Faker/Provider/Base.php
+++ b/src/Faker/Provider/Base.php
@@ -15,7 +15,7 @@ class Base
     protected $generator;
 
     /**
-     * @var \Faker\UniqueGenerator
+     * @var null|\Faker\UniqueGenerator
      */
     protected $unique;
 


### PR DESCRIPTION
`$unique` is `null` until `unique()` is called; marking it as nullable should make that clear.

This came up for me because [Psalm](https://psalm.dev/) complains about subclasses of `Faker/Provider/Base` not initializing `$unique`.