### PR TITLE
Enhancement: Add configuration for Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,29 @@
+# https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+
+updates:
+  - commit-message:
+      include: "scope"
+      prefix: "composer"
+    directory: "/"
+    labels:
+      - "dependency"
+    open-pull-requests-limit: 10
+    package-ecosystem: "composer"
+    schedule:
+      interval: "daily"
+    target-branch: "next"
+    versioning-strategy: "increase"
+
+  - commit-message:
+      include: "scope"
+      prefix: "github-actions"
+    directory: "/"
+    labels:
+      - "dependency"
+    open-pull-requests-limit: 10
+    package-ecosystem: "github-actions"
+    schedule:
+      interval: "daily"
+    target-branch: "next"


### PR DESCRIPTION
This PR

* [x] adds a basic configuration for Dependabot

💁‍♂️ All of the pull requests that we now manually open can be automated. To be honest, it feels like years ago that I manually updated dependencies. In the @ergebnis organization, I even let GitHub Actions automatically merge pull requests created by Dependabot, given that the build passes.