### PR TITLE
Enhancement: Raise error level from 5 to 4

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
     cacheDirectory=".build/psalm"
     errorBaseline="psalm-baseline.xml"
-    errorLevel="5"
+    errorLevel="4"
     resolveFromConfigFile="true"
     totallyTyped="false"
 >

--- a/src/Faker/Provider/ms_MY/Address.php
+++ b/src/Faker/Provider/ms_MY/Address.php
@@ -500,7 +500,7 @@ class Address extends \Faker\Provider\Address
      *
      * @example 'No.'
      *
-     * @return @string
+     * @return string
      */
     public static function buildingPrefix()
     {
@@ -512,7 +512,7 @@ class Address extends \Faker\Provider\Address
      *
      * @example '123'
      *
-     * @return @string
+     * @return string
      */
     public static function buildingNumber()
     {
@@ -536,7 +536,7 @@ class Address extends \Faker\Provider\Address
      *
      * @example 'Jalan Utama 7'
      *
-     * @return @string
+     * @return string
      */
     public function streetName()
     {
@@ -550,7 +550,7 @@ class Address extends \Faker\Provider\Address
      *
      * @example Taman Bahagia
      *
-     * @return @string
+     * @return string
      */
     public function township()
     {
@@ -564,7 +564,7 @@ class Address extends \Faker\Provider\Address
      *
      * @example 'USJ'
      *
-     * @return @string
+     * @return string
      */
     public function townshipPrefixAbbr()
     {
@@ -576,7 +576,7 @@ class Address extends \Faker\Provider\Address
      *
      * @example 'Taman'
      *
-     * @return @string
+     * @return string
      */
     public function townshipPrefix()
     {
@@ -601,7 +601,7 @@ class Address extends \Faker\Provider\Address
      *
      * @param null|string $state 'state' or null
      *
-     * @return @string
+     * @return string
      */
     public static function postcode($state = null)
     {
@@ -668,7 +668,7 @@ class Address extends \Faker\Provider\Address
      *
      * @example 55100 Bukit Bintang, Kuala Lumpur
      *
-     * @return @string
+     * @return string
      */
     public function townState()
     {
@@ -685,7 +685,7 @@ class Address extends \Faker\Provider\Address
      *
      * @example 'Ampang'
      *
-     * @return @string
+     * @return string
     */
     public function city()
     {
@@ -698,7 +698,7 @@ class Address extends \Faker\Provider\Address
      *
      * @example 'Johor'
      *
-     * @return @string
+     * @return string
     */
     public function state()
     {

--- a/src/Faker/Provider/ms_MY/Miscellaneous.php
+++ b/src/Faker/Provider/ms_MY/Miscellaneous.php
@@ -86,7 +86,7 @@ class Miscellaneous extends \Faker\Provider\Miscellaneous
      *
      * @example 'WKN 2368'
      *
-     * @return @string
+     * @return string
      */
     public function jpjNumberPlate()
     {
@@ -100,7 +100,7 @@ class Miscellaneous extends \Faker\Provider\Miscellaneous
      *
      * @example 'W'
      *
-     * @return @string
+     * @return string
      */
     public static function peninsularPrefix()
     {
@@ -112,7 +112,7 @@ class Miscellaneous extends \Faker\Provider\Miscellaneous
      *
      * @example 'QA'
      *
-     * @return @string
+     * @return string
      */
     public static function sarawakPrefix()
     {
@@ -124,7 +124,7 @@ class Miscellaneous extends \Faker\Provider\Miscellaneous
      *
      * @example 'SA'
      *
-     * @return @string
+     * @return string
      */
     public static function sabahPrefix()
     {
@@ -136,7 +136,7 @@ class Miscellaneous extends \Faker\Provider\Miscellaneous
      *
      * @example 'G1M'
      *
-     * @return @string
+     * @return string
      */
     public static function specialPrefix()
     {
@@ -148,7 +148,7 @@ class Miscellaneous extends \Faker\Provider\Miscellaneous
      *
      * @example 'A'
      *
-     * @return @string
+     * @return string
      */
     public static function validAlphabet()
     {
@@ -160,7 +160,7 @@ class Miscellaneous extends \Faker\Provider\Miscellaneous
      *
      * @example '1234'
      *
-     * @return @integer
+     * @return int
      */
     public static function numberSequence()
     {

--- a/src/Faker/Provider/ms_MY/Payment.php
+++ b/src/Faker/Provider/ms_MY/Payment.php
@@ -147,7 +147,7 @@ class Payment extends \Faker\Provider\Payment
      *
      * @example 'Maybank'
      *
-     * @return @string
+     * @return string
      */
     public function bank()
     {
@@ -161,7 +161,7 @@ class Payment extends \Faker\Provider\Payment
      *
      * @example '1234567890123456'
      *
-     * @return @string
+     * @return string
      */
     public function bankAccountNumber()
     {
@@ -175,7 +175,7 @@ class Payment extends \Faker\Provider\Payment
      *
      * @example 'Public Bank'
      *
-     * @return @string
+     * @return string
      */
     public static function localBank()
     {
@@ -187,7 +187,7 @@ class Payment extends \Faker\Provider\Payment
      *
      * @example 'Citibank Berhad'
      *
-     * @return @string
+     * @return string
      */
     public static function foreignBank()
     {
@@ -199,7 +199,7 @@ class Payment extends \Faker\Provider\Payment
      *
      * @example 'Bank Simpanan Nasional'
      *
-     * @return @string
+     * @return string
      */
     public static function governmentBank()
     {
@@ -211,7 +211,7 @@ class Payment extends \Faker\Provider\Payment
      *
      * @example 'AIA Malaysia'
      *
-     * @return @string
+     * @return string
      */
     public static function insurance()
     {
@@ -223,7 +223,7 @@ class Payment extends \Faker\Provider\Payment
      *
      * @example 'MBBEMYKLXXX'
      *
-     * @return @string
+     * @return string
      */
     public static function swiftCode()
     {
@@ -235,7 +235,7 @@ class Payment extends \Faker\Provider\Payment
      *
      * @example 'RM'
      *
-     * @return @string
+     * @return string
      */
     public static function currencySymbol()
     {

--- a/test/Faker/Provider/pt_PT/PersonTest.php
+++ b/test/Faker/Provider/pt_PT/PersonTest.php
@@ -42,7 +42,7 @@ class PersonTest extends TestCase
         }
         $n = str_split($tin);
         // cd - Control Digit
-        $cd = ($n[0] * 9 + $n[1] * 8 + $n[2] * 7 + $n[3] * 6 + $n[4] * 5 + $n[5] * 4 + $n[6] * 3 + $n[7] * 2) % 11;
+        $cd = ((int) $n[0] * 9 + (int) $n[1] * 8 + (int) $n[2] * 7 + (int) $n[3] * 6 + (int) $n[4] * 5 + (int) $n[5] * 4 + (int) $n[6] * 3 + (int) $n[7] * 2) % 11;
         if ($cd === 0 || $cd === 1) {
             $cd = 0;
         } else {

--- a/test/Faker/Provider/pt_PT/PersonTest.php
+++ b/test/Faker/Provider/pt_PT/PersonTest.php
@@ -30,7 +30,7 @@ class PersonTest extends TestCase
      *
      * @link http://pt.wikipedia.org/wiki/N%C3%BAmero_de_identifica%C3%A7%C3%A3o_fiscal
      *
-     * @param mixed $tin
+     * @param string $tin
      *
      * @return boolean
      */

--- a/test/Faker/Provider/ro_RO/PersonTest.php
+++ b/test/Faker/Provider/ro_RO/PersonTest.php
@@ -231,7 +231,7 @@ class PersonTest extends TestCase
 
             $checksum = 0;
             foreach (range(0, 11) as $digit) {
-                $checksum += (int)substr($cnp, $digit, 1) * (int)substr($checkNumber, $digit, 1);
+                $checksum += (int)substr($cnp, $digit, 1) * (int)substr((string)$checkNumber, $digit, 1);
             }
             $checksum %= 11;
             $checksum = $checksum == 10 ? 1 : $checksum;


### PR DESCRIPTION
This PR

* [x] raises the error level for `vimeo/psalm` from `5` to `4`
* [ ] fixes issues reported via static code analysis

Follows #1897.
