### PR TITLE
Enhancement: Raise error level from 6 to 5

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
     cacheDirectory=".build/psalm"
     errorBaseline="psalm-baseline.xml"
-    errorLevel="6"
+    errorLevel="5"
     resolveFromConfigFile="true"
     totallyTyped="false"
 >

--- a/src/Faker/Factory.php
+++ b/src/Faker/Factory.php
@@ -49,7 +49,7 @@ class Factory
     /**
      * @param string $provider
      * @param string $locale
-     * @return string
+     * @return string|null
      */
     protected static function findProviderClassname($provider, $locale = '')
     {

--- a/src/Faker/Guesser/Name.php
+++ b/src/Faker/Guesser/Name.php
@@ -19,7 +19,7 @@ class Name
     /**
      * @param string $name
      * @param int|null $size Length of field, if known
-     * @return callable
+     * @return callable|null
      */
     public function guessFormat($name, $size = null)
     {

--- a/src/Faker/Provider/File.php
+++ b/src/Faker/Provider/File.php
@@ -568,7 +568,7 @@ class File extends Base
      * @param  string  $sourceDirectory The directory to look for random file taking
      * @param  string  $targetDirectory
      * @param  boolean $fullPath        Whether to have the full path or just the filename
-     * @return string
+     * @return string|false
      */
     public static function file($sourceDirectory = '/tmp', $targetDirectory = '/tmp', $fullPath = true)
     {


### PR DESCRIPTION
This PR

* [x] raises the error level for `vimeo/psalm` from `6` to `5`
* [x] fixes issues reported via static code analysis

Follows #1897.
