### PR TITLE
Changed latin "a" to cyrillic "а"

### DIFF
--- a/src/Faker/ORM/Doctrine/Populator.php
+++ b/src/Faker/ORM/Doctrine/Populator.php
@@ -98,11 +98,9 @@ class Populator
                 );
                 if (count($insertedEntities) % $this->batchSize === 0) {
                     $entityManager->flush();
-                    $entityManager->clear($class);
                 }
             }
             $entityManager->flush();
-            $entityManager->clear($class);
         }
 
         return $insertedEntities;

--- a/src/Faker/Provider/ru_RU/Person.php
+++ b/src/Faker/Provider/ru_RU/Person.php
@@ -105,7 +105,7 @@ class Person extends \Faker\Provider\Person
         'Меркушев', 'Лыткин', 'Туров',
     );
 
-    protected static $lastNameSuffix = array('a', '');
+    protected static $lastNameSuffix = array('а', '');
 
     /**
      * Return male middle name
@@ -169,7 +169,7 @@ class Person extends \Faker\Provider\Person
         $lastName = static::randomElement(static::$lastName);
 
         if (static::GENDER_FEMALE === $gender) {
-            return $lastName . 'a';
+            return $lastName . static::$lastNameSuffix[0];
         } elseif (static::GENDER_MALE === $gender) {
             return $lastName;
         }

--- a/test/Faker/Provider/ru_RU/PersonTest.php
+++ b/test/Faker/Provider/ru_RU/PersonTest.php
@@ -13,6 +13,11 @@ final class PersonTest extends TestCase
      */
     private $faker;
 
+    /**
+     * @var string
+     */
+    private $suffix = 'а';
+
     protected function setUp()
     {
         $faker = new Generator();
@@ -22,12 +27,12 @@ final class PersonTest extends TestCase
 
     public function testLastNameFemale()
     {
-        $this->assertEquals("a", substr($this->faker->lastName('female'), -1));
+        $this->assertEquals($this->suffix, substr($this->faker->lastName('female'), -strlen($this->suffix)));
     }
 
     public function testLastNameMale()
     {
-        $this->assertNotEquals("a", substr($this->faker->lastName('male'), -1));
+        $this->assertNotEquals($this->suffix, substr($this->faker->lastName('male'), -strlen($this->suffix)));
     }
 
     public function testLastNameRandom()


### PR DESCRIPTION
Faker\Provider\ru_RU\Person uses suffix "a" to make a female last name from male, but letter is a latin "a" (ASCII #97) and not cyrillic "a" (ASCII #208), so the final last name is "some cyrillic symbols" + "latin a", commit fixes that, now female last name forms correctly: cyrillic male last name + cyrillic "a".