### PR TITLE
Changed latin "a" to cyrillic "а"

### DIFF
--- a/src/Faker/Provider/ru_RU/Person.php
+++ b/src/Faker/Provider/ru_RU/Person.php
@@ -105,7 +105,7 @@ class Person extends \Faker\Provider\Person
         'Меркушев', 'Лыткин', 'Туров',
     );
 
-    protected static $lastNameSuffix = array('a', '');
+    protected static $lastNameSuffix = array('а', '');
 
     /**
      * Return male middle name
@@ -169,7 +169,7 @@ class Person extends \Faker\Provider\Person
         $lastName = static::randomElement(static::$lastName);
 
         if (static::GENDER_FEMALE === $gender) {
-            return $lastName . 'a';
+            return $lastName . static::$lastNameSuffix[0];
         } elseif (static::GENDER_MALE === $gender) {
             return $lastName;
         }


### PR DESCRIPTION
Faker\Provider\ru_RU\Person uses suffix "a" to make a female last name from male, but used symbol was a latin "a" (ASCII #97) and not cyrillic "a" (ASCII #208), so the final last name was "some cyrillic symbols" + "latin a", now female last name forms correctly: cyrillic male last name + cyrillic "a".