### PR TITLE
Enhancement: Enable UnusedUses rule

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -13,6 +13,11 @@
 
     <rule ref="Generic.Arrays.DisallowLongArraySyntax" />
     <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
+        <properties>
+            <property name="searchAnnotations" value="true"/>
+        </properties>
+    </rule>
 
     <arg name="colors" />
     <arg value="np" />

--- a/src/Faker/Provider/ms_MY/Address.php
+++ b/src/Faker/Provider/ms_MY/Address.php
@@ -2,8 +2,6 @@
 
 namespace Faker\Provider\ms_MY;
 
-use Faker\Generator;
-
 class Address extends \Faker\Provider\Address
 {
     /**

--- a/src/Faker/Provider/ms_MY/Person.php
+++ b/src/Faker/Provider/ms_MY/Person.php
@@ -2,7 +2,6 @@
 
 namespace Faker\Provider\ms_MY;
 
-use Faker\Generator;
 use Faker\Provider\DateTime;
 
 class Person extends \Faker\Provider\Person

--- a/test/Faker/Provider/BaseTest.php
+++ b/test/Faker/Provider/BaseTest.php
@@ -5,7 +5,6 @@ namespace Faker\Test\Provider;
 use Faker\Provider\Base as BaseProvider;
 use Faker\Test\Fixture;
 use PHPUnit\Framework\TestCase;
-use Traversable;
 
 class BaseTest extends TestCase
 {

--- a/test/Faker/Provider/nl_BE/PersonTest.php
+++ b/test/Faker/Provider/nl_BE/PersonTest.php
@@ -2,7 +2,6 @@
 
 namespace Faker\Test\Provider\nl_BE;
 
-use Datetime;
 use Faker\Generator;
 use Faker\Provider\nl_BE\Person;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
This PR

* [x] enables the `SlevomatCodingStandard.Namespaces.UnusedUses` rule
* [x] runs `make fix`

Follows #1896.